### PR TITLE
Add resource package prefixes

### DIFF
--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -280,9 +280,7 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
 
             // Current prototype is a mesh, get the mesh and add it
 
-            // TODO: put package prefixes in resource path
-            //       for now just get the first package
-            Package& package = m_scene.get_application().debug_get_packges()[0];
+            Package& package = m_scene.get_application().debug_find_package("lzdb");
             const DrawableData& drawable =
                 std::get<DrawableData>(currentPrototype.m_objectData);
 

--- a/src/osp/OSPApplication.cpp
+++ b/src/osp/OSPApplication.cpp
@@ -30,3 +30,18 @@ OSPApplication::OSPApplication()
 {
 
 }
+
+void OSPApplication::debug_add_package(Package&& p)
+{
+    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
+    assert(success);
+}
+
+Package& OSPApplication::debug_find_package(std::string_view prefix)
+{
+    if (auto it = m_packages.find(prefix); it != m_packages.end())
+    {
+        return it->second;
+    }
+    throw std::out_of_range("Package not found");
+}

--- a/src/osp/OSPApplication.h
+++ b/src/osp/OSPApplication.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <map>
 #include "Universe.h"
 #include "Resource/Package.h"
 
@@ -39,12 +40,30 @@ public:
 
     OSPApplication();
 
-    std::vector<Package>& debug_get_packges() { return m_packages; };
+    /**
+     * Add a resource package to the application
+     *
+     * The package should be populated externally, then passed via rvalue
+     * reference so the contents can be moved into the application resources
+     *
+     * @param p [in] The package to add
+     */
+    void debug_add_package(Package&& p);
+
+    /**
+     * Get a resource package by prefix name
+     *
+     * @param prefix [in] The short prefix name of the package
+     * @return The resource package
+     */
+    Package& debug_find_package(std::string_view prefix);
+
+    size_t debug_num_packages() const { return m_packages.size(); }
 
     universe::Universe& get_universe() { return m_universe; }
 
 private:
-    std::vector<Package> m_packages;
+    std::map<ResPrefix_t, Package, std::less<>> m_packages;
     universe::Universe m_universe;
 };
 

--- a/src/osp/Resource/Package.cpp
+++ b/src/osp/Resource/Package.cpp
@@ -29,12 +29,27 @@
 namespace osp
 {
 
-Package::Package(std::string const& prefix, std::string const& packageName) :
-    // not sure about this but it compiles
+Package::Package(std::string prefix, std::string packageName) :
     m_groups(),
-    //m_prefix{prefix[0], prefix[1], prefix[2], prefix[3]},
-    m_packageName(packageName)
+    m_prefix(std::move(prefix)),
+    m_packageName(std::move(packageName))
 {
 }
+
+StrViewPair_t decompose_str(std::string_view path, const char delim)
+{
+    size_t pos = path.find(delim);
+    return {
+        path.substr(0, pos),
+        path.substr(pos + 1, path.length())
+    };
+}
+
+Path decompose_str(std::string_view path)
+{
+    StrViewPair_t pair = decompose_str(path, ':');
+    return { pair.first, pair.second };
+}
+
 
 }

--- a/src/osp/Resource/Package.h
+++ b/src/osp/Resource/Package.h
@@ -61,24 +61,47 @@ namespace osp
 
 // supported resources
 
+// Just a string, but typedef'd to indicate that it represents a prefix
+using ResPrefix_t = std::string;
+
+// Stores a split path as <prefix, rest of path>
+struct Path
+{
+    std::string_view prefix;
+    std::string_view identifier;
+};
+
+using StrViewPair_t = std::pair<std::string_view, std::string_view>;
+/**
+ * Split a string_view at the first instance of a delimiter
+ *
+ */
+StrViewPair_t decompose_str(std::string_view path, const char delim);
+
+/**
+ * Split a resource path into a prefix and identifier
+ *
+ * A path of the format "prefix:identifier" is divided into the prefix (any
+ * text preceeding the first instance of the ':' character), and the following
+ * identifier.
+ *
+ * @param path [in] The path to split
+ * @return The path divided into a prefix and identifier
+ */
+Path decompose_path(std::string_view path);
 
 class Package
 {
-
-
-
 public:
 
 
     Package(Package&& move) = default;
     Package(const Package& copy) = delete;
+    Package& operator=(Package const& copy) = delete;
 
-    Package(std::string const& prefix, std::string const& packageName);
+    Package(std::string prefix, std::string packageName);
 
     //ResourceTable m_resources;
-
-    typedef uint32_t Prefix;
-    //typedef char Prefix[4];
 
     //virtual Magnum::GL::Mesh* request_mesh(const std::string& path);
 
@@ -118,6 +141,7 @@ public:
         std::map<std::string, Resource<TYPE_T>> m_resources;
     };
 
+    ResPrefix_t get_prefix() const { return m_prefix; }
 
 private:
 
@@ -125,7 +149,7 @@ private:
 
     std::string m_packageName;
 
-    Prefix m_prefix;
+    ResPrefix_t m_prefix;
 
     std::string m_displayName;
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -155,8 +155,8 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     // workaround: wipe mesh resources because they're specific to the
     // opengl context
-    rOspApp.debug_get_packges()[0].clear<Magnum::GL::Mesh>();
-    rOspApp.debug_get_packges()[0].clear<Magnum::GL::Texture2D>();
+    rOspApp.debug_find_package("lzdb").clear<Magnum::GL::Mesh>();
+    rOspApp.debug_find_package("lzdb").clear<Magnum::GL::Texture2D>();
 
     // destruct the application, this closes the window
     pMagnumApp.reset();

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -185,7 +185,7 @@ bool destroy_universe()
     g_osp.get_universe().get_reg().clear();
 
     // Destroy blueprints as part of destroying all vehicles
-    g_osp.debug_get_packges()[0].clear<osp::BlueprintVehicle>();
+    g_osp.debug_find_package("lzdb").clear<osp::BlueprintVehicle>();
 
     std::cout << "*explosion* Universe destroyed!\n";
 
@@ -202,7 +202,7 @@ void load_a_bunch_of_stuff()
     osp::AssetImporter::load_sturdy_file("OSPData/adera/stomper.sturdy.gltf", lazyDebugPack);
 
     // Add package to the univere
-    g_osp.debug_get_packges().push_back(std::move(lazyDebugPack));
+    g_osp.debug_add_package(std::move(lazyDebugPack));
 
     // Add 50 vehicles so there's something to load
     //g_osp.get_universe().get_sats().reserve(64);

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -54,7 +54,7 @@ using planeta::universe::UCompPlanet;
 void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
 {
     Universe &uni = ospApp.get_universe();
-    Package &pkg = ospApp.debug_get_packges()[0];
+    Package &pkg = ospApp.debug_find_package("lzdb");
 
     // Get the planet system used to create a UCompPlanet
     SatPlanet &typePlanet = static_cast<planeta::universe::SatPlanet&>(


### PR DESCRIPTION
Adds the resource package prefixes Cap planned originally.

I recommend looking at Package.h/Package.cpp first, then OSPApplication.h/.cpp. The rest of the changes are simply updating other code to use the new system. I wish there were a way to order the files in the "files changed" tab so that the logical cascade of changes was easier to follow.