### PR TITLE
Improve GL Context-dependent resource management

### DIFF
--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -38,8 +38,9 @@ void ACompCamera::calculate_projection()
 }
 
 
-ActiveScene::ActiveScene(UserInputHandler &userInput, OSPApplication &app) :
+ActiveScene::ActiveScene(UserInputHandler &userInput, OSPApplication &app, Package& context) :
         m_app(app),
+        m_context(context),
         m_hierarchyDirty(false),
         m_userInput(userInput)
 {

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -59,7 +59,7 @@ class ActiveScene
 {
 
 public:
-    ActiveScene(UserInputHandler &userInput, OSPApplication& app);
+    ActiveScene(UserInputHandler &userInput, OSPApplication& app, Package& context);
     ~ActiveScene();
 
     OSPApplication& get_application() { return m_app; };
@@ -209,12 +209,14 @@ public:
 
     bool dynamic_system_it_valid(MapDynamicSys_t::iterator it);
 
+    Package& get_context_resources() { return m_context; }
 private:
 
     void on_hierarchy_construct(entt::registry& reg, ActiveEnt ent);
     void on_hierarchy_destruct(entt::registry& reg, ActiveEnt ent);
 
     OSPApplication& m_app;
+    Package& m_context;
 
     //std::vector<std::vector<ActiveEnt> > m_hierLevels;
     entt::basic_registry<ActiveEnt> m_registry;

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -285,7 +285,8 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                 std::get<DrawableData>(currentPrototype.m_objectData);
 
             //Mesh* mesh = nullptr;
-            DependRes<Mesh> meshRes = package.get<Mesh>(
+            Package& glResources = m_scene.get_context_resources();
+            DependRes<Mesh> meshRes = glResources.get<Mesh>(
                                             part.get_strings()[drawable.m_mesh]);
 
             if (meshRes.empty())
@@ -293,7 +294,7 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                 // Mesh isn't compiled yet, now check if mesh data exists
                 std::string const& meshName = part.get_strings()[drawable.m_mesh];
                 DependRes<MeshData> meshData = package.get<MeshData>(meshName);
-                meshRes = AssetImporter::compile_mesh(meshData, package);
+                meshRes = AssetImporter::compile_mesh(meshData, glResources);
             }
 
             std::vector<Texture2D*> textureResources;
@@ -301,12 +302,12 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
             {
                 unsigned texID = drawable.m_textures[i];
                 std::string const& texName = part.get_strings()[texID];
-                DependRes<Texture2D> texRes = package.get<Texture2D>(texName);
+                DependRes<Texture2D> texRes = glResources.get<Texture2D>(texName);
 
                 if (texRes.empty())
                 {
                     DependRes<ImageData2D> imageData = package.get<ImageData2D>(texName);
-                    texRes = AssetImporter::compile_tex(imageData, package);
+                    texRes = AssetImporter::compile_tex(imageData, glResources);
                 }
                 textureResources.push_back(&(*texRes));
             }

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -139,13 +139,15 @@ void OSPMagnum::mouseScrollEvent(MouseScrollEvent & event)
 
 osp::active::ActiveScene& OSPMagnum::scene_create(std::string const& name)
 {
-    auto const& [it, success] = m_scenes.try_emplace(name, m_userInput, m_ospApp);
+    auto const& [it, success] =
+        m_scenes.try_emplace(name, m_userInput, m_ospApp, m_glResources);
     return it->second;
 }
 
 osp::active::ActiveScene& OSPMagnum::scene_create(std::string && name)
 {
-    auto const& [it, success] = m_scenes.try_emplace(std::move(name), m_userInput, m_ospApp);
+    auto const& [it, success] =
+        m_scenes.try_emplace(std::move(name), m_userInput, m_ospApp, m_glResources);
     return it->second;
 }
 

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -47,6 +47,12 @@ OSPMagnum::OSPMagnum(const Magnum::Platform::Application::Arguments& arguments,
 
 }
 
+OSPMagnum::~OSPMagnum()
+{
+    // Clear scene data before GL resources are freed
+    m_scenes.clear();
+}
+
 void OSPMagnum::drawEvent()
 {
 

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -56,6 +56,8 @@ public:
             const Magnum::Platform::Application::Arguments& arguments,
             osp::OSPApplication &ospApp);
 
+    ~OSPMagnum();
+
     void keyPressEvent(KeyEvent& event) override;
     void keyReleaseEvent(KeyEvent& event) override;
 

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -78,6 +78,8 @@ private:
 
     MapActiveScene_t m_scenes;
 
+    osp::Package m_glResources{"gl", "gl-resources"};
+
     Magnum::Timeline m_timeline;
 
     osp::OSPApplication& m_ospApp;

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -153,11 +153,6 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     // Disconnect ActiveArea
     sysArea.disconnect();
 
-    // workaround: wipe mesh resources because they're specific to the
-    // opengl context
-    rOspApp.debug_find_package("lzdb").clear<Magnum::GL::Mesh>();
-    rOspApp.debug_find_package("lzdb").clear<Magnum::GL::Texture2D>();
-
     // destruct the application, this closes the window
     pMagnumApp.reset();
 }

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -155,6 +155,7 @@ int debug_cli_loop()
                 // request exit if application exists
                 g_ospMagnum->exit();
             }
+            destroy_universe();
             break;
         }
         else


### PR DESCRIPTION
This is the cleanest way to handle this issue I've found so far, but let me know if you have any better ideas. A new `Package` is stored inside OSPMagnum as `OSPMagnum::m_context` and stores handles to GL context data. Scenes receive a reference to the context data, so that systems may access meshes, shaders, textures, and so on. When the OSPMagnum instance is destroyed, the GL resources are automatically freed, leaving the rest alone. The main crash that happened even before shaders or anything just required a `destroy_universe()` call in the CLI loop's exit clause.