### PR TITLE
Unique mesh identities

### DIFF
--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -52,7 +52,7 @@ PluginManager;
 public:
     AssetImporter() {}
 
-    static void load_sturdy_file(std::string const& filepath, Package& package);
+    static void load_sturdy_file(std::string_view filepath, Package& package);
 
     /**
      * Load an image from disk at the specified filepath
@@ -92,9 +92,12 @@ private:
      * But for now, this function just loads everything.
      *
      * @param gltfImporter [in] glTF importer referencing opened sturdy file
+     * @param resPrefix [in] Unique name associated with the data source,
+     *       used to make resource names (e.g. mesh) unique to avoid collisions
      * @param package [out] Package to put resource paths into
      */
-    static void load_sturdy(TinyGltfImporter& gltfImporter, Package& package);
+    static void load_sturdy(TinyGltfImporter& gltfImporter,
+            std::string_view resPrefix, Package& package);
 
     /**
      * Load a part from a sturdy
@@ -105,15 +108,17 @@ private:
      * @param gltfImpoter [in] importer used to read node data
      * @param package [out] package which receives loaded data
      * @param id [in] ID of node containing part information
+     * @param resPrefix [in] Unique prefix for mesh names (see load_sturdy())
      */
     static void load_part(TinyGltfImporter& gltfImporter,
-        Package& package, unsigned id);
+        Package& package, Magnum::UnsignedInt id, std::string_view resPrefix);
 
     static void proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
                                Package& package,
+                               std::string_view resPrefix,
                                PrototypePart& part,
-                               unsigned parentProtoIndex,
-                               unsigned childGltfIndex);
+                               Magnum::UnsignedInt parentProtoIndex,
+                               Magnum::UnsignedInt childGltfIndex);
 
 };
 


### PR DESCRIPTION
Mesh data in blender files are given autogenerated names like
"Cylinder.004" and are usually not touched by the user. Thus, two
separate glTF files can easily end up containing meshes that share the
same name. To solve this, we use the data filepath to generate a unique
name prefix for meshes, which is used by the various loading functions
to discriminate between mesh resources.

---

As yet these changes are untested; it compiles and the program runs, but I haven't tried to induce a name collision yet. I'll try it sometime before merging, but for now I'm throwing this up here so it can be reviewed.