### PR TITLE
Add slightly more general AssetImporter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,9 +368,8 @@ void load_a_bunch_of_stuff()
     osp::Package lazyDebugPack("lzdb", "lazy-debug");
 
     // Load sturdy glTF files
-    osp::AssetImporter importer;
-    importer.load_sturdy("OSPData/adera/spamcan.sturdy.gltf", lazyDebugPack);
-    importer.load_sturdy("OSPData/adera/stomper.sturdy.gltf", lazyDebugPack);
+    osp::AssetImporter::load_sturdy_file("OSPData/adera/spamcan.sturdy.gltf", lazyDebugPack);
+    osp::AssetImporter::load_sturdy_file("OSPData/adera/stomper.sturdy.gltf", lazyDebugPack);
 
     // Add package to the univere
     g_osp.debug_get_packges().push_back(std::move(lazyDebugPack));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
 #include "osp/Trajectories/Stationary.h"
 #include "osp/Satellites/SatActiveArea.h"
 #include "osp/Satellites/SatVehicle.h"
-#include "osp/Resource/SturdyImporter.h"
+#include "osp/Resource/AssetImporter.h"
 #include "osp/Resource/Package.h"
 
 #include "osp/Active/ActiveScene.h"
@@ -290,6 +290,7 @@ void magnum_application()
     // workaround: wipe mesh resources because they're specific to the
     // opengl context
     g_osp.debug_get_packges()[0].clear<Magnum::GL::Mesh>();
+    g_osp.debug_get_packges()[0].clear<Magnum::GL::Texture2D>();
 
     // destruct the application, this closes the window
     g_ospMagnum.reset();
@@ -366,18 +367,10 @@ void load_a_bunch_of_stuff()
     // Create a new package
     osp::Package lazyDebugPack("lzdb", "lazy-debug");
 
-    // Create a sturdy
-    osp::SturdyImporter importer;
-    importer.open_filepath("OSPData/adera/spamcan.sturdy.gltf");
-
-    // load the sturdy into the package
-    importer.load_config(lazyDebugPack);
-
-    // Create another sturdy
-    importer.open_filepath("OSPData/adera/stomper.sturdy.gltf");
-    importer.load_config(lazyDebugPack);
-
-
+    // Load sturdy glTF files
+    osp::AssetImporter importer;
+    importer.load_sturdy("OSPData/adera/spamcan.sturdy.gltf", lazyDebugPack);
+    importer.load_sturdy("OSPData/adera/stomper.sturdy.gltf", lazyDebugPack);
 
     // Add package to the univere
     g_osp.debug_get_packges().push_back(std::move(lazyDebugPack));

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -244,13 +244,10 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
 
         if (currentPrototype.m_type == ObjectType::MESH)
         {
-            using Magnum::Trade::MeshData;
-            using Magnum::Trade::ImageData2D;
             using Magnum::GL::Mesh;
+            using Magnum::Trade::MeshData;
             using Magnum::GL::Texture2D;
-            using Magnum::GL::SamplerWrapping;
-            using Magnum::GL::SamplerFilter;
-            using Magnum::GL::TextureFormat;
+            using Magnum::Trade::ImageData2D;
 
             // Current prototype is a mesh, get the mesh and add it
 
@@ -268,7 +265,8 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
             {
                 // Mesh isn't compiled yet, now check if mesh data exists
                 std::string const& meshName = part.get_strings()[drawable.m_mesh];
-                meshRes = AssetImporter::compile_mesh(meshName, package);
+                DependRes<MeshData> meshData = package.get<MeshData>(meshName);
+                meshRes = AssetImporter::compile_mesh(meshData, package);
             }
 
             std::vector<Texture2D*> textureResources;
@@ -280,7 +278,8 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
 
                 if (texRes.empty())
                 {
-                    texRes = AssetImporter::compile_tex(texName, package);
+                    DependRes<ImageData2D> imageData = package.get<ImageData2D>(texName);
+                    texRes = AssetImporter::compile_tex(imageData, package);
                 }
                 textureResources.push_back(&(*texRes));
             }

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -234,6 +234,7 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
     using Corrade::Containers::Pointer;
     using Corrade::Containers::Optional;
     using Magnum::Trade::ObjectData3D;
+    using Magnum::Trade::MeshObjectData3D;
     using Magnum::Trade::ObjectInstanceType3D;
     using Magnum::Trade::MaterialData;
     using Magnum::Trade::MaterialType;
@@ -286,8 +287,9 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
             static_cast<unsigned>(part.get_strings().size())};
         part.get_strings().push_back(meshName);
 
