### PR TITLE
Add data-oriented instancable shaders

### DIFF
--- a/src/adera/Shaders/Phong.h
+++ b/src/adera/Shaders/Phong.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright Â© 2019-2020 Open Space Program Project
+ * Copyright © 2019-2020 Open Space Program Project
  *
  * MIT License
  *
@@ -22,22 +22,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "OSPApplication.h"
+#pragma once
 
-using namespace osp;
+#include <vector>
+#include <Magnum/Shaders/Phong.h>
+#include <Magnum/GL/Mesh.h>
+#include <Magnum/GL/Texture.h>
+#include <Magnum/Math/Color.h>
+#include "osp/Active/activetypes.h"
+#include "osp/Active/ActiveScene.h"
+#include "osp/Resource/Resource.h"
 
-void OSPApplication::debug_add_package(Package&& p)
+namespace adera::shader
 {
-    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
-    assert(success);
-}
 
-Package& OSPApplication::debug_find_package(std::string_view prefix)
+
+class Phong : protected Magnum::Shaders::Phong
 {
-    if (auto it = m_packages.find(prefix); it != m_packages.end())
+public:
+    using Magnum::Shaders::Phong::Phong;
+
+    struct ACompPhongInstance
     {
-        return it->second;
-    }
-    throw std::out_of_range("Package not found");
-}
+        osp::DependRes<Phong> m_shaderProgram;
+        std::vector<osp::DependRes<Magnum::GL::Texture2D>> m_textures;
+        Magnum::Vector3 m_lightPosition;
+        Magnum::Color3 m_ambientColor;
+        Magnum::Color3 m_specularColor;
+    };
 
+    static void draw_entity(osp::active::ActiveEnt e,
+        osp::active::ActiveScene& rScene,
+        Magnum::GL::Mesh& rMesh,
+        osp::active::ACompCamera const& camera,
+        osp::active::ACompTransform const& transform);
+
+};
+
+
+}

--- a/src/osp/Active/Shader.h
+++ b/src/osp/Active/Shader.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright Â© 2019-2020 Open Space Program Project
+ * Copyright © 2019-2020 Open Space Program Project
  *
  * MIT License
  *
@@ -22,22 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "OSPApplication.h"
+#pragma once
 
-using namespace osp;
+#include "activetypes.h"
+#include "osp/Active/ActiveScene.h"
+#include <Magnum/GL/Mesh.h>
 
-void OSPApplication::debug_add_package(Package&& p)
+namespace osp::active
 {
-    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
-    assert(success);
+/**
+ * A function pointer to a Shader's draw() function
+ * @param ActiveEnt - The entity being drawn; used to fetch component data
+ * @param ActiveScene - The scene containing the entity's component data
+ * @param Mesh - Mesh data to be drawn with the shader
+ * @param ACompCamera - Camera used to draw the scene
+ * @param ACompTransform - Object transformation data
+ */
+using ShaderDrawFnc_t = void (*)(
+    ActiveEnt,
+    ActiveScene&,
+    Magnum::GL::Mesh&,
+    ACompCamera const&,
+    ACompTransform const&);
 }
-
-Package& OSPApplication::debug_find_package(std::string_view prefix)
-{
-    if (auto it = m_packages.find(prefix); it != m_packages.end())
-    {
-        return it->second;
-    }
-    throw std::out_of_range("Package not found");
-}
-

--- a/src/osp/Active/SysDebugRender.cpp
+++ b/src/osp/Active/SysDebugRender.cpp
@@ -27,6 +27,7 @@
 
 #include "SysDebugRender.h"
 #include "ActiveScene.h"
+#include "adera/Shaders/Phong.h"
 
 
 using namespace osp::active;
@@ -44,7 +45,9 @@ SysDebugRender::SysDebugRender(ActiveScene &rScene) :
         m_renderDebugDraw(rScene.get_render_order(), "debug", "", "",
                           std::bind(&SysDebugRender::draw, this, _1))
 {
-
+    Package& glResources = m_scene.get_context_resources();
+    glResources.add<adera::shader::Phong>("phong_shader",
+        adera::shader::Phong{Magnum::Shaders::Phong::Flag::DiffuseTexture});
 }
 
 void SysDebugRender::draw(ACompCamera const& camera)
@@ -67,16 +70,6 @@ void SysDebugRender::draw(ACompCamera const& camera)
 
         entRelative = camera.m_inverse * transform.m_transformWorld;
 
