### PR TITLE
Improve Planet code and Add real-world moon test universe

### DIFF
--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -51,13 +51,13 @@ void Universe::sat_remove(Satellite sat)
 }
 
 
-Vector3s Universe::sat_calc_pos(Satellite referenceFrame, Satellite target)
+Vector3s Universe::sat_calc_pos(Satellite referenceFrame, Satellite target) const
 {
-    auto view = m_registry.view<UCompTransformTraj>();
+    auto const view = m_registry.view<const UCompTransformTraj>();
 
     // TODO: maybe do some checks to make sure they have the components
-    auto &framePosTraj = view.get<UCompTransformTraj>(referenceFrame);
-    auto &targetPosTraj = view.get<UCompTransformTraj>(target);
+    auto const &framePosTraj = view.get<const UCompTransformTraj>(referenceFrame);
+    auto const &targetPosTraj = view.get<const UCompTransformTraj>(target);
 
     if (framePosTraj.m_parent == targetPosTraj.m_parent)
     {
@@ -69,7 +69,7 @@ Vector3s Universe::sat_calc_pos(Satellite referenceFrame, Satellite target)
     return {0, 0, 0};
 }
 
-Vector3 Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target)
+Vector3 Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const
 {
     // 1024 units = 1 meter. this can change
     return Vector3(sat_calc_pos(referenceFrame, target)) / 1024.0f;

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -105,7 +105,7 @@ public:
      * @param target [in]
      * @return relative position of target in SpaceInt vector
      */
-    Vector3s sat_calc_pos(Satellite referenceFrame, Satellite target);
+    Vector3s sat_calc_pos(Satellite referenceFrame, Satellite target) const;
 
     /**
      * Calculate position between two satellites.
@@ -113,7 +113,7 @@ public:
      * @param target [in]
      * @return relative position of target in meters
      */
-    Vector3 sat_calc_pos_meters(Satellite referenceFrame, Satellite target);
+    Vector3 sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const;
 
     /**
      * Register an ITypeSatellite so the universe can recognize that this type

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -296,7 +296,7 @@ void SysPlanetA::update_geometry()
             planet.m_icoTree->subdivide_remove_all_unused();
             planet.m_icoTree->event_notify();
 
-            planet.m_planet->debug_raise_by_share_count();
+            //planet.m_planet->debug_raise_by_share_count();
 
             using Corrade::Containers::ArrayView;
 

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -53,7 +53,6 @@ using osp::universe::Satellite;
 
 const std::string SysPlanetA::smc_name = "PlanetA";
 
-
 StatusActivated SysPlanetA::activate_sat(
         osp::active::ActiveScene &scene,
         osp::active::SysAreaAssociate &area,
@@ -276,7 +275,7 @@ void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt)
 
     // Set this somewhere else. Radius at which detail falloff will start
     // This will essentially be the physics area size
-    float viewerRadius = 128.0f;
+    float viewerRadius = 64.0f;
 
     // camera position relative to planet
     Vector3 camRelative = camTf.m_transform.translation()
@@ -290,7 +289,8 @@ void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt)
     static const float sc_icoEdgeRatio = sqrt(10.0f + 2.0f * sqrt(5.0f)) / 4.0f;
 
     // edge length of largest possible triangle
-    float edgeLengthA = planetUComp.m_radius / sc_icoEdgeRatio / rPlanetGeo.get_chunk_vertex_width();
+    float edgeLengthA = planetUComp.m_radius / sc_icoEdgeRatio
+                        / rPlanetGeo.get_chunk_vertex_width();
 
     rPlanetGeo.chunk_geometry_update_all(
             [edgeLengthA, planetUComp, camRelative, viewerRadius] (

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -285,6 +285,8 @@ void SysPlanetA::update_geometry()
                 }*/
             });
 
+            planet.m_planet.debug_raise_by_share_count();
+
             using Corrade::Containers::ArrayView;
 
             std::vector<unsigned> const &indxData = planet.m_planet.get_index_buffer();

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -221,7 +221,7 @@ void SysPlanetA::update_geometry()
             std::cout << "Planet initialized, now making colliders\n";
 
             // temporary: make colliders for all the chunks
-            for (chindex_t i = 0; i < rPlanetGeo.chunk_count(); i ++)
+            for (chindex_t i = 0; i < rPlanetGeo.get_chunk_count(); i ++)
             {
                 debug_create_chunk_collider(ent, planet, i);
                 std::cout << "* completed chunk collider: " << i << "\n";

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -83,6 +83,9 @@ public:
                                      ACompPlanet &planet,
                                      chindex_t chunk);
 
+    void planet_update_geometry(osp::active::ActiveEnt ent,
+                                ACompPlanet &planet);
+
     void update_geometry();
 
     void update_physics();

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -83,8 +83,7 @@ public:
                                      ACompPlanet &planet,
                                      chindex_t chunk);
 
