### PR TITLE
Rework Floating Origin into SysAreaAssociate, Generalize Rigid body translation

### DIFF
--- a/src/DebugObject.cpp
+++ b/src/DebugObject.cpp
@@ -90,12 +90,11 @@ void DebugCameraController::update_physics_pre()
     Matrix4 &xform = m_scene.reg_get<active::ACompTransform>(m_ent).m_transform;
 
     // round to nearest (floatingOriginThreshold)
-    Vector3s tra(xform.translation() / floatingOriginThreshold);
+    Vector3s tra(-xform.translation() / floatingOriginThreshold);
     tra *= floatingOriginThreshold;
 
     // convert to space int
     tra *= gc_units_per_meter;
-
 
     if (!tra.isZero())
     {
@@ -103,7 +102,7 @@ void DebugCameraController::update_physics_pre()
 
         // Move the active area to center on the camera
         m_scene.dynamic_system_get<active::SysAreaAssociate>("AreaAssociate")
-                .area_move(tra);
+                .area_move(-tra);
     }
 }
 

--- a/src/DebugObject.cpp
+++ b/src/DebugObject.cpp
@@ -82,24 +82,28 @@ void DebugCameraController::update_vehicle_mod_pre()
 
 void DebugCameraController::update_physics_pre()
 {
-    // Floating Origin
+    // Floating Origin / Active area movement
 
     // When the camera is too far from the origin of the ActiveScene
     const int floatingOriginThreshold = 256;
 
     Matrix4 &xform = m_scene.reg_get<active::ACompTransform>(m_ent).m_transform;
 
-    // round to nearest (floatingOriginThreshold) by casting to int
-    Magnum::Vector3i tra(xform.translation() / floatingOriginThreshold);
+    // round to nearest (floatingOriginThreshold)
+    Vector3s tra(xform.translation() / floatingOriginThreshold);
     tra *= floatingOriginThreshold;
+
+    // convert to space int
+    tra *= gc_units_per_meter;
 
 
     if (!tra.isZero())
     {
         std::cout << "Floating origin translation!\n";
-        // Tell SysAreaAssociate to translate everything
+
+        // Move the active area to center on the camera
         m_scene.dynamic_system_get<active::SysAreaAssociate>("AreaAssociate")
-                .floating_origin_translate(-Vector3(tra));
+                .area_move(tra);
     }
 }
 

--- a/src/DebugObject.cpp
+++ b/src/DebugObject.cpp
@@ -76,6 +76,18 @@ void DebugCameraController::update_vehicle_mod_pre()
         }
         tgtVehicle.m_separationCount = tgtVehicle.m_parts.size();
     }
+
+    // Floating origin follow cameara
+
+    Matrix4 &xform = m_scene.reg_get<active::ACompTransform>(m_ent).m_transform;
+
+    Magnum::Vector3i tra(xform.translation() / 64);
+    tra *= 64;
+
+    //Magnum::Vector3i tra{0, 1, 0};
+
+    m_scene.floating_origin_translate(-Vector3(tra));
+
 }
 
 void DebugCameraController::update_physics_post()

--- a/src/DebugObject.h
+++ b/src/DebugObject.h
@@ -52,6 +52,7 @@ public:
     DebugCameraController(active::ActiveScene &scene, active::ActiveEnt ent);
     ~DebugCameraController() = default;
     void update_vehicle_mod_pre();
+    void update_physics_pre();
     void update_physics_post();
     void view_orbit(active::ActiveEnt ent);
 private:
@@ -61,6 +62,7 @@ private:
     float m_orbitDistance;
 
     active::UpdateOrderHandle m_updateVehicleModPre;
+    active::UpdateOrderHandle m_updatePhysicsPre;
     active::UpdateOrderHandle m_updatePhysicsPost;
 
     UserInputHandler &m_userInput;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -404,7 +404,7 @@ void create_solar_system()
     auto &stationary = uni.trajectory_create<universe::TrajStationary>(
                                         uni, uni.sat_root());
 
