### PR TITLE
Add ActiveScene& argument to update functons, and clean up related code

### DIFF
--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -52,7 +52,7 @@ public:
 private:
 
     osp::active::SysPhysics &m_physics;
-    osp::active::UpdateOrderHandle m_updatePhysics;
+    osp::active::UpdateOrderHandle_t m_updatePhysics;
 };
 
 /**

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -64,7 +64,7 @@ private:
     osp::ButtonControlHandle m_rollLf;
     osp::ButtonControlHandle m_rollRt;
 
-    osp::active::UpdateOrderHandle m_updateSensor;
+    osp::active::UpdateOrderHandle_t m_updateSensor;
 };
 
 /**

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -73,10 +73,10 @@ ActiveScene::~ActiveScene()
 }
 
 
-entt::entity ActiveScene::hier_create_child(entt::entity parent,
+ActiveEnt ActiveScene::hier_create_child(ActiveEnt parent,
                                             std::string const& name)
 {
-    entt::entity child = m_registry.create();
+    ActiveEnt child = m_registry.create();
     ACompHierarchy& childHierarchy = m_registry.emplace<ACompHierarchy>(child);
     //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
     childHierarchy.m_name = name;
@@ -86,7 +86,7 @@ entt::entity ActiveScene::hier_create_child(entt::entity parent,
     return child;
 }
 
-void ActiveScene::hier_set_parent_child(entt::entity parent, entt::entity child)
+void ActiveScene::hier_set_parent_child(ActiveEnt parent, ActiveEnt child)
 {
     ACompHierarchy& childHierarchy = m_registry.get<ACompHierarchy>(child);
     //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
@@ -106,9 +106,8 @@ void ActiveScene::hier_set_parent_child(entt::entity parent, entt::entity child)
     // If has siblings (not first child)
     if (parentHierarchy.m_childCount)
     {
-        entt::entity const sibling = parentHierarchy.m_childFirst;
-        ACompHierarchy& siblingHierarchy
-                = m_registry.get<ACompHierarchy>(sibling);
+        ActiveEnt sibling = parentHierarchy.m_childFirst;
+        auto& siblingHierarchy = m_registry.get<ACompHierarchy>(sibling);
 
         // Set new child and former first child as siblings
         siblingHierarchy.m_siblingPrev = child;
@@ -168,17 +167,14 @@ void ActiveScene::hier_cut(ActiveEnt ent)
             = entt::null;
 }
 
-void ActiveScene::on_hierarchy_construct(entt::registry& reg, entt::entity ent)
+void ActiveScene::on_hierarchy_construct(ActiveReg_t& reg, ActiveEnt ent)
 {
-    //std::cout << "hierarchy entity constructed\n";
-
     m_hierarchyDirty = true;
 }
 
-void ActiveScene::on_hierarchy_destruct(entt::registry& reg, entt::entity ent)
+void ActiveScene::on_hierarchy_destruct(ActiveReg_t& reg, ActiveEnt ent)
 {
-    std::cout << "hierarchy entity destructed\n";
-
+    m_hierarchyDirty = true;
 }
 
 void ActiveScene::update()
@@ -195,7 +191,7 @@ void ActiveScene::update()
     //{
     //    sysMachine.update_physics(1.0f/60.0f);
     //}
-    m_updateOrder.call();
+    m_updateOrder.call(*this);
 }
 
 
@@ -244,7 +240,7 @@ void ActiveScene::update_hierarchy_transforms()
 
 }
 
-void ActiveScene::draw(entt::entity camera)
+void ActiveScene::draw(ActiveEnt camera)
 {
     //Matrix4 cameraProject;
     //Matrix4 cameraInverse;

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -59,6 +59,7 @@ class ActiveScene
 {
 
 public:
+
     ActiveScene(UserInputHandler &userInput, OSPApplication& app, Package& context);
     ~ActiveScene();
 
@@ -103,7 +104,8 @@ public:
     /**
      * @return Internal entt::registry
      */