-        (*drawable.m_shader)
-                .bindDiffuseTexture(*drawable.m_textures[0])
-                .setAmbientColor(0x111111_rgbf)
-                .setSpecularColor(0x330000_rgbf)
-                .setLightPosition({10.0f, 15.0f, 5.0f})
-                .setTransformationMatrix(entRelative)
-                .setProjectionMatrix(camera.m_projection)
-                .setNormalMatrix(entRelative.normalMatrix())
-                .draw(*(drawable.m_mesh));
-
-        //std::cout << "render! \n";
+        drawable.m_shader_draw(entity, m_scene, *drawable.m_mesh, camera, transform);
     }
 }

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -26,8 +26,9 @@
 
 #include <Magnum/Math/Color.h>
 #include <Magnum/GL/Mesh.h>
-#include <Magnum/Shaders/Phong.h>
 
+#include "osp/Resource/Resource.h"
+#include "osp/Active/Shader.h"
 #include "../types.h"
 #include "activetypes.h"
 
@@ -36,9 +37,8 @@ namespace osp::active
 
 struct CompDrawableDebug
 {
-    Magnum::GL::Mesh* m_mesh;
-    std::vector<Magnum::GL::Texture2D*> m_textures;
-    Magnum::Shaders::Phong* m_shader;
+    DependRes<Magnum::GL::Mesh> m_mesh;
+    ShaderDrawFnc_t m_shader_draw;
     Magnum::Color4 m_color;
 };
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -31,6 +31,7 @@
 #include "../Satellites/SatVehicle.h"
 #include "../Resource/PrototypePart.h"
 #include "../Resource/AssetImporter.h"
+#include "adera/Shaders/Phong.h"
 
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
@@ -52,9 +53,6 @@ SysVehicle::SysVehicle(ActiveScene &scene) :
             scene.get_update_order(), "vehicle_modification", "", "physics",
             std::bind(&SysVehicle::update_vehicle_modification, this))
 {
-    using Magnum::Shaders::Phong;
-
-    m_shader = std::make_unique<Phong>(Phong::Flag::DiffuseTexture);
 }
 
 StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
@@ -297,7 +295,7 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                 meshRes = AssetImporter::compile_mesh(meshData, glResources);
             }
 
-            std::vector<Texture2D*> textureResources;
+            std::vector<DependRes<Texture2D>> textureResources;
             for (unsigned i = 0; i < drawable.m_textures.size(); i++)
             {
                 unsigned texID = drawable.m_textures[i];
@@ -309,14 +307,21 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                     DependRes<ImageData2D> imageData = package.get<ImageData2D>(texName);
                     texRes = AssetImporter::compile_tex(imageData, glResources);
                 }
-                textureResources.push_back(&(*texRes));
+                textureResources.push_back(texRes);
             }
 
             // by now, the mesh and texture should both exist
+            using adera::shader::Phong;
+            Phong::ACompPhongInstance shader;
+            shader.m_shaderProgram = glResources.get<Phong>("phong_shader");
+            shader.m_textures = std::move(textureResources);
+            shader.m_lightPosition = Vector3{10.0f, 15.0f, 5.0f};
+            shader.m_ambientColor = 0x111111_rgbf;
+            shader.m_specularColor = 0x330000_rgbf;
+            m_scene.reg_emplace<Phong::ACompPhongInstance>(currentEnt, std::move(shader));
 
-            CompDrawableDebug& bBocks
-                    = m_scene.reg_emplace<CompDrawableDebug>(
-                        currentEnt, &(*meshRes), std::move(textureResources), m_shader.get(), 0x0202EE_rgbf);
+            CompDrawableDebug& bBocks = m_scene.reg_emplace<CompDrawableDebug>(
+                        currentEnt, meshRes, &Phong::draw_entity, 0x0202EE_rgbf);
 
             //new DrawablePhongColored(*obj, *m_shader, *mesh, 0xff0000_rgbf, m_drawables);
         }

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -32,8 +32,6 @@
 #include "../Resource/Package.h"
 #include "../Resource/blueprints.h"
 
-#include <Magnum/Shaders/Phong.h>
-
 // forward declare
 namespace osp
 {
@@ -127,9 +125,6 @@ public:
 private:
     ActiveScene& m_scene;
     //AppPackages& m_packages;
-
-    // temporary
-    std::unique_ptr<Magnum::Shaders::Phong> m_shader;
 
     UpdateOrderHandle m_updateVehicleModification;
 };

--- a/src/osp/OSPApplication.h
+++ b/src/osp/OSPApplication.h
@@ -38,7 +38,7 @@ public:
 
     // put more stuff into here eventually
 
-    OSPApplication();
+    OSPApplication() = default;
 
     /**
      * Add a resource package to the application


### PR DESCRIPTION
Latest version of data-oriented shaders, now built on top of new GL resource management system and with previous PR comments taken into account. Tested; flight scene launches, can be closed and re-launched, and program exits, all without crashing. Yay!