-    for (int i = 0; i < 0; i ++)
+    for (int i = 0; i < 10; i ++)
     {
         // Creates a random mess of spamcans
         universe::Satellite sat = debug_add_random_vehicle("TestyMcTestFace Mk"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,8 +268,7 @@ void magnum_application()
     auto &cameraComp = scene.get_registry().emplace<active::ACompCamera>(camera);
 
     cameraTransform.m_transform = Matrix4::translation(Vector3(0, 0, 25));
-    //scene.reg_emplace<active::ACompFloatingOrigin>(camera);
-    //cameraTransform.m_enableFloatingOrigin = true;
+    scene.reg_emplace<active::ACompFloatingOrigin>(camera);
 
     cameraComp.m_viewport
             = Vector2(Magnum::GL::defaultFramebuffer.viewport().size());
@@ -404,9 +403,10 @@ void create_solar_system()
     auto &stationary = uni.trajectory_create<universe::TrajStationary>(
                                         uni, uni.sat_root());
 
+    // Create 10 random vehicles
     for (int i = 0; i < 10; i ++)
     {
-        // Creates a random mess of spamcans
+        // Creates a random mess of spamcans as a vehicle
         universe::Satellite sat = debug_add_random_vehicle("TestyMcTestFace Mk"
                                                  + std::to_string(i));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,8 @@ void magnum_application()
     auto &cameraComp = scene.get_registry().emplace<active::ACompCamera>(camera);
 
     cameraTransform.m_transform = Matrix4::translation(Vector3(0, 0, 25));
-    cameraTransform.m_enableFloatingOrigin = true;
+    //scene.reg_emplace<active::ACompFloatingOrigin>(camera);
+    //cameraTransform.m_enableFloatingOrigin = true;
 
     cameraComp.m_viewport
             = Vector2(Magnum::GL::defaultFramebuffer.viewport().size());
@@ -403,7 +404,7 @@ void create_solar_system()
     auto &stationary = uni.trajectory_create<universe::TrajStationary>(
                                         uni, uni.sat_root());
 
-    for (int i = 0; i < 20; i ++)
+    for (int i = 0; i < 0; i ++)
     {
         // Creates a random mess of spamcans
         universe::Satellite sat = debug_add_random_vehicle("TestyMcTestFace Mk"

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -173,27 +173,10 @@ void ActiveScene::update()
     m_updateOrder.call();
 }
 
-void ActiveScene::floating_origin_translate_begin()
-{
-
-    // check if floating origin translation is requested
-    m_floatingOriginInProgress = !(m_floatingOriginTranslate.isZero());
-    if (m_floatingOriginInProgress)
-    {
-        std::cout << "Floating origin translation\n";
-    }
-}
 
 void ActiveScene::update_hierarchy_transforms()
 {
-    // skip top level
-    /*for(auto it = m_hierLevels.begin() + 1; it != m_hierLevels.end(); it ++)
-    {
-        for (entt::entity entity : *it)
-        {
 
-        }
-    }*/
     auto group = m_registry.group<ACompHierarchy, ACompTransform>();
 
     if (m_hierarchyDirty)
@@ -208,10 +191,6 @@ void ActiveScene::update_hierarchy_transforms()
         m_hierarchyDirty = false;
     }
 
-    //std::cout << "size: " << group.size() << "\n";
-
-    //bool translateAll = !(m_floatingOriginTranslate.isZero());
-
     for(auto entity: group)
     {
         //std::cout << "nice: " << group.get<ACompHierarchy>(entity).m_name << "\n";
@@ -222,13 +201,6 @@ void ActiveScene::update_hierarchy_transforms()
         if (hierarchy.m_parent == m_root)
         {
             // top level object, parent is root
-
-            if (m_floatingOriginInProgress && transform.m_enableFloatingOrigin)
-            {
-                // Do floating origin translation if enabled
-                Vector3& translation = transform.m_transform[3].xyz();
-                translation += m_floatingOriginTranslate;
-            }
 
             transform.m_transformWorld = transform.m_transform;
 
@@ -245,18 +217,6 @@ void ActiveScene::update_hierarchy_transforms()
         }
     }
 
-    if (m_floatingOriginInProgress)
-    {
-        // everything was translated already, set back to zero
-        m_floatingOriginTranslate = Vector3(0.0f, 0.0f, 0.0f);
-        m_floatingOriginInProgress = false;
-    }
-}
-
-void ActiveScene::floating_origin_translate(Vector3 const& amount)
-{
-    m_floatingOriginTranslate += amount;
-    //m_floatingOriginDirty = true;
 }
 
 void ActiveScene::draw(entt::entity camera)

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -8,7 +8,7 @@
 
 #include "../types.h"
 #include "activetypes.h"
-#include "physics.h"
+//#include "physics.h"
 
 //#include "SysDebugRender.h"
 //#include "SysNewton.h"
@@ -87,14 +87,14 @@ public:
      * @return Reference to component
      */
     template<class T>
-    constexpr T& reg_get(ActiveEnt ent) { return m_registry.get<T>(ent); };
+    decltype(auto) reg_get(ActiveEnt ent) { return m_registry.get<T>(ent); };
 
     /**
      * Shorthand for get_registry().emplace<T>()
      * @tparam T Component to emplace
      */
     template<class T, typename... Args>
-    constexpr T& reg_emplace(ActiveEnt ent, Args&& ... args)
+    decltype(auto) reg_emplace(ActiveEnt ent, Args&& ... args)
     {
         return m_registry.emplace<T>(ent, std::forward<Args>(args)...);
     }

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -111,30 +111,6 @@ public:
     void update_hierarchy_transforms();
 
     /**
-     * Request a floating origin mass translation. Multiple calls to this are
-     * accumulated and are applied on the next physics update
-     * @param pAmount [in] Meters to translate
-     */
-    void floating_origin_translate(Vector3 const& pAmount);
-
-    /**
-     * @return Accumulated total of floating_origin_translate
-     */
-    constexpr Vector3 const& floating_origin_get_total() { return m_floatingOriginTranslate; }
-
-    /**
-     * Attempt ro perform translations on this frame. Will do nothing if the
-     * floating origin total (m_floatingOriginTranslate) is 0
-     */
-    void floating_origin_translate_begin();
-
-    /**
-     * @return True if a floating origin translation is being performed this
-     *         frame
-     */
-    constexpr bool floating_origin_in_progress() { return m_floatingOriginInProgress; }
-
-    /**
      * Calculate transformations relative to camera, and draw every
      * CompDrawableDebug
      * @param camera [in] Entity containing a ACompCamera
@@ -203,11 +179,7 @@ private:
     ActiveEnt m_root;
     bool m_hierarchyDirty;
 
-    Vector3 m_floatingOriginTranslate;
-    bool m_floatingOriginInProgress;
-
     float m_timescale;
-
 
     UserInputHandler &m_userInput;
     //std::vector<std::reference_wrapper<ISysMachine>> m_update_sensor;
@@ -269,7 +241,18 @@ struct ACompTransform
     //Matrix4 m_transformPrev;
     Matrix4 m_transform;
     Matrix4 m_transformWorld;
-    bool m_enableFloatingOrigin;
+    //bool m_enableFloatingOrigin;
+
+    // For when transform is controlled by a specific system.
+    // Examples of this behaviour:
+    // * Entities with ACompRigidBody are controlled by SysPhysics, transform
+    //   is updated each frame
+    bool m_controlled{false};
+
+    // if this is true, then transform can be modified, as long as
+    // m_transformDirty is set afterwards
+    bool m_mutable{true};
+    bool m_transformDirty{false};
 };
 
 struct ACompHierarchy

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -105,6 +105,18 @@ void SysAreaAssociate::disconnect()
     m_areaSat = entt::null;
 }
 
+void SysAreaAssociate::area_move(Vector3s translate)
+{
+    auto &areaPosTraj = m_universe.get_reg()
+            .get<universe::UCompTransformTraj>(m_areaSat);
+
+    areaPosTraj.m_position += translate;
+
+    Vector3 meters = Vector3(translate) / gc_units_per_meter;
+
+    floating_origin_translate(-meters);
+}
+
 void SysAreaAssociate::sat_transform_update(ActiveEnt ent)
 {
     auto const &entAct = m_scene.reg_get<ACompActivatedSat>(ent);
@@ -118,7 +130,8 @@ void SysAreaAssociate::sat_transform_update(ActiveEnt ent)
             .get<universe::UCompTransformTraj>(m_areaSat);
 
     // 1024 units = 1 meter
-    Vector3s posAreaRelative(entTransform.m_transform.translation() * 1024.0f);
+    Vector3s posAreaRelative(entTransform.m_transform.translation()
+                             * gc_units_per_meter);
 
 
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -13,12 +13,6 @@ namespace osp::active
 class SysAreaAssociate;
 struct ACompActivatedSat;
 
-//typedef int (*LoadStrategy)(ActiveScene &scene, SysAreaAssociate &area,
-//                universe::Satellite areaSat, universe::Satellite loadMe);
-
-// TODO: maybe consider getting rid of raw pointers here somehow.
-//       none of these take ownership, only reference
-
 struct StatusActivated
 {
     int m_status; // 0 for no errors
@@ -84,6 +78,8 @@ public:
     void activator_add(universe::ITypeSatellite const* type,
                        IActivator &activator);
 
+    void floating_origin_translate(Vector3 translation);
+
     constexpr universe::Universe& get_universe() { return m_universe; }
 
     using MapActivators
@@ -100,7 +96,10 @@ private:
     //std::vector<universe::Satellite> m_activatedSats;
     entt::sparse_set<universe::Satellite> m_activatedSats;
 
+    //UpdateOrderHandle m_updateFloatingOrigin;
     UpdateOrderHandle m_updateScan;
+
+    //void floating_origin_translate(Vector3 translation);
 
     /**
      * Attempt to load a satellite

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -65,6 +65,12 @@ public:
     void disconnect();
 
     /**
+     * Move the ActiveArea satellite, and translate everything in the
+     * ActiveScene, aka: floating origin translation
+     */
+    void area_move(Vector3s translate);
+
+    /**
      * Update position of ent's associated Satellite in the Universe, based on
      * it's transform in the ActiveScene.
      */
@@ -77,8 +83,6 @@ public:
      */
     void activator_add(universe::ITypeSatellite const* type,
                        IActivator &activator);
-
-    void floating_origin_translate(Vector3 translation);
 
     constexpr universe::Universe& get_universe() { return m_universe; }
 
@@ -99,7 +103,11 @@ private:
     //UpdateOrderHandle m_updateFloatingOrigin;
     UpdateOrderHandle m_updateScan;
 
-    //void floating_origin_translate(Vector3 translation);
+    /**
+     * Translate everything in the ActiveScene
+     * @param translation
+     */
+    void floating_origin_translate(Vector3 translation);
 
     /**
      * Attempt to load a satellite

--- a/src/osp/Active/SysNewton.cpp
+++ b/src/osp/Active/SysNewton.cpp
@@ -7,19 +7,23 @@
 using namespace osp;
 using namespace osp::active;
 
+// Callback called for every Rigid Body (even static ones) on NewtonUpdate
 void cb_force_torque(const NewtonBody* body, dFloat timestep, int threadIndex)
 {
+    // Get SysNewton from Newton World
     auto* sysNewton = static_cast<SysNewton*>(
                 NewtonWorldGetUserData(NewtonBodyGetWorld(body)));
     ActiveScene &scene = sysNewton->get_scene();
 
+    // Get ACompNwtBody. Every NewtonBody created here is associated with an
+    // entity that contains one.
     auto *bodyComp = static_cast<ACompNwtBody*>(NewtonBodyGetUserData(body));
     DataPhyRigidBody &bodyPhy = bodyComp->m_bodyData;
 
-    auto& transform
-            = scene.get_registry().get<ACompTransform>(bodyComp->m_entity);
+    auto& transform = scene.get_registry().get<ACompTransform>(
+                bodyComp->m_entity);
 
-    // Check if transform is being set
+    // Check if transform has been set externally
     if (transform.m_transformDirty)
     {
 
@@ -36,12 +40,6 @@ void cb_force_torque(const NewtonBody* body, dFloat timestep, int threadIndex)
     // Reset accumolated net force and torque for next frame
     bodyPhy.m_netForce = {0.0f, 0.0f, 0.0f};
     bodyPhy.m_netTorque = {0.0f, 0.0f, 0.0f};
-
-    // temporary fun stuff:
-    //NewtonBodySetForce(body, (-(matrix[3].xyz() + Vector3(0, 0, 20)) * 0.1f).data());
-    //Vector3 torque(0, 1, 0);
-    //NewtonBodySetTorque(body, torque.data());
-
 }
 
 ACompNwtBody::ACompNwtBody(ACompNwtBody&& move) :
@@ -50,7 +48,7 @@ ACompNwtBody::ACompNwtBody(ACompNwtBody&& move) :
         //m_scene(move.m_scene),
         m_bodyData(move.m_bodyData)
 {
-    if (m_body)
+    if (m_body != nullptr)
     {
         NewtonBodySetUserData(m_body, this);
     }
@@ -62,7 +60,7 @@ ACompNwtBody& ACompNwtBody::operator=(ACompNwtBody&& move)
     m_entity = move.m_entity;
     m_bodyData = move.m_bodyData;
 
-    if (m_body)
+    if (m_body != nullptr)
     {
         NewtonBodySetUserData(m_body, this);
     }
@@ -100,17 +98,21 @@ SysNewton::~SysNewton()
     NewtonDestroy(m_nwtWorld);
 }
 
-void SysNewton::find_and_add_colliders(ActiveEnt ent, NewtonCollision *compound, Matrix4 const &currentTransform)
+void SysNewton::find_and_add_colliders(ActiveEnt ent, NewtonCollision *compound,
+                                       Matrix4 const &currentTransform)
 {
 
     ActiveEnt nextChild = ent;
 
+    // iterate through siblings of ent
     while(nextChild != entt::null)
     {
-        ACompHierarchy const &childHeir = m_scene.reg_get<ACompHierarchy>(nextChild);
-        ACompTransform const &childTransform = m_scene.reg_get<ACompTransform>(nextChild);
+        auto const &childHeir = m_scene.reg_get<ACompHierarchy>(nextChild);
+        auto const &childTransform = m_scene.reg_get<ACompTransform>(nextChild);
 
-        ACompCollisionShape* childCollide = m_scene.get_registry().try_get<ACompCollisionShape>(nextChild);
+        auto* childCollide = m_scene.get_registry()
+                                .try_get<ACompCollisionShape>(nextChild);
+
         Matrix4 childMatrix = currentTransform * childTransform.m_transform;
 
         if (childCollide)
@@ -123,8 +125,10 @@ void SysNewton::find_and_add_colliders(ActiveEnt ent, NewtonCollision *compound,
             }
             else
             {
-                // TODO: care about collision shape
-                childCollide->m_collision = collision = NewtonCreateSphere(m_nwtWorld, 0.5f, 0, NULL);
+                // TODO: care about collision shape. for now, everything is a
+                //       sphere
+                collision = NewtonCreateSphere(m_nwtWorld, 0.5f, 0, NULL);
+                childCollide->m_collision = collision;
             }
 
             //Matrix4 nextTransformNorm = nextTransform.
@@ -150,28 +154,27 @@ void SysNewton::find_and_add_colliders(ActiveEnt ent, NewtonCollision *compound,
 void SysNewton::create_body(ActiveEnt entity)
 {
 
-    ACompHierarchy& entHeir = m_scene.reg_get<ACompHierarchy>(entity);
-    ACompNwtBody& entBody = m_scene.reg_get<ACompNwtBody>(entity);
-    ACompCollisionShape* entShape = m_scene.get_registry().try_get<ACompCollisionShape>(entity);
-    ACompTransform& entTransform = m_scene.reg_get<ACompTransform>(entity);
+    auto& entHeir = m_scene.reg_get<ACompHierarchy>(entity);
+    auto& entTransform = m_scene.reg_get<ACompTransform>(entity);
 
-    if (!entShape)
+    auto& entBody = m_scene.reg_get<ACompNwtBody>(entity);
+    auto* entShape = m_scene.get_registry()
+                        .try_get<ACompCollisionShape>(entity);
+
+    if (entShape == nullptr)
     {
-        // need collision shape to make a body
+        // Entity must also have a collision shape to make a body
         return;
     }
-
-    //if (entBody.m_body)
-    //{
-        // body is already initialized, delete it first and make a new one
-    //}
-
 
     switch (entShape->m_shape)
     {
     case ECollisionShape::COMBINED:
     {
-        NewtonCollision* compound = NewtonCreateCompoundCollision(m_nwtWorld, 0);
+        // Combine collision shapes from descendants
+
+        NewtonCollision* compound
+                = NewtonCreateCompoundCollision(m_nwtWorld, 0);
 
         NewtonCompoundCollisionBeginAddRemove(compound);
         find_and_add_colliders(entHeir.m_childFirst, compound, Matrix4());
@@ -184,20 +187,22 @@ void SysNewton::create_body(ActiveEnt entity)
         else
         {
             entBody.m_body = NewtonCreateDynamicBody(m_nwtWorld, compound,
-                                                       Matrix4().data());
+                                                     Matrix4().data());
         }
 
         NewtonDestroyCollision(compound);
 
         // Set inertia and mass
-        NewtonBodySetMassMatrix(entBody.m_body, entBody.m_bodyData.m_mass, 1, 1, 1);
+        NewtonBodySetMassMatrix(entBody.m_body, entBody.m_bodyData.m_mass,
+                                1, 1, 1);
 
-        Vector3 tmpOset{0.0f, 0.0f, 0.0f};
-        NewtonBodySetCentreOfMass(entBody.m_body, tmpOset.data());
         break;
     }
     case ECollisionShape::TERRAIN:
     {
+        // Get NewtonTreeCollision generated from elsewhere
+        // such as SysPlanetA::debug_create_chunk_collider
+
         if (entShape->m_collision)
         {
             if (entBody.m_body)
@@ -233,7 +238,8 @@ void SysNewton::create_body(ActiveEnt entity)
     NewtonBodySetLinearDamping(entBody.m_body, 0.0f);
 
     // Make it easier to rotate
-    NewtonBodySetAngularDamping(entBody.m_body, Vector3(1.0f, 1.0f, 1.0f).data());
+    NewtonBodySetAngularDamping(entBody.m_body,
+                                Vector3(1.0f, 1.0f, 1.0f).data());
 
     // Set callback for updating position of entity and everything else
     NewtonBodySetForceAndTorqueCallback(entBody.m_body, cb_force_torque);
@@ -291,7 +297,7 @@ std::pair<ActiveEnt, ACompRigidBody*> SysNewton::find_rigidbody_ancestor(
     }
     while (currHeir->m_level != gc_heir_physics_level);
 
-    ACompRigidBody *body = m_scene.get_registry().try_get<ACompRigidBody>(prevEnt);
+    auto *body = m_scene.get_registry().try_get<ACompRigidBody>(prevEnt);
 
     return {prevEnt, body};
 
@@ -356,7 +362,7 @@ void SysNewton::on_shape_destruct(entt::registry& reg, ActiveEnt ent)
 {
     // make sure the collision shape destroyed
     NewtonCollision *shape = reg.get<ACompCollisionShape>(ent).m_collision;
-    if (shape)
+    if (shape != nullptr)
     {
         NewtonDestroyCollision(shape);
     }
@@ -368,24 +374,12 @@ NewtonCollision* SysNewton::newton_create_tree_collision(
     return NewtonCreateTreeCollision(newtonWorld, shapeId);
 }
 
-void foo(void* const serializeHandle, const void * const buffer, int size)
-{
-    std::cout << std::hex;
-    for (size_t i = 0; i < size; i ++)
-    {
-        int f = uint8_t(*((uint8_t*)buffer + i));
-         std::cout << f;
-    }
-    std::cout << std::dec;
-
-}
-
-
 void SysNewton::newton_tree_collision_add_face(
         const NewtonCollision* treeCollision, int vertexCount,
         const float* vertexPtr, int strideInBytes, int faceAttribute)
 {
-    NewtonTreeCollisionAddFace(treeCollision, vertexCount, vertexPtr, strideInBytes, faceAttribute);
+    NewtonTreeCollisionAddFace(treeCollision, vertexCount, vertexPtr,
+                               strideInBytes, faceAttribute);
 }
 
 void SysNewton::newton_tree_collision_begin_build(

--- a/src/osp/Active/SysNewton.cpp
+++ b/src/osp/Active/SysNewton.cpp
@@ -22,12 +22,9 @@ void cb_force_torque(const NewtonBody* body, dFloat timestep, int threadIndex)
     // Check if transform is being set
     if (transform.m_transformDirty)
     {
-        Matrix4 matrix;
-        NewtonBodyGetMatrix(body, matrix.data());
 
-        // Set matrix without Newton 'conveniently' sleeping for a frame
-        NewtonBodySetMatrixNoSleep(body,
-                                   matrix.data());
+        // Set matrix
+        NewtonBodySetMatrix(body, transform.m_transform.data());
 
         transform.m_transformDirty = false;
     }

--- a/src/osp/Active/SysNewton.h
+++ b/src/osp/Active/SysNewton.h
@@ -37,8 +37,6 @@ struct ACompNwtBody
     ActiveEnt m_entity{entt::null};
     //ActiveScene &m_scene;
 
-    Matrix4 m_prevTransform;
-
     DataPhyRigidBody m_bodyData;
 };
 

--- a/src/osp/Active/SysNewton.h
+++ b/src/osp/Active/SysNewton.h
@@ -37,6 +37,8 @@ struct ACompNwtBody
     ActiveEnt m_entity{entt::null};
     //ActiveScene &m_scene;
 
+    Matrix4 m_prevTransform;
+
     DataPhyRigidBody m_bodyData;
 };
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -1,6 +1,8 @@
 #include "ActiveScene.h"
 #include "SysVehicle.h"
 #include "SysDebugRender.h"
+#include "physics.h"
+
 #include "../Satellites/SatActiveArea.h"
 #include "../Satellites/SatVehicle.h"
 #include "../Resource/PrototypePart.h"

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -68,7 +68,8 @@ StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
                                         .emplace<ACompTransform>(vehicleEnt);
     vehicleTransform.m_transform
             = Matrix4::from(tgtPosTraj.m_rotation.toMatrix(), positionInScene);
-    vehicleTransform.m_enableFloatingOrigin = true;
+    scene.reg_emplace<ACompFloatingOrigin>(vehicleEnt);
+    //vehicleTransform.m_enableFloatingOrigin = true;
 
     // Create the parts
 
@@ -241,7 +242,6 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                 = Matrix4::from(currentPrototype.m_rotation.toMatrix(),
                                 currentPrototype.m_translation)
                 * Matrix4::scaling(currentPrototype.m_scale);
-        currentTransform.m_enableFloatingOrigin = true;
 
         if (currentPrototype.m_type == ObjectType::MESH)
         {
@@ -354,7 +354,7 @@ void SysVehicle::update_vehicle_modification()
                 islandShape.m_shape = ECollisionShape::COMBINED;
 
                 islandTransform.m_transform = vehicleTransform.m_transform;
-                islandTransform.m_enableFloatingOrigin = true;
+                m_scene.reg_emplace<ACompFloatingOrigin>(islandEnt);
 
                 islands[i] = islandEnt;
 

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -29,7 +29,7 @@ using RenderOrderHandle = FunctionOrderHandle<void(ACompCamera const&)>;
 
 struct ACompFloatingOrigin
 {
-    bool m_dummy;
+    //bool m_dummy;
 };
 
 // not really sure what else to put in here

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -27,6 +27,11 @@ using UpdateOrderHandle = FunctionOrderHandle<void(void)>;
 using RenderOrder = FunctionOrder<void(ACompCamera const&)>;
 using RenderOrderHandle = FunctionOrderHandle<void(ACompCamera const&)>;
 
+struct ACompFloatingOrigin
+{
+    bool m_dummy;
+};
+
 // not really sure what else to put in here
 class IDynamicSystem
 {

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -32,6 +32,9 @@ struct UCompActiveArea
     //active::ActiveEnt m_camera;
 
     unsigned m_sceneIndex;
+
+    // true when the ActiveArea is moving
+    bool m_inMotion;
 };
 
 

--- a/src/osp/types.h
+++ b/src/osp/types.h
@@ -27,6 +27,10 @@ using Magnum::Rad;
 // An int for space
 typedef int64_t SpaceInt;
 
+// 1024 space units = 1 meter
+// TODO: this should vary by trajectory, but for now it's global
+const float gc_units_per_meter = 1024.0f;
+
 // A Vector3 for space
 //typedef Magnum::Math::Vector3<SpaceInt> Vector3sp;
 

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -14,7 +14,7 @@
 namespace planeta::active
 {
 
-struct CompPlanet
+struct ACompPlanet
 {
     PlanetGeometryA m_planet;
     Magnum::GL::Mesh m_mesh{};
@@ -54,7 +54,7 @@ public:
     void draw(osp::active::ACompCamera const& camera);
 
     void debug_create_chunk_collider(osp::active::ActiveEnt ent,
-                                     CompPlanet &planet,
+                                     ACompPlanet &planet,
                                      chindex_t chunk);
 
     void update_geometry();


### PR DESCRIPTION
These changes will rework Floating Origin, where entities containing an ACompFloatingOrigin in the ActiveScene are translated towards the origin of the scene when the viewer moves too far away. This prevents significant floating point precision errors.

The translation code is in SysAreaAssociate, the system class that pairs the ActiveScene with a UCompActiveArea, so that the scene can represent an area in the Universe. When translating the scene, the UCompActiveArea has to be translated too. Call `SysAreaAssociate::area_move` to translate both the UCompActiveArea, and every entity with a ACompFloatingOrigin in the ActiveScene.

Floating origin was implemented previously, but all the old code is removed. `ACompTransform::m_enableFloatingOrigin` no longer works. Use `scene.reg_emplace<ACompFloatingOrigin>(entity);` instead to enable Floating Origin on an entity. This should only be added to level-1 entities, parented to the scene's root.

### Rigid bodies and 'controlled entities'

Entities with an ACompRigidBody are controlled by SysNewton; their ACompTransform is updated each frame. This behaviour of 'transform updated each frame' will definitely end up repeated throughout other parts of the code, now named 'controlled' for the time being. 

It would be best if there was a common way to modify the transform from elsewhere while making the controlling system aware of the change. A few new bool members were added to ACompTransform for this purpose:
* m_controlled - Set true from a controlling system to control the entity
* m_mutable - Set true from a controlling system to allow other systems to modify m_transform 
* m_transformDirty Set true from elsewhere, to notify the controlling system when m_transform is modified

SysAreaAssociate uses this interface to translate ACompRigidBody entities without being coupled to SysNewton.

~~Setting a rigid body's transform will modify it AFTER Newton has calculated a new transform for it. This means a frame will be lost, which will cause a bit of a 'twitch' during floating origin translations. SysNewton deals this a little hackily by saving the previous transform of rigid bodies. When transform is set dirty, it will apply the difference between its previous and new/desired transform.~~

Previously, physics was drawn 1 frame behind, as SysNewton will update rigid body's ACompTransform with that of the previous frame. A loop after the physics world update was added to update ACompTransform separately.