-    constexpr entt::registry& get_registry() { return m_registry; }
+    constexpr ActiveReg_t& get_registry()
+    { return m_registry; }
 
     /**
      * Shorthand for get_registry().get<T>()
@@ -147,9 +149,9 @@ public:
 
     constexpr UserInputHandler& get_user_input() { return m_userInput; }
 
-    constexpr UpdateOrder& get_update_order() { return m_updateOrder; }
+    constexpr UpdateOrder_t& get_update_order() { return m_updateOrder; }
 
-    constexpr RenderOrder& get_render_order() { return m_renderOrder; }
+    constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
 
     // TODO
     constexpr float get_time_delta_fixed() { return 1.0f / 60.0f; }
@@ -212,14 +214,14 @@ public:
     Package& get_context_resources() { return m_context; }
 private:
 
-    void on_hierarchy_construct(entt::registry& reg, ActiveEnt ent);
-    void on_hierarchy_destruct(entt::registry& reg, ActiveEnt ent);
+    void on_hierarchy_construct(ActiveReg_t& reg, ActiveEnt ent);
+    void on_hierarchy_destruct(ActiveReg_t& reg, ActiveEnt ent);
 
     OSPApplication& m_app;
     Package& m_context;
 
     //std::vector<std::vector<ActiveEnt> > m_hierLevels;
-    entt::basic_registry<ActiveEnt> m_registry;
+    ActiveReg_t m_registry;
     ActiveEnt m_root;
     bool m_hierarchyDirty;
 
@@ -229,8 +231,8 @@ private:
     //std::vector<std::reference_wrapper<ISysMachine>> m_update_sensor;
     //std::vector<std::reference_wrapper<ISysMachine>> m_update_physics;
 
-    UpdateOrder m_updateOrder;
-    RenderOrder m_renderOrder;
+    UpdateOrder_t m_updateOrder;
+    RenderOrder_t m_renderOrder;
 
     MapSysMachine_t m_sysMachines; // TODO: Put this in SysVehicle
     MapDynamicSys_t m_dynamicSys;

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -33,16 +33,16 @@ using namespace osp;
 
 const std::string SysAreaAssociate::smc_name = "AreaAssociate";
 
-SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene, Universe &uni) :
-       m_scene(rScene),
-       m_universe(uni),
-       m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
-                    [this] { this->update_scan(); })
+SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene, Universe &uni)
+ : m_scene(rScene)
+ , m_universe(uni)
+ , m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
+                [this] (ActiveScene& rScene) { this->update_scan(rScene); })
 {
 
 }
 
-void SysAreaAssociate::update_scan()
+void SysAreaAssociate::update_scan(ActiveScene& rScene)
 {
     // scan for nearby satellites, maybe move this somewhere else some day
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -75,7 +75,7 @@ public:
      * What this is suppose to do in the future:
      * Scan for nearby Satellites and attempt to activate them
      */