-        Optional<MaterialData> mat = gltfImporter.material(meshID);
-        
+        MeshObjectData3D& mesh = static_cast<MeshObjectData3D&>(*childData);
+        Pointer<MaterialData> mat = gltfImporter.material(mesh.material());
+
         if (mat->types() & MaterialType::PbrMetallicRoughness)
         {
             const auto& pbr = mat->as<PbrMetallicRoughnessMaterialData>();

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -31,95 +31,110 @@ using Magnum::GL::Mesh;
 namespace osp
 {
 
-void osp::AssetImporter::load_sturdy(const std::string& filepath, Package& pkg)
+void osp::AssetImporter::load_sturdy_file(std::string const& filepath, Package& pkg)
 {
-    // Pre-initialize sceneData to avoid compiler error
-    Optional<SceneData> sceneData;
+    PluginManager pluginManager;
+    TinyGltfImporter gltfImporter{pluginManager};
 
     // Open .sturdy.gltf file
-    m_gltfImporter.openFile(filepath);
-    if (!m_gltfImporter.isOpened() || m_gltfImporter.defaultScene() == -1)
+    gltfImporter.openFile(filepath);
+    if (!gltfImporter.isOpened() || gltfImporter.defaultScene() == -1)
     {
         std::cout << "Error: couldn't open file: " << filepath << "\n";
-        goto exit;
     }
 
-    // Try to load the scene
-    std::cout << "LOADING STURDY: " << filepath << "\n";
-    std::cout << "Found " << m_gltfImporter.object3DCount() << " nodes\n";
-    sceneData = m_gltfImporter.scene(m_gltfImporter.defaultScene());
+    load_sturdy(gltfImporter, pkg);
+
+    gltfImporter.close();
+}
+
+void osp::AssetImporter::load_part(TinyGltfImporter& gltfImporter,
+    Package& pkg, unsigned id)
+{
+    // It's a part
+    std::cout << "PART!\n";
+
+    // Recursively add child nodes to part
+    PrototypePart part;
+    proto_add_obj_recurse(gltfImporter, pkg, part, 0, id);
+
+    // Parse extra properties
+    tinygltf::Node const& node = *static_cast<tinygltf::Node const*>(
+        gltfImporter.object3D(id)->importerState());
+
+    tinygltf::Value const& extras = node.extras;
+    if (!extras.Has("machines"))
+    {
+        std::cout << "Error: no machines found in "
+            << gltfImporter.object3DName(id) << "!\n";
+        return;
+    }
+    tinygltf::Value const& machines = extras.Get("machines");
+    std::cout << "JSON machines!\n";
+    auto const& machArray = machines.Get<tinygltf::Value::Array>();
+
+    // Loop through machine configs
+            // machArray looks like:
+            // [
+            //    { "type": "Rocket", stuff... },
+            //    { "type": "Control", stuff...}
+            // ]
+    for (tinygltf::Value const& value : machArray)
+    {
+        std::string type = value.Get("type").Get<std::string>();
+        std::cout << "test: " << type << "\n";
+
+        if (type.empty())
+        {
+            continue;
+        }
+
+        // TODO: more stuff
+        PrototypeMachine machine;
+        machine.m_type = std::move(type);
+        part.get_machines().emplace_back(std::move(machine));
+    }
+
+    pkg.add<PrototypePart>(gltfImporter.object3DName(id), std::move(part));
+}
+
+void osp::AssetImporter::load_sturdy(TinyGltfImporter& gltfImporter, Package& pkg)
+{
+    std::cout << "Found " << gltfImporter.object3DCount() << " nodes\n";
+    Optional<SceneData> sceneData = gltfImporter.scene(gltfImporter.defaultScene());
     if (!sceneData)
     {
-        std::cout << "Error: couldn't load scene from " << filepath << "\n";
-        goto exit;
+        std::cout << "Error: couldn't load scene data\n";
+        return;
     }
 
     // Loop over and discriminate all top-level nodes
     // Currently, part_* are the only nodes that necessitate special handling
     for (unsigned childID : sceneData->children3D())
     {
-        const std::string& nodeName = m_gltfImporter.object3DName(childID);
+        const std::string& nodeName = gltfImporter.object3DName(childID);
         std::cout << "Found node: " << nodeName << "\n";
 
         if (nodeName.compare(0, 5, "part_") == 0)
         {
-            // It's a part
-            std::cout << "PART!\n";
-
-            // Recursively add child nodes to part
-            PrototypePart part;
-            proto_add_obj_recurse(pkg, part, 0, childID);
-            
-            // Parse extra properties
-            tinygltf::Node const& node = *static_cast<tinygltf::Node const*>(
-                m_gltfImporter.object3D(childID)->importerState());
-
-            tinygltf::Value const& extras = node.extras;
-            if (!extras.Has("machines"))
-            {
-                std::cout << "Error: no machines found in " << nodeName << "!\n";
-                goto exit;
-            }
-            tinygltf::Value const& machines = extras.Get("machines");
-            std::cout << "JSON machines!\n";
-            auto const& machArray = machines.Get<tinygltf::Value::Array>();
-
-            // Loop through machine configs
-                    // machArray looks like:
-                    // [
-                    //    { "type": "Rocket", stuff... },
-                    //    { "type": "Control", stuff...}
-                    // ]
-            for (tinygltf::Value const& value : machArray)
-            {
-                std::string type = value.Get("type").Get<std::string>();
-                std::cout << "test: " << type << "\n";
-
-                if (type.empty())
-                {
-                    continue;
-                }
-
-                // TODO: more stuff
-                PrototypeMachine machine;
-                machine.m_type = std::move(type);
-                part.get_machines().emplace_back(std::move(machine));
-            }
-            pkg.add<PrototypePart>(nodeName, std::move(part));
+            load_part(gltfImporter, pkg, childID);
         }
     }
 
     // Load all associated mesh data
     // Temporary: eventually if would be preferable to retrieve the mesh names only
-    for (unsigned i = 0; i < m_gltfImporter.meshCount(); i++)
+    for (unsigned i = 0; i < gltfImporter.meshCount(); i++)
     {
-        std::string const& meshName = m_gltfImporter.meshName(i);
+        using Magnum::MeshPrimitive;
+
+        std::string const& meshName = gltfImporter.meshName(i);
         std::cout << "Mesh: " << meshName << "\n";
 
-        Optional<MeshData> meshData = m_gltfImporter.mesh(i);
-        if (!meshData || (meshData->primitive() != Magnum::MeshPrimitive::Triangles))
+        Optional<MeshData> meshData = gltfImporter.mesh(i);
+        if (!meshData || (meshData->primitive() != MeshPrimitive::Triangles))
         {
-            std::cout << "Error: mesh " << meshName << " not composed of triangles\n";
+            std::cout << "Error: mesh " << meshName
+                << " not composed of triangles\n";
             continue;
         }
         pkg.add<MeshData>(meshName, std::move(*meshData));
@@ -127,33 +142,31 @@ void osp::AssetImporter::load_sturdy(const std::string& filepath, Package& pkg)
 
     // Load all associated image data
     // Temporary: eventually it would be preferable to retrieve the URIs only
-    for (unsigned i = 0; i < m_gltfImporter.textureCount(); i++)
+    for (unsigned i = 0; i < gltfImporter.textureCount(); i++)
     {
-        auto imgID = m_gltfImporter.texture(i)->image();
-        std::string const& imgName = m_gltfImporter.image2DName(imgID);
+        auto imgID = gltfImporter.texture(i)->image();
+        std::string const& imgName = gltfImporter.image2DName(imgID);
         std::cout << "Loading image: " << imgName << "\n";
 
-        Optional<ImageData2D> imgData = m_gltfImporter.image2D(imgID);
+        Optional<ImageData2D> imgData = gltfImporter.image2D(imgID);
         if (!imgData)
         {
             continue;
         }
         pkg.add<ImageData2D>(imgName, std::move(*imgData));
     }
-
-exit:
-    m_gltfImporter.close();
 }
 
-DependRes<ImageData2D> osp::AssetImporter::load_image(const std::string& filepath,
-    Package& pkg)
+DependRes<ImageData2D> osp::AssetImporter::load_image(
+    const std::string& filepath, Package& pkg)
 {
     using Magnum::Trade::AbstractImporter;
     using Corrade::PluginManager::Manager;
     using Corrade::Containers::Pointer;
 
     Manager<AbstractImporter> manager;
-    Pointer<AbstractImporter> importer = manager.loadAndInstantiate("AnyImageImporter");
+    Pointer<AbstractImporter> importer
+        = manager.loadAndInstantiate("AnyImageImporter");
     if (!importer || !importer->openFile(filepath))
     {
         std::cout << "Error: could not open file " << filepath << "\n";
@@ -170,63 +183,65 @@ DependRes<ImageData2D> osp::AssetImporter::load_image(const std::string& filepat
     return pkg.add<ImageData2D>(filepath, std::move(*image));
 }
 
-DependRes<Mesh> osp::AssetImporter::compile_mesh(const std::string& meshDataName, Package& pkg)
+DependRes<Mesh> osp::AssetImporter::compile_mesh(
+    const DependRes<MeshData> meshData, Package& pkg)
 {
     using Magnum::GL::Mesh;
 
-    DependRes<MeshData> meshData = pkg.get<MeshData>(meshDataName);
     if (meshData.empty())
     {
-        std::cout << "Error: requested MeshData resource \"" << meshDataName
+        std::cout << "Error: requested MeshData resource \"" << meshData.name()
             << "\" not found\n";
         return DependRes<Mesh>();
     }
 
-    return pkg.add<Mesh>(meshDataName, Magnum::MeshTools::compile(*meshData));
+    return pkg.add<Mesh>(meshData.name(), Magnum::MeshTools::compile(*meshData));
 }
 
-DependRes<Texture2D> osp::AssetImporter::compile_tex(const std::string& imageDataName,
-    Package& package)
+DependRes<Texture2D> osp::AssetImporter::compile_tex(
+    const DependRes<ImageData2D> imageData, Package& package)
 {
     using Magnum::GL::SamplerWrapping;
     using Magnum::GL::SamplerFilter;
     using Magnum::GL::textureFormat;
 
-    DependRes<ImageData2D> image = package.get<ImageData2D>(imageDataName);
-    if (image.empty())
+    if (imageData.empty())
     {
-        std::cout << "Error: requested ImageData2D resource \"" << imageDataName
+        std::cout << "Error: requested ImageData2D resource \"" << imageData.name()
             << "\" not found\n";
         return DependRes<Texture2D>();
     }
 
-    Magnum::ImageView2D view = *image;
+    Magnum::ImageView2D view = *imageData;
 
     Magnum::GL::Texture2D tex;
     tex.setWrapping(SamplerWrapping::ClampToEdge)
         .setMagnificationFilter(SamplerFilter::Linear)
         .setMinificationFilter(SamplerFilter::Linear)
-        .setStorage(1, textureFormat((*image).format()), (*image).size())
+        .setStorage(1, textureFormat((*imageData).format()), (*imageData).size())
         .setSubImage(0, {}, view);
 
-    return package.add<Texture2D>(imageDataName, std::move(tex));
+    return package.add<Texture2D>(imageData.name(), std::move(tex));
 }
 
 //either an appendable package, or
-void AssetImporter::proto_add_obj_recurse(Package& package,
+void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter, 
+                                           Package& package,
                                            PrototypePart& part,
                                            unsigned parentProtoIndex,
                                            unsigned childGltfIndex)
 {
     using Corrade::Containers::Pointer;
     using Magnum::Trade::ObjectData3D;
+    using Magnum::Trade::ObjectInstanceType3D;
     using Magnum::Trade::MaterialData;
+    using Magnum::Trade::MaterialType;
     using Magnum::Trade::PbrMetallicRoughnessMaterialData;
 
     // Add the object to the prototype
-    Pointer<ObjectData3D> childData = m_gltfImporter.object3D(childGltfIndex);
+    Pointer<ObjectData3D> childData = gltfImporter.object3D(childGltfIndex);
     std::vector<PrototypeObject>& protoObjects = part.get_objects();
-    const std::string& name = m_gltfImporter.object3DName(childGltfIndex);
+    const std::string& name = gltfImporter.object3DName(childGltfIndex);
 
     // I think I've been doing too much C
     PrototypeObject obj;
@@ -242,7 +257,7 @@ void AssetImporter::proto_add_obj_recurse(Package& package,
     int meshID = childData->instance();
 
     bool hasMesh = (
-            childData->instanceType() == Magnum::Trade::ObjectInstanceType3D::Mesh
+            childData->instanceType() == ObjectInstanceType3D::Mesh
             && meshID != -1);
 
     if (name.compare(0, 4, "col_") == 0)
@@ -258,7 +273,7 @@ void AssetImporter::proto_add_obj_recurse(Package& package,
     else if (hasMesh)
     {
         // It's a drawable mesh
-        const std::string& meshName = m_gltfImporter.meshName(meshID);
+        const std::string& meshName = gltfImporter.meshName(meshID);
         std::cout << "obj: " << name << " uses mesh: " << meshName << "\n";
         obj.m_type = ObjectType::MESH;
 
@@ -266,17 +281,18 @@ void AssetImporter::proto_add_obj_recurse(Package& package,
         // as their resource paths. So the resource path is added to the part's
         // list of strings, and the object's mesh is set to the index to that
         // string.
-        obj.m_objectData = DrawableData{ static_cast<unsigned>(part.get_strings().size()) };
+        obj.m_objectData = DrawableData{
+            static_cast<unsigned>(part.get_strings().size())};
         part.get_strings().push_back(meshName);
 
-        Pointer<MaterialData> mat = m_gltfImporter.material(meshID);
+        Pointer<MaterialData> mat = gltfImporter.material(meshID);
         
-        if (mat->types() & Magnum::Trade::MaterialType::PbrMetallicRoughness)
+        if (mat->types() & MaterialType::PbrMetallicRoughness)
         {
             const auto& pbr = mat->as<PbrMetallicRoughnessMaterialData>();
 
-            auto imgID = m_gltfImporter.texture(pbr.baseColorTexture())->image();
-            std::string const& imgName = m_gltfImporter.image2DName(imgID);
+            auto imgID = gltfImporter.texture(pbr.baseColorTexture())->image();
+            std::string const& imgName =gltfImporter.image2DName(imgID);
             std::cout << "Base Tex: " << imgName << "\n";
             std::get<DrawableData>(obj.m_objectData).m_textures.push_back(
                 static_cast<unsigned>(part.get_strings().size()));
@@ -284,8 +300,9 @@ void AssetImporter::proto_add_obj_recurse(Package& package,
 
             if (pbr.hasNoneRoughnessMetallicTexture())
             {
-                imgID = m_gltfImporter.texture(pbr.metalnessTexture())->image();
-                std::cout << "Metal/rough texture: " << m_gltfImporter.image2DName(imgID) << "\n";
+                imgID = gltfImporter.texture(pbr.metalnessTexture())->image();
+                std::cout << "Metal/rough texture: "
+                    << gltfImporter.image2DName(imgID) << "\n";
             } else
             {
                 std::cout << "No metal/rough texture found for " << name << "\n";
@@ -297,14 +314,12 @@ void AssetImporter::proto_add_obj_recurse(Package& package,
         }
     }
 
-    //obj.m_mesh = m_meshOffset + childData->
     int objIndex = protoObjects.size();
     protoObjects.push_back(std::move(obj));
 
     for (unsigned childId: childData->children())
     {
-        //proto_add_obj_recurse(part, protoObjects.size() - 1, childId);
-        proto_add_obj_recurse(package, part, objIndex, childId);
+        proto_add_obj_recurse(gltfImporter, package, part, objIndex, childId);
     }
 }
 

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -1,0 +1,312 @@
+#include <iostream>
+
+#include <Corrade/Containers/Optional.h>
+#include <Corrade/PluginManager/Manager.h>
+#include <Magnum/Trade/AbstractImporter.h>
+#include <Magnum/Trade/MeshObjectData3D.h>
+#include <Magnum/Trade/SceneData.h>
+#include <Magnum/Trade/MeshData.h>
+#include <Magnum/Trade/TextureData.h>
+#include <Magnum/GL/TextureFormat.h>
+#include <Magnum/Trade/ImageData.h>
+#include <Magnum/ImageView.h>
+#include <Magnum/Trade/MaterialData.h>
+#include <Magnum/Trade/PbrMetallicRoughnessMaterialData.h>
+#include <Magnum/MeshTools/Compile.h>
+#include <Magnum/GL/Mesh.h>
+
+
+#include <MagnumExternal/TinyGltf/tiny_gltf.h>
+
+#include "Package.h"
+#include "AssetImporter.h"
+
+using Corrade::Containers::Optional;
+using Magnum::Trade::ImageData2D;
+using Magnum::Trade::MeshData;
+using Magnum::Trade::SceneData;
+using Magnum::GL::Texture2D;
+using Magnum::GL::Mesh;
+
+namespace osp
+{
+
+void osp::AssetImporter::load_sturdy(const std::string& filepath, Package& pkg)
+{
+    // Pre-initialize sceneData to avoid compiler error
+    Optional<SceneData> sceneData;
+
+    // Open .sturdy.gltf file
+    m_gltfImporter.openFile(filepath);
+    if (!m_gltfImporter.isOpened() || m_gltfImporter.defaultScene() == -1)
+    {
+        std::cout << "Error: couldn't open file: " << filepath << "\n";
+        goto exit;
+    }
+
+    // Try to load the scene
+    std::cout << "LOADING STURDY: " << filepath << "\n";
+    std::cout << "Found " << m_gltfImporter.object3DCount() << " nodes\n";
+    sceneData = m_gltfImporter.scene(m_gltfImporter.defaultScene());
+    if (!sceneData)
+    {
+        std::cout << "Error: couldn't load scene from " << filepath << "\n";
+        goto exit;
+    }
+
+    // Loop over and discriminate all top-level nodes
+    // Currently, part_* are the only nodes that necessitate special handling
+    for (unsigned childID : sceneData->children3D())
+    {
+        const std::string& nodeName = m_gltfImporter.object3DName(childID);
+        std::cout << "Found node: " << nodeName << "\n";
+
+        if (nodeName.compare(0, 5, "part_") == 0)
+        {
+            // It's a part
+            std::cout << "PART!\n";
+
+            // Recursively add child nodes to part
+            PrototypePart part;
+            proto_add_obj_recurse(pkg, part, 0, childID);
+            
+            // Parse extra properties
+            tinygltf::Node const& node = *static_cast<tinygltf::Node const*>(
+                m_gltfImporter.object3D(childID)->importerState());
+
+            tinygltf::Value const& extras = node.extras;
+            if (!extras.Has("machines"))
+            {
+                std::cout << "Error: no machines found in " << nodeName << "!\n";
+                goto exit;
+            }
+            tinygltf::Value const& machines = extras.Get("machines");
+            std::cout << "JSON machines!\n";
+            auto const& machArray = machines.Get<tinygltf::Value::Array>();
+
+            // Loop through machine configs
+                    // machArray looks like:
+                    // [
+                    //    { "type": "Rocket", stuff... },
+                    //    { "type": "Control", stuff...}
+                    // ]
+            for (tinygltf::Value const& value : machArray)
+            {
+                std::string type = value.Get("type").Get<std::string>();
+                std::cout << "test: " << type << "\n";
+
+                if (type.empty())
+                {
+                    continue;
+                }
+
+                // TODO: more stuff
+                PrototypeMachine machine;
+                machine.m_type = std::move(type);
+                part.get_machines().emplace_back(std::move(machine));
+            }
+            pkg.add<PrototypePart>(nodeName, std::move(part));
+        }
+    }
+
+    // Load all associated mesh data
+    // Temporary: eventually if would be preferable to retrieve the mesh names only
+    for (unsigned i = 0; i < m_gltfImporter.meshCount(); i++)
+    {
+        std::string const& meshName = m_gltfImporter.meshName(i);
+        std::cout << "Mesh: " << meshName << "\n";
+
+        Optional<MeshData> meshData = m_gltfImporter.mesh(i);
+        if (!meshData || (meshData->primitive() != Magnum::MeshPrimitive::Triangles))
+        {
+            std::cout << "Error: mesh " << meshName << " not composed of triangles\n";
+            continue;
+        }
+        pkg.add<MeshData>(meshName, std::move(*meshData));
+    }
+
+    // Load all associated image data
+    // Temporary: eventually it would be preferable to retrieve the URIs only
+    for (unsigned i = 0; i < m_gltfImporter.textureCount(); i++)
+    {
+        auto imgID = m_gltfImporter.texture(i)->image();
+        std::string const& imgName = m_gltfImporter.image2DName(imgID);
+        std::cout << "Loading image: " << imgName << "\n";
+
+        Optional<ImageData2D> imgData = m_gltfImporter.image2D(imgID);
+        if (!imgData)
+        {
+            continue;
+        }
+        pkg.add<ImageData2D>(imgName, std::move(*imgData));
+    }
+
+exit:
+    m_gltfImporter.close();
+}
+
+DependRes<ImageData2D> osp::AssetImporter::load_image(const std::string& filepath,
+    Package& pkg)
+{
+    using Magnum::Trade::AbstractImporter;
+    using Corrade::PluginManager::Manager;
+    using Corrade::Containers::Pointer;
+
+    Manager<AbstractImporter> manager;
+    Pointer<AbstractImporter> importer = manager.loadAndInstantiate("AnyImageImporter");
+    if (!importer || !importer->openFile(filepath))
+    {
+        std::cout << "Error: could not open file " << filepath << "\n";
+        return DependRes<ImageData2D>();
+    }
+
+    Optional<ImageData2D> image = importer->image2D(0);
+    if (!image)
+    {
+        std::cout << "Error: could not read image in file " << filepath << "\n";
+        return DependRes<ImageData2D>();
+    }
+
+    return pkg.add<ImageData2D>(filepath, std::move(*image));
+}
+
+DependRes<Mesh> osp::AssetImporter::compile_mesh(const std::string& meshDataName, Package& pkg)
+{
+    using Magnum::GL::Mesh;
+
+    DependRes<MeshData> meshData = pkg.get<MeshData>(meshDataName);
+    if (meshData.empty())
+    {
+        std::cout << "Error: requested MeshData resource \"" << meshDataName
+            << "\" not found\n";
+        return DependRes<Mesh>();
+    }
+
+    return pkg.add<Mesh>(meshDataName, Magnum::MeshTools::compile(*meshData));
+}
+
+DependRes<Texture2D> osp::AssetImporter::compile_tex(const std::string& imageDataName,
+    Package& package)
+{
+    using Magnum::GL::SamplerWrapping;
+    using Magnum::GL::SamplerFilter;
+    using Magnum::GL::textureFormat;
+
+    DependRes<ImageData2D> image = package.get<ImageData2D>(imageDataName);
+    if (image.empty())
+    {
+        std::cout << "Error: requested ImageData2D resource \"" << imageDataName
+            << "\" not found\n";
+        return DependRes<Texture2D>();
+    }
+
+    Magnum::ImageView2D view = *image;
+
+    Magnum::GL::Texture2D tex;
+    tex.setWrapping(SamplerWrapping::ClampToEdge)
+        .setMagnificationFilter(SamplerFilter::Linear)
+        .setMinificationFilter(SamplerFilter::Linear)
+        .setStorage(1, textureFormat((*image).format()), (*image).size())
+        .setSubImage(0, {}, view);
+
+    return package.add<Texture2D>(imageDataName, std::move(tex));
+}
+
+//either an appendable package, or
+void AssetImporter::proto_add_obj_recurse(Package& package,
+                                           PrototypePart& part,
+                                           unsigned parentProtoIndex,
+                                           unsigned childGltfIndex)
+{
+    using Corrade::Containers::Pointer;
+    using Magnum::Trade::ObjectData3D;
+    using Magnum::Trade::MaterialData;
+    using Magnum::Trade::PbrMetallicRoughnessMaterialData;
+
+    // Add the object to the prototype
+    Pointer<ObjectData3D> childData = m_gltfImporter.object3D(childGltfIndex);
+    std::vector<PrototypeObject>& protoObjects = part.get_objects();
+    const std::string& name = m_gltfImporter.object3DName(childGltfIndex);
+
+    // I think I've been doing too much C
+    PrototypeObject obj;
+    obj.m_parentIndex = parentProtoIndex;
+    obj.m_childCount = childData->children().size();
+    obj.m_translation = childData->translation();
+    obj.m_rotation = childData->rotation();
+    obj.m_scale = childData->scaling();
+    obj.m_type = ObjectType::NONE;
+    obj.m_name = name;
+
+    std::cout << "Adding obj to Part: " << name << "\n";
+    int meshID = childData->instance();
+
+    bool hasMesh = (
+            childData->instanceType() == Magnum::Trade::ObjectInstanceType3D::Mesh
+            && meshID != -1);
+
+    if (name.compare(0, 4, "col_") == 0)
+    {
+        // It's a collider
+        obj.m_type = ObjectType::COLLIDER;
+
+        // do some stuff here
+        obj.m_objectData = ColliderData{ECollisionShape::BOX};
+
+        std::cout << "obj: " << name << " is a collider\n";
+    }
+    else if (hasMesh)
+    {
+        // It's a drawable mesh
+        const std::string& meshName = m_gltfImporter.meshName(meshID);
+        std::cout << "obj: " << name << " uses mesh: " << meshName << "\n";
+        obj.m_type = ObjectType::MESH;
+
+        // The way it's currently set up is that the mesh's names are the same
+        // as their resource paths. So the resource path is added to the part's
+        // list of strings, and the object's mesh is set to the index to that
+        // string.
+        obj.m_objectData = DrawableData{ static_cast<unsigned>(part.get_strings().size()) };
+        part.get_strings().push_back(meshName);
+
+        Pointer<MaterialData> mat = m_gltfImporter.material(meshID);
+        
+        if (mat->types() & Magnum::Trade::MaterialType::PbrMetallicRoughness)
+        {
+            const auto& pbr = mat->as<PbrMetallicRoughnessMaterialData>();
+
+            auto imgID = m_gltfImporter.texture(pbr.baseColorTexture())->image();
+            std::string const& imgName = m_gltfImporter.image2DName(imgID);
+            std::cout << "Base Tex: " << imgName << "\n";
+            std::get<DrawableData>(obj.m_objectData).m_textures.push_back(
+                static_cast<unsigned>(part.get_strings().size()));
+            part.get_strings().push_back(imgName);
+
+            if (pbr.hasNoneRoughnessMetallicTexture())
+            {
+                imgID = m_gltfImporter.texture(pbr.metalnessTexture())->image();
+                std::cout << "Metal/rough texture: " << m_gltfImporter.image2DName(imgID) << "\n";
+            } else
+            {
+                std::cout << "No metal/rough texture found for " << name << "\n";
+            }
+            
+        } else
+        {
+            std::cout << "Error: unsupported material type\n";
+        }
+    }
+
+    //obj.m_mesh = m_meshOffset + childData->
+    int objIndex = protoObjects.size();
+    protoObjects.push_back(std::move(obj));
+
+    for (unsigned childId: childData->children())
+    {
+        //proto_add_obj_recurse(part, protoObjects.size() - 1, childId);
+        proto_add_obj_recurse(package, part, objIndex, childId);
+    }
+}
+
+}
+

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -232,6 +232,7 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
                                            unsigned childGltfIndex)
 {
     using Corrade::Containers::Pointer;
+    using Corrade::Containers::Optional;
     using Magnum::Trade::ObjectData3D;
     using Magnum::Trade::ObjectInstanceType3D;
     using Magnum::Trade::MaterialData;
@@ -285,7 +286,7 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
             static_cast<unsigned>(part.get_strings().size())};
         part.get_strings().push_back(meshName);
 
-        Pointer<MaterialData> mat = gltfImporter.material(meshID);
+        Optional<MaterialData> mat = gltfImporter.material(meshID);
         
         if (mat->types() & MaterialType::PbrMetallicRoughness)
         {

--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -22,18 +22,13 @@ namespace osp
 class AssetImporter
 {
 typedef Magnum::Trade::TinyGltfImporter TinyGltfImporter;
+typedef Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter>
+PluginManager;
 
 public:
-    AssetImporter() : m_gltfImporter(m_pluginManager) {}
+    AssetImporter() {}
 
-    /**
-     * Load only associated config files, and add resource paths to the package
-     * But for now, this function just loads everything.
-     *
-     * @param filepath [in] string filepath of requested sturdy file
-     * @param package [out] Package to put resource paths into
-     */
-    void load_sturdy(const std::string& filepath, Package& package);
+    static void load_sturdy_file(std::string const& filepath, Package& package);
 
     /**
      * Load an image from disk at the specified filepath
@@ -51,31 +46,51 @@ public:
      *
      * Takes the MeshData object from the package and compiles it into a Mesh
      * which can then be drawn
-     * @param filepath [in] string identifier of MeshData resource
+     * @param meshData [in] MeshData resource
      * @param package [out] Package to put Mesh resource into
      */
     static DependRes<Magnum::GL::Mesh> compile_mesh(
-        const std::string& meshDataName, Package& package);
+        const DependRes<Magnum::Trade::MeshData> meshData, Package& package);
 
     /**
      * Compile ImageData2D into an OpenGL Texture2D object
      *
      * Takes the ImageData2D object from the package and compiles it into a
      * Texture2D which can then be used by shaders
-     * @param filepath [in] string identifier of ImageData2D resource
+     * @param imageData [in] ImageData2D resource
      * @param package [out] Package to put Texture2D resource into
      */
     static DependRes<Magnum::GL::Texture2D> compile_tex(
-        const std::string& imageDataName, Package& package);
+        const DependRes<Magnum::Trade::ImageData2D> imageData, Package& package);
 private:
+    /**
+     * Load only associated config files, and add resource paths to the package
+     * But for now, this function just loads everything.
+     *
+     * @param gltfImporter [in] glTF importer referencing opened sturdy file
+     * @param package [out] Package to put resource paths into
+     */
+    static void load_sturdy(TinyGltfImporter& gltfImporter, Package& package);
 
-    void proto_add_obj_recurse(Package& package,
+    /**
+     * Load a part from a sturdy
+     *
+     * Reads the config from the node with the specified ID into a PrototypePart
+     * and stores it in the specified package
+     *
+     * @param gltfImpoter [in] importer used to read node data
+     * @param package [out] package which receives loaded data
+     * @param id [in] ID of node containing part information
+     */
+    static void load_part(TinyGltfImporter& gltfImporter,
+        Package& package, unsigned id);
+
+    static void proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
+                               Package& package,
                                PrototypePart& part,
                                unsigned parentProtoIndex,
                                unsigned childGltfIndex);
 
-    Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter> m_pluginManager;
-    Magnum::Trade::TinyGltfImporter m_gltfImporter;
 };
 
 }

--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+
+#include <MagnumPlugins/TinyGltfImporter/TinyGltfImporter.h>
+#include <MagnumPlugins/StbImageImporter/StbImageImporter.h>
+#include <Corrade/PluginManager/Manager.h>
+#include <Magnum/GL/Texture.h>
+#include <Magnum/Trade/ImageData.h>
+#include <Magnum/Trade/MeshData.h>
+
+
+#include "Package.h"
+#include "PrototypePart.h"
+
+#include "../types.h"
+//#include "../scene.h"
+
+namespace osp
+{
+
+class AssetImporter
+{
+typedef Magnum::Trade::TinyGltfImporter TinyGltfImporter;
+
+public:
+    AssetImporter() : m_gltfImporter(m_pluginManager) {}
+
+    /**
+     * Load only associated config files, and add resource paths to the package
+     * But for now, this function just loads everything.
+     *
+     * @param filepath [in] string filepath of requested sturdy file
+     * @param package [out] Package to put resource paths into
+     */
+    void load_sturdy(const std::string& filepath, Package& package);
+
+    /**
+     * Load an image from disk at the specified filepath
+     * 
+     * Loads an ImageData2D into the specified package, but does not create
+     * a texture in GPU memory until compile_tex() is called
+     * @param filepath [in] string filepath of requested image file
+     * @param package [out] Package to put image data into
+     */
+    static DependRes<Magnum::Trade::ImageData2D> load_image(
+        const std::string& filepath, Package& package);
+
+    /**
+     * Compile MeshData into an OpenGL Mesh object
+     *
+     * Takes the MeshData object from the package and compiles it into a Mesh
+     * which can then be drawn
+     * @param filepath [in] string identifier of MeshData resource
+     * @param package [out] Package to put Mesh resource into
+     */
+    static DependRes<Magnum::GL::Mesh> compile_mesh(
+        const std::string& meshDataName, Package& package);
+
+    /**
+     * Compile ImageData2D into an OpenGL Texture2D object
+     *
+     * Takes the ImageData2D object from the package and compiles it into a
+     * Texture2D which can then be used by shaders
+     * @param filepath [in] string identifier of ImageData2D resource
+     * @param package [out] Package to put Texture2D resource into
+     */
+    static DependRes<Magnum::GL::Texture2D> compile_tex(
+        const std::string& imageDataName, Package& package);
+private:
+
+    void proto_add_obj_recurse(Package& package,
+                               PrototypePart& part,
+                               unsigned parentProtoIndex,
+                               unsigned childGltfIndex);
+
+    Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter> m_pluginManager;
+    Magnum::Trade::TinyGltfImporter m_gltfImporter;
+};
+
+}

--- a/src/osp/Resource/Resource.h
+++ b/src/osp/Resource/Resource.h
@@ -121,6 +121,7 @@ public:
     }
 
     bool empty() const { return m_empty; }
+    std::string name() const { return m_it->first; }
 
     TYPE_T const& operator*() const { return m_it->second.m_data; }
     TYPE_T& operator*() { return m_it->second.m_data; }


### PR DESCRIPTION
`SturdyImporter` works great for parts, but when creating general 3D
effects, it is limiting since it is only capable of importing images
that are directly referenced by the sturdy file. `AssetImporter` is
mostly a copy of `SturdyImporter`, but with general functions to load
and compile meshes and image textures. These functions can be used to
load in any image texture for use in shaders or other non-part uses.
Meshes are still loaded via `load_sturdy()`, but it no longer ignores
meshes which don't belong to `part_*` nodes. Future node types will
be explictly handled by the loading loop in `load_sturdy()`, but for
now `part_` is the only one necessary.

Right now, it's possible to load the same resource multiple times,
since the texture names from a glTF file are different from the
actual filepath to that mesh. Avoid doing this for now, in the future
we'll find some way to make sure each asset can only have one
identifier.