-    void planet_update_geometry(osp::active::ActiveEnt ent,
-                                ACompPlanet &planet);
+    void planet_update_geometry(osp::active::ActiveEnt planetEnt);
 
     void update_geometry();
 

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -42,7 +42,8 @@ namespace planeta::active
 
 struct ACompPlanet
 {
-    PlanetGeometryA m_planet;
+    std::shared_ptr<IcoSphereTree> m_icoTree;
+    std::shared_ptr<PlanetGeometryA> m_planet;
     Magnum::GL::Mesh m_mesh{};
     Magnum::Shaders::MeshVisualizer3D m_shader{
             Magnum::Shaders::MeshVisualizer3D::Flag::Wireframe

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -31,6 +31,8 @@
 #include <osp/Active/SysForceFields.h>
 #include <osp/Active/activetypes.h>
 
+#include <osp/UserInputHandler.h>
+
 #include <Magnum/Shaders/MeshVisualizer.h>
 #include <Magnum/GL/Mesh.h>
 
@@ -58,7 +60,8 @@ public:
 
     static const std::string smc_name;
 
-    SysPlanetA(osp::active::ActiveScene &scene);
+    SysPlanetA(osp::active::ActiveScene &scene,
+               osp::UserInputHandler &userInput);
     ~SysPlanetA() = default;
 
     osp::active::StatusActivated activate_sat(
@@ -91,6 +94,8 @@ private:
     osp::active::UpdateOrderHandle m_updatePhysics;
 
     osp::active::RenderOrderHandle m_renderPlanetDraw;
+
+    osp::ButtonControlHandle m_debugUpdate;
 };
 
 }

--- a/src/planet-a/IcoSphereTree.cpp
+++ b/src/planet-a/IcoSphereTree.cpp
@@ -261,6 +261,7 @@ trindex_t IcoSphereTree::ancestor_at_depth(trindex_t start, uint8_t targetDepth)
 
 int IcoSphereTree::subdivide_add(trindex_t t)
 {
+    //std::cout << "m_icoTree->subdivide_add(" << t << ");\n";
     if (m_vrtxCount + 3 >= m_maxVertice)
     {
         // error! max vertex count exceeded

--- a/src/planet-a/IcoSphereTree.h
+++ b/src/planet-a/IcoSphereTree.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include <osp/types.h>
+
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -101,12 +103,9 @@ public:
         return m_triangles[t];
     }
 
-    trindex_t triangle_count()
-    {
-        return m_triangles.size();
-    }
+    trindex_t triangle_count() { return m_triangles.size(); }
 
-    std::vector<float> const& get_vertex_buffer()
+    constexpr std::vector<float> const& get_vertex_buffer()
     {
         return m_vrtxBuffer;
     }
@@ -219,6 +218,8 @@ struct SubTriangle
 
     trindex_t m_neighbours[3];
     buindex_t m_corners[3]; // to vertex buffer, 3 corners of triangle
+
+    osp::Vector3 m_center;
 
     //bool subdivided;
     uint8_t m_bitmask;

--- a/src/planet-a/IcoSphereTree.h
+++ b/src/planet-a/IcoSphereTree.h
@@ -171,12 +171,12 @@ public:
     /**
      * Get triangle from vector of triangles
      * be careful of reallocation!
-     * @param t [in] Index to triangle
+     * @param triInd [in] Index to triangle
      * @return Pointer to triangle
      */
-    SubTriangle& get_triangle(trindex_t t)
+    SubTriangle& get_triangle(trindex_t triInd)
     {
-        return m_triangles[t];
+        return m_triangles[triInd];
     }
 
     constexpr std::vector<float> const& get_vertex_buffer()
@@ -209,7 +209,7 @@ public:
      * Calculates and sets m_center of a SubTriangle
      * @param tri [ref] Reference to triangle
      */
-    void calculate_center(SubTriangle& tri);
+    void calculate_center(SubTriangle& rTri);
 
     /**
      * A quick way to set neighbours of a triangle
@@ -218,7 +218,7 @@ public:
      * @param rte [in] Right
      * @param lft [in] Left
      */
-    static void set_neighbours(SubTriangle& tri, trindex_t bot,
+    static void set_neighbours(SubTriangle& rTri, trindex_t bot,
                                trindex_t rte, trindex_t lft);
 
     /**
@@ -228,7 +228,7 @@ public:
      * @param rte [in] Right
      * @param lft [in] Left
      */
-    static void set_neighbour_sides(SubTriangle& tri, trindex_t bot,
+    static void set_neighbour_sides(SubTriangle& rTri, trindex_t bot,
                                     trindex_t rte, trindex_t lft);
 
     /**
@@ -238,7 +238,7 @@ public:
      * @param lft Left
      * @param rte Right
      */
-    static void set_verts(SubTriangle& tri, buindex_t top,
+    static void set_verts(SubTriangle& rTri, buindex_t top,
                           buindex_t lft, buindex_t rte);
 
     /**
@@ -247,7 +247,7 @@ public:
      * @param side [in] Which side to set
      * @param to [in] Neighbour to operate on
      */
-    void set_side_recurse(SubTriangle& tri, int side, trindex_t to);
+    void set_side_recurse(SubTriangle& rTri, int side, trindex_t to);
 
     /**
      * Find which side a triangle is on another triangle
@@ -265,7 +265,7 @@ public:
      * @param [in] Triangle to subdivide
      * @return 0 if subdivision is succesful
      */
-    int subdivide_add(trindex_t t);
+    int subdivide_add(trindex_t triInd);
 
     /**
      * Unsubdivide a triangle.
@@ -273,7 +273,7 @@ public:
      * @param t [in] Index of triangle to unsubdivide
      * @return 0 if removal is succesful
      */
-    int subdivide_remove(trindex_t t);
+    int subdivide_remove(trindex_t triInd);
 
     /**
      * Calls subdivide_remove on all triangles that have a 0 m_useCount
@@ -313,7 +313,7 @@ public:
      * @return A TriangleSideTransform that can be used to transform positions
      */
     TriangleSideTransform transform_to_ancestor(
-            trindex_t t, uint8_t side, uint8_t targetDepth,
+            trindex_t triInd, uint8_t side, uint8_t targetDepth,
             trindex_t *pAncestorOut = nullptr);
 
     /**

--- a/src/planet-a/PlanetGeometryA.cpp
+++ b/src/planet-a/PlanetGeometryA.cpp
@@ -24,9 +24,6 @@
  */
 #include "PlanetGeometryA.h"
 
-#include <Magnum/Math/Functions.h>
-#include <osp/types.h>
-
 #include <algorithm>
 #include <iostream>
 #include <stack>
@@ -291,14 +288,14 @@ void PlanetGeometryA::chunk_add(trindex_t t)
     {
         trindex_t neighbourIndex = rTri.m_neighbours[side];
 
-        trindex_t &rNeighbourChunked = rChunk.m_neighourChunked[side];
+        trindex_t &rNeighbourChunked = rChunk.m_neighbourChunked[side];
         rNeighbourChunked = gc_invalidTri;
 
         // Neighbour that may be chunked, contains a chunk, or is part of a
         // chunk
         SubTriangle const &neighTri = m_icoTree->get_triangle(neighbourIndex);
         SubTriangleChunk const &neighChunk = m_triangleChunks[neighbourIndex];
-        TriangleSideTransform &neighTransform = rChunk.m_neighourTransform[side];
+        TriangleSideTransform &neighTransform = rChunk.m_neighbourTransform[side];
 
         neighTransform.m_scale = 1.0f;
         neighTransform.m_translation = 0.0f;
@@ -342,17 +339,17 @@ void PlanetGeometryA::chunk_add(trindex_t t)
             if (rTri.m_depth == rNeighBTri.m_depth)
             {
 
-                rNeighBChunk.m_neighourChunked[neighbourSide] = t;
-                rNeighBChunk.m_neighourTransform[side]
+                rNeighBChunk.m_neighbourChunked[neighbourSide] = t;
+                rNeighBChunk.m_neighbourTransform[side]
                         = TriangleSideTransform{0.0f, 1.0f};
             }
             else if (rTri.m_depth > rNeighBTri.m_depth)
             {
-                rNeighBChunk.m_neighourTransform[side]
+                rNeighBChunk.m_neighbourTransform[side]
                         = TriangleSideTransform{0.0f, 1.0f};
-                if (rNeighBChunk.m_neighourChunked[neighbourSide] == gc_invalidVrtx)
+                if (rNeighBChunk.m_neighbourChunked[neighbourSide] == gc_invalidVrtx)
                 {
-                    rNeighBChunk.m_neighourChunked[neighbourSide]
+                    rNeighBChunk.m_neighbourChunked[neighbourSide]
                             = rNeighBTri.m_neighbours[neighbourSide];
                 }
 
@@ -701,7 +698,7 @@ void PlanetGeometryA::chunk_add(trindex_t t)
 
     for (uint8_t side = 0; side < 3; side ++)
     {
-        trindex_t neighInd = rChunk.m_neighourChunked[side];
+        trindex_t neighInd = rChunk.m_neighbourChunked[side];
 
         if (neighInd == gc_invalidTri)
         {
@@ -796,16 +793,16 @@ void PlanetGeometryA::chunk_set_neighbour_recurse(
 
     if (rChunk.m_chunk != gc_invalidChunk)
     {
-        rChunk.m_neighourChunked[side] = to;
+        rChunk.m_neighbourChunked[side] = to;
 
         if (to != gc_invalidTri)
         {
-            rChunk.m_neighourTransform[side] = m_icoTree->transform_to_ancestor(
+            rChunk.m_neighbourTransform[side] = m_icoTree->transform_to_ancestor(
                         t, side, m_icoTree->get_triangle(to).m_depth);
         }
         else
         {
-            rChunk.m_neighourTransform[side] = TriangleSideTransform{0.0f, 1.0f};
+            rChunk.m_neighbourTransform[side] = TriangleSideTransform{0.0f, 1.0f};
         }
         return;
     }
@@ -881,7 +878,7 @@ void PlanetGeometryA::chunk_remove(trindex_t t)
     for (uint8_t i = 0; i < 3; i ++)
     {
         // Remove from neighbours
-        trindex_t &rNeighInd = rChunk.m_neighourChunked[i];
+        trindex_t &rNeighInd = rChunk.m_neighbourChunked[i];
 
         if (rNeighInd == gc_invalidTri)
         {
@@ -1067,7 +1064,7 @@ vrindex_t PlanetGeometryA::shared_from_neighbour(
     SubTriangle& tri = m_icoTree->get_triangle(triInd);
     SubTriangleChunk& chunk = m_triangleChunks[triInd];
 
-    trindex_t neighInd = chunk.m_neighourChunked[side];
+    trindex_t neighInd = chunk.m_neighbourChunked[side];
 
     if (neighInd == gc_invalidTri)
     {
@@ -1085,7 +1082,7 @@ vrindex_t PlanetGeometryA::shared_from_neighbour(
 
         if (neighChunk.m_chunk != gc_invalidChunk)
         {
-            takeInd = chunk.m_neighourChunked[side];
+            takeInd = chunk.m_neighbourChunked[side];
         }
         else // if neigh is same depth and contains chunked descendents.
         {
@@ -1138,8 +1135,8 @@ vrindex_t PlanetGeometryA::shared_from_neighbour(
         }
     }
 
-    TriangleSideTransform tranFrom = chunk.m_neighourTransform[side];
-    TriangleSideTransform tranTo = takeChunk.m_neighourTransform[takeSide];
+    TriangleSideTransform tranFrom = chunk.m_neighbourTransform[side];
+    TriangleSideTransform tranTo = takeChunk.m_neighbourTransform[takeSide];
 
     // apply transform from
     posTransformed = posTransformed * tranFrom.m_scale + tranFrom.m_translation;

--- a/src/planet-a/PlanetGeometryA.h
+++ b/src/planet-a/PlanetGeometryA.h
@@ -72,6 +72,7 @@ struct UpdateRangeSub;
 
 struct SubTriangleChunk
 {
+
     // Index to chunk. (First triangle ever chunked will be 0)
     // set to m_chunkMax when not chunked
     chindex_t m_chunk;
@@ -127,14 +128,12 @@ public:
 
     /**
      * Configure and Initialize buffers.
-     * @param radius    [in] Radius of planet
      * @param chunkDiv  [in] Number of subdivisions per chunk
      * @param maxChunks [in] Chunk buffer size
      * @param maxShared [in] Area in buffer reserved for shared vertices between
      *                       chunks
      */
-    void initialize(std::shared_ptr<IcoSphereTree> sphere,
-                    float radius, unsigned chunkDiv,
+    void initialize(std::shared_ptr<IcoSphereTree> sphere, unsigned chunkDiv,
                     chindex_t maxChunks, vrindex_t maxShared);
 
     /**
@@ -213,9 +212,13 @@ private:
     void chunk_add(trindex_t t);
 
     /**
-     * @param t
-     * @param side
-     * @param depth
+     * Align the vertices along the edge of a chunk with the edges of another
+     * chunk of lower level of detail.
+     *
+     * @param t     [in] Index of triangle containing chunk
+     * @param side  [in] 0, 1, or 2 for bottom, left, right
+     * @param depth [in] Depth of neighbouring chunk. This should be lower than
+     *                   t's depth
      */
     void chunk_edge_transition(trindex_t t, uint8_t side, uint8_t depth);
 

--- a/src/planet-a/PlanetGeometryA.h
+++ b/src/planet-a/PlanetGeometryA.h
@@ -28,7 +28,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <queue>
 #include <set>
 #include <vector>
 
@@ -90,11 +89,11 @@ struct SubTriangleChunk
     buindex_t m_dataVrtx; // Index to vertex data
 
     // Neighbours that are chunked. used for vertex sharing
-    trindex_t m_neighourChunked[3];
+    trindex_t m_neighbourChunked[3];
 
     // Used to convert positions along the edge of this triangle, to a position
     // along a neighbour's edge
-    TriangleSideTransform m_neighourTransform[3];
+    TriangleSideTransform m_neighbourTransform[3];
 };
 
 
@@ -186,6 +185,8 @@ public:
     constexpr chindex_t chunk_count() { return m_chunkCount; }
 
     IcoSphereTree* get_ico_tree() { return m_icoTree.get(); }
+
+    constexpr unsigned get_chunk_vertex_width() { return m_chunkWidth; }
 
     unsigned debug_chunk_count_descendents(SubTriangle const& tri);
 

--- a/src/planet-a/PlanetGeometryA.h
+++ b/src/planet-a/PlanetGeometryA.h
@@ -50,6 +50,8 @@ constexpr loindex_t gc_invalidLocal = std::numeric_limits<loindex_t>::max();
 constexpr trindex_t gc_invalidTri = std::numeric_limits<trindex_t>::max();
 constexpr vrindex_t gc_invalidVrtx = std::numeric_limits<vrindex_t>::max();
 
+enum class EChunkUpdateAction { Nothing, Subdivide, Unsubdivide,
+                                Chunk, Unchunk };
 
 struct UpdateRange;
 
@@ -122,6 +124,12 @@ public:
      * Print out information on vertice count, chunk count, etc...
      */
     void log_stats() const;
+
+    /**
+     * @tparam FUNC_T
+     */
+    template<typename FUNC_T>
+    void chunk_geometry_update(FUNC_T condition);
 
     std::pair<IteratorTriIndexed, IteratorTriIndexed> iterate_chunk(chindex_t c);
 
@@ -223,7 +231,6 @@ private:
     int m_vrtxCompOffsetNrm = 3;
 
 
-
     // Main buffer stuff
 
     std::vector<unsigned> m_indxBuffer;
@@ -247,7 +254,11 @@ private:
 
     std::vector<trindex_t> m_chunkToTri; // Maps chunks to triangles
 
-    std::vector<buindex_t> m_vrtxFree; // Deleted chunk data to overwrite
+    // Deleted chunks to overwrite
+    // Make sure this is empty before rendering
+    std::vector<chindex_t> m_chunkFree;
+
+    std::vector<buindex_t> m_vrtxFree; // Deleted chunk vertex data to overwrite
 
     unsigned m_vrtxSharedPerChunk; // How many shared verticies per chunk
     unsigned m_vrtxPerChunk; // How many vertices there are in each chunk
@@ -360,5 +371,23 @@ struct UpdateRange
     buindex_t m_start;
     buindex_t m_end;
 };
+
+template<typename FUNC_T>
+void PlanetGeometryA::chunk_geometry_update(FUNC_T condition)
+{
+    // loop through triangles
+
+    // pass entity through lambda
+
+    for (trindex_t i = 0; i < m_icoTree->triangle_count(); i ++)
+    {
+        SubTriangle const& tri = m_icoTree->get_triangle(i);
+        SubTriangleChunk const& chunk = m_triangleChunks[i];
+
+        // use condition to determine what should be done to this triangle
+        EChunkUpdateAction action = condition(tri, chunk, i);
+    }
+}
+
 
 }

--- a/src/planet-a/PlanetGeometryA.h
+++ b/src/planet-a/PlanetGeometryA.h
@@ -119,7 +119,7 @@ public:
 
     constexpr bool is_initialized() const { return m_initialized; }
 
-    constexpr bool tri_is_chunked(SubTriangleChunk &chunk) const
+    constexpr bool tri_is_chunked(SubTriangleChunk const& chunk) const
     {
         return chunk.m_chunk != gc_invalidChunk;
     };
@@ -187,7 +187,7 @@ public:
 
     IcoSphereTree* get_ico_tree() { return m_icoTree.get(); }
 
-    unsigned debug_chunk_count_descendents(SubTriangle &tri);
+    unsigned debug_chunk_count_descendents(SubTriangle const& tri);
 
     /**
      * Checks all triangles for invalid states in order to squash some bugs

--- a/src/planet-a/PlanetGeometryA.h
+++ b/src/planet-a/PlanetGeometryA.h
@@ -45,8 +45,13 @@ constexpr chindex_t gc_invalidChunk = std::numeric_limits<chindex_t>::max();
 constexpr loindex_t gc_invalidLocal = std::numeric_limits<loindex_t>::max();
 
 
-enum class EChunkUpdateAction { Nothing, Subdivide, Unsubdivide,
-                                Chunk, Unchunk };
+enum class EChunkUpdateAction : uint8_t
+{
+    Nothing     = 0,
+    Subdivide   = 1,
+    Chunk       = 2,
+    Unchunk     = 3
+};
 
 struct UpdateRangeSub;
 
@@ -225,7 +230,7 @@ private:
      * @param side   [in] Side to realign 0, 1, or 2 for bottom, left, right
      * @param depth  [in] Depth of neighbouring triangle to align to
      */
-    void chunk_edge_transition(trindex_t triInd, uint8_t side, uint8_t depth);
+    void chunk_edge_transition(trindex_t triInd, triside_t side, uint8_t depth);
 
     /**
      * Calls chunk_edge_transition on all children along a side
@@ -233,7 +238,7 @@ private:
      * @param side   [in] Side to realign 0, 1, or 2 for bottom, left, right
      * @param depth  [in] Depth of neighbouring triangle to align to
      */
-    void chunk_edge_transition_recurse(trindex_t triInd, uint8_t side, uint8_t depth);
+    void chunk_edge_transition_recurse(trindex_t triInd, triside_t side, uint8_t depth);
 
     /**
      * Set m_neighbourChunked of a triangle and all of it's children along a
@@ -243,7 +248,7 @@ private:
      * @param side   [in] Side for recursing children
      * @param to     [in] Index to set m_neighbourChunked to
      */
-    void chunk_set_neighbour_recurse(trindex_t triInd, uint8_t side, trindex_t to);
+    void chunk_set_neighbour_recurse(trindex_t triInd, triside_t side, trindex_t to);
 
     /**
      * Resize m_triangleChunks to assure that it's parallel with m_icoTree's
@@ -333,7 +338,7 @@ private:
      * @return Index to found vertex
      */
     vrindex_t shared_from_tri(SubTriangleChunk const& chunk,
-                              uint8_t side, loindex_t pos);
+                              triside_t side, loindex_t pos);
 
     /**
      * Attempt to grab a shared vertex from a triangle's neighbour
@@ -343,7 +348,7 @@ private:
      *                    that overlaps with one of the neighbour's vertices
      * @return Index to found vertex. gc_invalidVrtx if not found.
      */
-    vrindex_t shared_from_neighbour(trindex_t triInd, uint8_t side,
+    vrindex_t shared_from_neighbour(trindex_t triInd, triside_t side,
                                     loindex_t posIn);
 
     /**
@@ -600,18 +605,6 @@ void PlanetGeometryA::chunk_geometry_update_recurse(FUNC_T condition,
 
             chunk_triangle_assure();
         }
-        break;
-    case EChunkUpdateAction::Unsubdivide:
-        /*if (subdivided)
-        {
-            if (m_icoTree->subdivide_remove(t) == 0)
-            {
-                subdivided = false;
-                m_icoTree->debug_verify_state();
-                m_triangleChunks[t].m_descendentChunked = 0;
-                m_triangleChunks[t].m_ancestorChunked = gc_invalidChunk;
-            }
-        }*/
         break;
     }
 

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -38,11 +38,18 @@ struct UCompPlanet
     double m_radius;
 
     // Approximate max length of a triangle edge on the surface. Lower number
-    // means higher resolution
+    // means higher detail.
     float m_resolutionSurfaceMax;
 
-    // Approximate max length of a triangle edge on the surface. Lower number
-    // means higher resolution
+    // Approximate max length of a triangle edge on the screen. The length is
+    // measured on a screen 1 meter away from the viewer. Lower number means
+    // higher detail.
+    //
+    // screenEdgeLength = physicalLength / distance
+    //
+    // If you stand 1m away from a meter stick perpendicular of you, then it
+    // will appear 1m wide on your screen. If you walk backwards 1m, then the
+    // meter stick will shrink to 0.5m, because it's further away.
     float m_resolutionScreenMax;
 
     // TODO: Use this until a UCompMass is added

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -36,6 +36,17 @@ namespace planeta::universe
 struct UCompPlanet
 {
     double m_radius;
+
+    // Approximate max length of a triangle edge on the surface. Lower number
+    // means higher resolution
+    float m_resolutionSurfaceMax;
+
+    // Approximate max length of a triangle edge on the surface. Lower number
+    // means higher resolution
+    float m_resolutionScreenMax;
+
+    // TODO: Use this until a UCompMass is added
+    float m_mass;
 };
 
 

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -214,4 +214,8 @@ void testapp::config_controls(OSPMagnum& rOspApp)
 
     rUserInput.config_register_control("ui_rmb", true,
             {{osp::sc_mouse, (int) Mouse_t::Right, VarTrig_t::PRESSED, false, VarOp_t::AND}});
+
+    rUserInput.config_register_control("debug_planet_update", false,
+            {{0, (int) Key_t::LeftCtrl, VarTrig_t::HOLD, false, VarOp_t::AND},
+             {0, (int) Key_t::One, VarTrig_t::PRESSED, false, VarOp_t::OR}});
 }

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -130,8 +130,8 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     cameraComp.m_viewport
             = Vector2(Magnum::GL::defaultFramebuffer.viewport().size());
-    cameraComp.m_far = 4096.0f;
-    cameraComp.m_near = 0.125f;
+    cameraComp.m_far = 1u << 24;
+    cameraComp.m_near = 1.0f;
     cameraComp.m_fov = 45.0_degf;
 
     cameraComp.calculate_projection();

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -97,7 +97,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     auto &sysDebugRender    = scene.dynamic_system_create<osp::active::SysDebugRender>();
     auto &sysArea           = scene.dynamic_system_create<osp::active::SysAreaAssociate>(uni);
     auto &sysVehicle        = scene.dynamic_system_create<osp::active::SysVehicle>();
-    auto &sysPlanet         = scene.dynamic_system_create<planeta::active::SysPlanetA>();
+    auto &sysPlanet         = scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
     auto &sysGravity        = scene.dynamic_system_create<osp::active::SysFFGravity>();
 
     // Register machines for that scene

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -27,6 +27,7 @@
 #include "flight.h"
 
 #include "universes/simple.h"
+#include "universes/planets.h"
 
 #include <osp/Resource/AssetImporter.h>
 
@@ -124,6 +125,13 @@ int debug_cli_loop()
             if (destroy_universe())
             {
                 create_simple_solar_system(g_osp);
+            }
+        }
+        else if (command == "moon")
+        {
+            if (destroy_universe())
+            {
+                create_real_moon(g_osp);
             }
         }
         else if (command == "flight")
@@ -226,6 +234,7 @@ void debug_print_help()
         << "OSP-Magnum Temporary Debug CLI\n"
         << "Choose a test universe:\n"
         << "* simple    - Simple test planet and vehicles (default)\n"
+        << "* moon      - Simulate size and gravity of real world moon\n"
         << "\n"
         << "Start Application:\n"
         << "* flight    - Create an ActiveArea and start Magnum\n"

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -22,3 +22,97 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include "planets.h"
+#include "vehicles.h"
+
+#include <osp/Satellites/SatActiveArea.h>
+#include <osp/Satellites/SatVehicle.h>
+
+#include <osp/Trajectories/Stationary.h>
+
+#include <planet-a/Satellites/SatPlanet.h>
+
+using namespace testapp;
+
+using osp::Package;
+
+using osp::universe::Satellite;
+using osp::universe::Universe;
+
+using osp::universe::SatActiveArea;
+using osp::universe::SatVehicle;
+
+using osp::universe::TrajStationary;
+
+using osp::universe::UCompTransformTraj;
+
+using planeta::universe::SatPlanet;
+using planeta::universe::UCompPlanet;
+
+
+void testapp::create_real_moon(osp::OSPApplication& ospApp)
+{
+    Universe &uni = ospApp.get_universe();
+    Package &pkg = ospApp.debug_get_packges()[0];
+
+    // Get the planet system used to create a UCompPlanet
+    SatPlanet &typePlanet = static_cast<planeta::universe::SatPlanet&>(
+            *uni.sat_type_find("Planet")->second);
+
+    // Create trajectory that will make things added to the universe stationary
+    auto &stationary = uni.trajectory_create<TrajStationary>(
+                                        uni, uni.sat_root());
+
+    // Create 10 random vehicles
+    for (int i = 0; i < 10; i ++)
+    {
+        // Creates a random mess of spamcans as a vehicle
+        Satellite sat = debug_add_random_vehicle(uni, pkg, "TestyMcTestFace Mk"
+                                                 + std::to_string(i));
+
+        auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+
+        posTraj.m_position = osp::Vector3s(i * 1024l * 5l, 0l, 0l);
+        posTraj.m_dirty = true;
+
+        stationary.add(sat);
+    }
+
+    Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
+    auto& posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+    posTraj.m_position = osp::Vector3s(22 * 1024l * 5l, 0l, 0l);
+    posTraj.m_dirty = true;
+    stationary.add(sat);
+
+
+    // Add Grid of planets too
+
+    for (int x = -0; x < 1; x ++)
+    {
+        for (int z = -0; z < 1; z ++)
+        {
+            Satellite sat = uni.sat_create();
+
+            // assign sat as a planet
+            UCompPlanet &planet = typePlanet.add_get_ucomp(sat);
+
+            // Create the real world moon
+            planet.m_radius = 1.737E+6;
+            planet.m_mass = 7.347673E+22;
+
+            planet.m_resolutionScreenMax = 0.056f;
+            planet.m_resolutionSurfaceMax = 12.0f;
+
+            auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+
+            // space planets 400m apart from each other
+            // 1024 units = 1 meter
+            posTraj.m_position = {x * 1024l * 400l,
+                                  -1024l * osp::SpaceInt(1.74E+6),
+                                  z * 1024l * 400l};
+        }
+    }
+
+    std::cout << "Created Large Planet umm... moon!\n";
+}

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -53,25 +53,25 @@ using planeta::universe::UCompPlanet;
 
 void testapp::create_real_moon(osp::OSPApplication& ospApp)
 {
-    Universe &uni = ospApp.get_universe();
-    Package &pkg = ospApp.debug_get_packges()[0];
+    Universe &rUni = ospApp.get_universe();
+    Package &rPkg = ospApp.debug_find_package("lzdb");
 
     // Get the planet system used to create a UCompPlanet
     SatPlanet &typePlanet = static_cast<planeta::universe::SatPlanet&>(
-            *uni.sat_type_find("Planet")->second);
+            *rUni.sat_type_find("Planet")->second);
 
     // Create trajectory that will make things added to the universe stationary
-    auto &stationary = uni.trajectory_create<TrajStationary>(
-                                        uni, uni.sat_root());
+    auto &stationary = rUni.trajectory_create<TrajStationary>(
+                                        rUni, rUni.sat_root());
 
     // Create 10 random vehicles
     for (int i = 0; i < 10; i ++)
     {
         // Creates a random mess of spamcans as a vehicle
-        Satellite sat = debug_add_random_vehicle(uni, pkg, "TestyMcTestFace Mk"
+        Satellite sat = debug_add_random_vehicle(rUni, rPkg, "TestyMcTestFace Mk"
                                                  + std::to_string(i));
 
-        auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+        auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 
         posTraj.m_position = osp::Vector3s(i * 1024l * 5l, 0l, 0l);
         posTraj.m_dirty = true;
@@ -79,8 +79,8 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
         stationary.add(sat);
     }
 
-    Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
-    auto& posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+    Satellite sat = debug_add_deterministic_vehicle(rUni, rPkg, "Stomper Mk. I");
+    auto& posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_position = osp::Vector3s(22 * 1024l * 5l, 0l, 0l);
     posTraj.m_dirty = true;
     stationary.add(sat);
@@ -92,7 +92,7 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
     {
         for (int z = -0; z < 1; z ++)
         {
-            Satellite sat = uni.sat_create();
+            Satellite sat = rUni.sat_create();
 
             // assign sat as a planet
             UCompPlanet &planet = typePlanet.add_get_ucomp(sat);
@@ -104,7 +104,7 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
             planet.m_resolutionScreenMax = 0.056f;
             planet.m_resolutionSurfaceMax = 12.0f;
 
-            auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+            auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 
             // space planets 400m apart from each other
             // 1024 units = 1 meter

--- a/src/test_application/universes/planets.h
+++ b/src/test_application/universes/planets.h
@@ -25,4 +25,11 @@
 
 #pragma once
 
-// TODO: put test with planets here
+#include <osp/OSPApplication.h>
+
+namespace testapp
+{
+
+void create_real_moon(osp::OSPApplication& ospApp);
+
+}

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -97,15 +97,19 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
             // assign sat as a planet
             UCompPlanet &planet = typePlanet.add_get_ucomp(sat);
 
-            // set radius
-            planet.m_radius = 128;
+            // Configure planet as a 256m radius sphere of black hole
+            planet.m_radius = 256;
+            planet.m_mass = 7.03E7 * 99999999; // volume of sphere * density
+
+            planet.m_resolutionScreenMax = 0.056f;
+            planet.m_resolutionSurfaceMax = 2.0f;
 
             auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
 
             // space planets 400m apart from each other
             // 1024 units = 1 meter
             posTraj.m_position = {x * 1024l * 400l,
-                                  1024l * -140l,
+                                  1024l * -300l,
                                   z * 1024l * 400l};
         }
     }

--- a/src/test_application/universes/simple.h
+++ b/src/test_application/universes/simple.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <osp/Universe.h>
 #include <osp/OSPApplication.h>
 
 namespace testapp


### PR DESCRIPTION
This big PR makes many improvements and additions to Planet-A, as well as few minor changes with other related files.

First off, a quick rundown on what the planet classes do:
* **IcoSphereTree**: A subdividable icosahedron where each triangle face can be subdivided into 4 children. This also keeps track of which triangles are neighbouring each other. Nothing rendering-related happens here.
* **PlanetGeometryA**: Creates 'chunks' to patch overtop of an IcoSphereTree intended to render later. These chunks consist of many smaller triangles, and are stored in a vertex and index buffer. Nothing rendering-related happens here either.
* **SysPlanetA**: Manages the active planets in the scene. It is responsible for dealing with entities assigned with planet data (ACompPlanet). ACompPlanets contain PlanetGeometryAs, and it's up to SysPlanetA to interface its buffers to the GPU for rendering, as well as deal with physics and colliders.

PlanetGeometryA is ridiculously complex, and may need to be explained better in some document or presentation.  God bless whoever attempts to fully understand it at this point.

Notable additions from this PR:
* Vertex sharing between chunks
* Configurable Planet Level-of-Detail falloff based on distance. This is implemented as a lambda function in SysPlanet. This function is used by PlanetGeometryA to determine if triangles should be chunked, subdivided, etc... Configuration is in UCompPlanet.
* Large Seamless surfaces. On a boundary between two chunks of varying detail, the chunk with higher detail are flattened against the lower detail one. Enable the stupid heightmap in PlanetGeometryA line 215 and enter the moon test in flight scene to see this more clearly.
* Gravity attraction force calculated from specified mass of planet
* Test universe with real-world moon simulation. This creates a 'planet' with a radius of 1.74E+6m, and a mass of 7.35E+22kg.
* Improved readability in all planet code

Not done, but possible:
* Generating planet colliders realtime
* Normal calculations for chunks
* Proper way to handle height maps
* Maybe cut up PlanetGeometryA and IcoSphereTree even further into something less OOPy. The state of these two classes are rather difficult to track, which can be improved