-    void update_scan();
+    void update_scan(ActiveScene& rScene);
 
     /**
      * Connect this AreaAssociate to an ActiveArea Satellite. This sets the
@@ -127,8 +127,8 @@ private:
     //std::vector<universe::Satellite> m_activatedSats;
     entt::sparse_set<universe::Satellite> m_activatedSats;
 
-    //UpdateOrderHandle m_updateFloatingOrigin;
-    UpdateOrderHandle m_updateScan;
+    //UpdateOrderHandle_t m_updateFloatingOrigin;
+    UpdateOrderHandle_t m_updateScan;
 
     /**
      * Translate everything in the ActiveScene

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -56,7 +56,7 @@ public:
 private:
     ActiveScene &m_scene;
 
-    RenderOrderHandle m_renderDebugDraw;
+    RenderOrderHandle_t m_renderDebugDraw;
 };
 
 }

--- a/src/osp/Active/SysForceFields.cpp
+++ b/src/osp/Active/SysForceFields.cpp
@@ -30,16 +30,16 @@ using namespace osp::active;
 
 const std::string SysFFGravity::smc_name = "FFGravity";
 
-SysFFGravity::SysFFGravity(ActiveScene &scene) :
-        m_scene(scene),
-        m_physics(scene.dynamic_system_find<SysPhysics>()),
-        m_updateForce(scene.get_update_order(), "ff_gravity", "", "physics",
-                        std::bind(&SysFFGravity::update_force, this))
+SysFFGravity::SysFFGravity(ActiveScene &scene)
+ : m_scene(scene)
+ , m_physics(scene.dynamic_system_find<SysPhysics>())
+ , m_updateForce(scene.get_update_order(), "ff_gravity", "", "physics",
+                 [this] (ActiveScene& rScene) { this->update_force(rScene); })
 {
 
 }
 
-void SysFFGravity::update_force()
+void SysFFGravity::update_force(ActiveScene& rScene)
 {
 
     auto viewFields = m_scene.get_registry()

--- a/src/osp/Active/SysForceFields.h
+++ b/src/osp/Active/SysForceFields.h
@@ -68,7 +68,7 @@ public:
     SysFFGravity(ActiveScene &scene);
     ~SysFFGravity() = default;
 
-    void update_force();
+    void update_force(ActiveScene& rScene);
 
 private:
 
@@ -76,7 +76,7 @@ private:
     ActiveScene &m_scene;
     SysPhysics &m_physics;
 
-    UpdateOrderHandle m_updateForce;
+    UpdateOrderHandle_t m_updateForce;
 };
 
 

--- a/src/osp/Active/SysNewton.cpp
+++ b/src/osp/Active/SysNewton.cpp
@@ -94,11 +94,11 @@ ACompNwtBody& ACompNwtBody::operator=(ACompNwtBody&& move)
     return *this;
 }
 
-SysNewton::SysNewton(ActiveScene &scene) :
-        m_scene(scene),
-        m_nwtWorld(NewtonCreate()),
-        m_updatePhysicsWorld(scene.get_update_order(), "physics", "wire", "",
-                             std::bind(&SysNewton::update_world, this))
+SysNewton::SysNewton(ActiveScene &scene)
+ : m_scene(scene)
+ , m_nwtWorld(NewtonCreate())
+ , m_updatePhysicsWorld(scene.get_update_order(), "physics", "wire", "",
+                [this] (ActiveScene& rScene) { this->update_world(rScene); })
 {
     //std::cout << "sysnewtoninit\n";
     NewtonWorldSetUserData(m_nwtWorld, this);
@@ -278,7 +278,7 @@ void SysNewton::create_body(ActiveEnt entity)
     //NewtonDestroyCollision(ball);
 }
 
-void SysNewton::update_world()
+void SysNewton::update_world(ActiveScene& rScene)
 {
     //m_scene.floating_origin_translate_begin();
 
@@ -363,13 +363,13 @@ void SysNewton::body_apply_torque_local(ACompRigidBody &body, Vector3 force)
 
 
 
-void SysNewton::on_body_construct(entt::registry& reg, ActiveEnt ent)
+void SysNewton::on_body_construct(ActiveReg_t& reg, ActiveEnt ent)
 {
     // TODO
     reg.get<ACompRigidBody>(ent).m_bodyData.m_mass = 1.0f;
 }
 
-void SysNewton::on_body_destruct(entt::registry& reg, ActiveEnt ent)
+void SysNewton::on_body_destruct(ActiveReg_t& reg, ActiveEnt ent)
 {
     // make sure the newton body is destroyed
     NewtonBody *body = reg.get<ACompRigidBody>(ent).m_body;
@@ -379,12 +379,12 @@ void SysNewton::on_body_destruct(entt::registry& reg, ActiveEnt ent)
     }
 }
 
-void SysNewton::on_shape_construct(entt::registry& reg, ActiveEnt ent)
+void SysNewton::on_shape_construct(ActiveReg_t& reg, ActiveEnt ent)
 {
 
 }
 
-void SysNewton::on_shape_destruct(entt::registry& reg, ActiveEnt ent)
+void SysNewton::on_shape_destruct(ActiveReg_t& reg, ActiveEnt ent)
 {
     // make sure the collision shape destroyed
     NewtonCollision *shape = reg.get<ACompCollisionShape>(ent).m_collision;

--- a/src/osp/Active/SysNewton.h
+++ b/src/osp/Active/SysNewton.h
@@ -134,7 +134,7 @@ public:
      */
     void create_body(ActiveEnt entity);
 
-    void update_world();
+    void update_world(ActiveScene& rScene);
 
     /**
      * Used to find which rigid body an entity belongs to. This will keep
@@ -187,11 +187,11 @@ private:
                                 NewtonCollision *compound,
                                 Matrix4 const &currentTransform);
 
-    void on_body_construct(entt::registry& reg, ActiveEnt ent);
-    void on_body_destruct(entt::registry& reg, ActiveEnt ent);
+    void on_body_construct(ActiveReg_t& reg, ActiveEnt ent);
+    void on_body_destruct(ActiveReg_t& reg, ActiveEnt ent);
 
-    void on_shape_construct(entt::registry& reg, ActiveEnt ent);
-    void on_shape_destruct(entt::registry& reg, ActiveEnt ent);
+    void on_shape_construct(ActiveReg_t& reg, ActiveEnt ent);
+    void on_shape_destruct(ActiveReg_t& reg, ActiveEnt ent);
 
     NewtonCollision* newton_create_tree_collision(
             const NewtonWorld *newtonWorld, int shapeId);
@@ -207,7 +207,7 @@ private:
     ActiveScene& m_scene;
     NewtonWorld *const m_nwtWorld;
 
-    UpdateOrderHandle m_updatePhysicsWorld;
+    UpdateOrderHandle_t m_updatePhysicsWorld;
 };
 
 template<class TRIANGLE_IT_T>

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -47,13 +47,12 @@ using namespace Magnum::Math::Literals;
 
 const std::string SysVehicle::smc_name = "Vehicle";
 
-SysVehicle::SysVehicle(ActiveScene &scene) :
-        m_scene(scene),
-        m_updateVehicleModification(
-            scene.get_update_order(), "vehicle_modification", "", "physics",
-            std::bind(&SysVehicle::update_vehicle_modification, this))
-{
-}
+SysVehicle::SysVehicle(ActiveScene &scene)
+ : m_scene(scene)
+ , m_updateVehicleModification(
+       scene.get_update_order(), "vehicle_modification", "", "physics",
+       [this] (ActiveScene& rScene) { this->update_vehicle_modification(rScene); })
+{ }
 
 StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
                                          SysAreaAssociate &area,
@@ -346,7 +345,7 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
     return newEntities[0];
 }
 
-void SysVehicle::update_vehicle_modification()
+void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
 {
     auto view = m_scene.get_registry().view<ACompVehicle>();
     auto viewParts = m_scene.get_registry().view<ACompPart>();

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -120,13 +120,13 @@ public:
     ActiveEnt part_instantiate(PrototypePart& part, ActiveEnt rootParent);
 
     // Handle deleted parts and separations
-    void update_vehicle_modification();
+    void update_vehicle_modification(ActiveScene& rScene);
 
 private:
     ActiveScene& m_scene;
     //AppPackages& m_packages;
 
-    UpdateOrderHandle m_updateVehicleModification;
+    UpdateOrderHandle_t m_updateVehicleModification;
 };
 
 

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -51,15 +51,15 @@ void WireInput::doErase()
      list()->cut(this);
 };
 
-SysWire::SysWire(ActiveScene &scene) :
-        m_updateWire(scene.get_update_order(), "wire", "", "",
-                     std::bind(&SysWire::update_propigate, this))
+SysWire::SysWire(ActiveScene &scene)
+ : m_updateWire(scene.get_update_order(), "wire", "", "",
+                [this] (ActiveScene& rScene) { this->update_propigate(rScene); })
 {
 
 }
 
 
-void SysWire::update_propigate()
+void SysWire::update_propigate(ActiveScene& rScene)
 {
     for (DependentOutput &output : m_dependentOutputs)
     {

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -53,13 +53,13 @@ void WireInput::doErase()
 
 SysWire::SysWire(ActiveScene &scene)
  : m_updateWire(scene.get_update_order(), "wire", "", "",
-                [this] (ActiveScene& rScene) { this->update_propigate(rScene); })
+                [this] (ActiveScene& rScene) { this->update_propagate(rScene); })
 {
 
 }
 
 
-void SysWire::update_propigate(ActiveScene& rScene)
+void SysWire::update_propagate(ActiveScene& rScene)
 {
     for (DependentOutput &output : m_dependentOutputs)
     {

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -287,7 +287,7 @@ public:
     SysWire(SysWire const& copy) = delete;
     SysWire(SysWire&& move) = delete;
 
-    void update_propigate(ActiveScene& rScene);
+    void update_propagate(ActiveScene& rScene);
     void connect(WireOutput &wireFrom, WireInput &wireTo);
 
 private:

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -287,12 +287,12 @@ public:
     SysWire(SysWire const& copy) = delete;
     SysWire(SysWire&& move) = delete;
 
-    void update_propigate();
+    void update_propigate(ActiveScene& rScene);
     void connect(WireOutput &wireFrom, WireInput &wireTo);
 
 private:
     std::vector<DependentOutput> m_dependentOutputs;
-    UpdateOrderHandle m_updateWire;
+    UpdateOrderHandle_t m_updateWire;
 };
 
 

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -43,13 +43,14 @@ struct ACompCamera;
 
 constexpr unsigned gc_heir_physics_level = 1;
 
-using ActiveEnt = entt::entity;
+enum class ActiveEnt: entt::id_type {};
+using ActiveReg_t = entt::basic_registry<ActiveEnt>;
 
-using UpdateOrder = FunctionOrder<void(void)>;
-using UpdateOrderHandle = FunctionOrderHandle<void(void)>;
+using UpdateOrder_t = FunctionOrder<void(ActiveScene&)>;
+using UpdateOrderHandle_t = FunctionOrderHandle<void(ActiveScene&)>;
 
-using RenderOrder = FunctionOrder<void(ACompCamera const&)>;
-using RenderOrderHandle = FunctionOrderHandle<void(ACompCamera const&)>;
+using RenderOrder_t = FunctionOrder<void(ACompCamera const&)>;
+using RenderOrderHandle_t = FunctionOrderHandle<void(ACompCamera const&)>;
 
 struct ACompFloatingOrigin
 {

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -96,11 +96,11 @@ SysPlanetA::SysPlanetA(osp::active::ActiveScene &scene,
                        osp::UserInputHandler &userInput)
  : m_scene(scene)
  , m_updateGeometry(scene.get_update_order(), "planet_geo", "", "physics",
-                    [this] { this->update_geometry(); } )
+            [this] (ActiveScene& rScene) { this->update_geometry(rScene); } )
  , m_updatePhysics(scene.get_update_order(), "planet_phys", "planet_geo", "",
-                   [this] { this->update_physics(); })
+            [this] (ActiveScene& rScene) { this->update_physics(rScene); })
  , m_renderPlanetDraw(scene.get_render_order(), "", "", "",
-                      [this] (ACompCamera const& camera) { this->draw(camera); })
+            [this] (ACompCamera const& camera) { this->draw(camera); })
  , m_debugUpdate(userInput.config_get("debug_planet_update"))
 { }
 
@@ -181,7 +181,7 @@ void SysPlanetA::debug_create_chunk_collider(osp::active::ActiveEnt ent,
     physics.create_body(fish);
 }
 
-void SysPlanetA::update_geometry()
+void SysPlanetA::update_geometry(ActiveScene& rScene)
 {
 
     auto view = m_scene.get_registry().view<ACompPlanet, ACompTransform>();
@@ -359,7 +359,7 @@ void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt)
     rPlanetGeo.get_ico_tree()->debug_verify_state();
 }
 
-void SysPlanetA::update_physics()
+void SysPlanetA::update_physics(ActiveScene& rScene)
 {
 
 }

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -85,18 +85,18 @@ public:
 
     void planet_update_geometry(osp::active::ActiveEnt planetEnt);
 
-    void update_geometry();
+    void update_geometry(osp::active::ActiveScene& rScene);
 
-    void update_physics();
+    void update_physics(osp::active::ActiveScene& rScene);
 
 private:
 
     osp::active::ActiveScene &m_scene;
 
-    osp::active::UpdateOrderHandle m_updateGeometry;
-    osp::active::UpdateOrderHandle m_updatePhysics;
+    osp::active::UpdateOrderHandle_t m_updateGeometry;
+    osp::active::UpdateOrderHandle_t m_updatePhysics;
 
-    osp::active::RenderOrderHandle m_renderPlanetDraw;
+    osp::active::RenderOrderHandle_t m_renderPlanetDraw;
 
     osp::ButtonControlHandle m_debugUpdate;
 };

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -66,29 +66,29 @@ using adera::active::machines::MachineUserControl;
 //}
 
 
-DebugCameraController::DebugCameraController(ActiveScene &scene, ActiveEnt ent) :
-        DebugObject(scene, ent),
-        m_orbiting(entt::null),
-        m_orbitPos(0, 0, 1),
-        m_updateVehicleModPre(scene.get_update_order(), "dbg_cam_vmod", "", "vehicle_modification",
-                [this] { this->update_vehicle_mod_pre(); }),
-        m_updatePhysicsPre(scene.get_update_order(), "dbg_cam_pre", "", "physics",
-                [this] { this->update_physics_pre(); }),
-        m_updatePhysicsPost(scene.get_update_order(), "dbg_cam_post", "physics", "",
-                [this] { this->update_physics_post(); }),
-        m_userInput(scene.get_user_input()),
-        m_mouseMotion(m_userInput.mouse_get()),
-        m_scrollInput(m_userInput.scroll_get()),
-        m_up(m_userInput.config_get("ui_up")),
-        m_dn(m_userInput.config_get("ui_dn")),
-        m_lf(m_userInput.config_get("ui_lf")),
-        m_rt(m_userInput.config_get("ui_rt")),
-        m_switch(m_userInput.config_get("game_switch")),
-        m_rmb(m_userInput.config_get("ui_rmb")),
-        m_selfDestruct(m_userInput.config_get("vehicle_self_destruct"))
-{
-    m_orbitDistance = 20.0f;
-}
+DebugCameraController::DebugCameraController(ActiveScene &rScene, ActiveEnt ent)
+ : DebugObject(rScene, ent)
+ , m_orbiting(entt::null)
+ , m_orbitPos(0, 0, 1)
+ , m_orbitDistance(20.0f)
+ , m_updateVehicleModPre(
+       rScene.get_update_order(), "dbg_cam_vmod", "", "vehicle_modification",
+       [this] (ActiveScene&) { this->update_vehicle_mod_pre(); })
+ , m_updatePhysicsPre(rScene.get_update_order(), "dbg_cam_pre", "", "physics",
+                      [this] (ActiveScene&) { this->update_physics_pre(); })
+ , m_updatePhysicsPost(rScene.get_update_order(), "dbg_cam_post", "physics", "",
+                       [this] (ActiveScene&) { this->update_physics_post(); })
+ , m_userInput(rScene.get_user_input())
+ , m_mouseMotion(m_userInput.mouse_get())
+ , m_scrollInput(m_userInput.scroll_get())
+ , m_rmb(m_userInput.config_get("ui_rmb"))
+ , m_up(m_userInput.config_get("ui_up"))
+ , m_dn(m_userInput.config_get("ui_dn"))
+ , m_lf(m_userInput.config_get("ui_lf"))
+ , m_rt(m_userInput.config_get("ui_rt"))
+ , m_switch(m_userInput.config_get("game_switch"))
+ , m_selfDestruct(m_userInput.config_get("vehicle_self_destruct"))
+{ }
 
 void DebugCameraController::update_vehicle_mod_pre()
 {

--- a/src/test_application/DebugObject.h
+++ b/src/test_application/DebugObject.h
@@ -89,9 +89,9 @@ private:
     osp::Vector3 m_orbitPos;
     float m_orbitDistance;
 
-    osp::active::UpdateOrderHandle m_updateVehicleModPre;
-    osp::active::UpdateOrderHandle m_updatePhysicsPre;
-    osp::active::UpdateOrderHandle m_updatePhysicsPost;
+    osp::active::UpdateOrderHandle_t m_updateVehicleModPre;
+    osp::active::UpdateOrderHandle_t m_updatePhysicsPre;
+    osp::active::UpdateOrderHandle_t m_updatePhysicsPost;
 
     osp::UserInputHandler &m_userInput;
     // Mouse inputs

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -283,8 +283,8 @@ void debug_print_update_order()
         return;
     }
 
-    osp::active::UpdateOrder const &order = g_ospMagnum->get_scenes().begin()
-                                            ->second.get_update_order();
+    osp::active::UpdateOrder_t const &order = g_ospMagnum->get_scenes().begin()
+                                              ->second.get_update_order();
 
     std::cout << "Update order:\n";
     for (auto const& call : order.get_call_list())


### PR DESCRIPTION
This PR adds an `ActiveScene&` argument to the UpdateOrder definitions in `src/active/activetypes.h`, adding the new argument to every update function. This is another step towards making systems stateless. Related code was also cleaned up, such as adding an `_t` to typedefs, and fixing the inconsistent use of entt default types in ActiveScene. Issue #13 is also fixed.