### PR TITLE
Plume effects

### DIFF
--- a/bin/OSPData/adera/Shaders/PlumeShader.frag
+++ b/bin/OSPData/adera/Shaders/PlumeShader.frag
@@ -1,0 +1,162 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//#version 430 core
+/* Rocket exhaust plume shader
+
+ * Mixes together a number of noise textures to produce a decent looking
+   rocket exhaust plume effect that scales with engine power
+ * Tons of hardcoded parameters for now, later can generalize it and pass
+   some sort of uniform block storing all the configuration options, but
+   for now this is it (dimensions of the plume can still be specified via
+   uniform, though)
+*/
+in vec3 normal;
+in vec3 fragPos;
+
+layout(location = 0, index = 0) out vec4 color;
+
+/* Z position of plume ends
+
+ * The origin is assumed to be located at the aperture of the nozzle. These
+   values are used to compute the UV coordinates for the plume, with V
+   increasing towards -Z.
+*/
+layout(location = 3) uniform float topZ;
+layout(location = 4) uniform float bottomZ;
+
+layout(location = 5) uniform sampler2D nozzleNoiseTex;
+layout(location = 6) uniform sampler2D combustionNoiseTex;
+
+/* Alpha currently unused, but later will control maximum opacity.
+   It's nontrivial because even if the exhaust overall is very thin,
+   that doesn't mean the exhaust will be dim at the nozzle
+ */
+layout(location = 7) uniform vec4 baseColor;
+
+layout(location = 8) uniform float flowVelocity;
+layout(location = 9) uniform float time;
+
+// Engine power, which is the primary influence on plume density
+layout(location = 10) uniform float power;
+
+const float PI = 3.14159265358;
+float height = topZ - bottomZ;
+// The plume is defined to leave the nozzle at the mesh origin
+float NOZZLE_THRESHOLD = abs(topZ / height);
+
+
+/* Converts rectilinear plume coordinates to polar
+ *
+ * Assumes cylinderical symmetry, and that the plume is centered at the origin.
+*/
+vec2 plumeCoords(vec3 rect)
+{
+    float x = rect.x;
+    float y = rect.y;
+    float z = rect.z;
+
+    float angle = atan(y, x) + PI;
+    float vert = clamp((topZ - z) / height, 0.0, 1.0);
+
+    return vec2(angle/(2*PI), vert);
+}
+
+// Offset UV by time uniform and wrap
+vec2 scrollUV(vec2 UV)
+{
+    float tmpI;
+    float scrollFac = modf(UV.y - time*flowVelocity, tmpI);
+    scrollFac = float(scrollFac < 0.0)*(scrollFac + 1.0) + float(scrollFac >= 0.0)*scrollFac;
+    return vec2(UV.x, scrollFac);
+}
+
+void main()
+{
+    // Generate cylinderical UVs from modelspace position of fragment
+    vec2 polarUV  = plumeCoords(fragPos);
+
+    /* Position Factors
+
+     * PlumeFactor is zero at the nozzle outlet, and 1 at the tail of the plume
+     * NozzleFactor is zero at the nozzle throat, and 1 at the nozzle outlet
+     */
+    float plumeFactor = clamp((polarUV.y - NOZZLE_THRESHOLD) / (1.0 - NOZZLE_THRESHOLD), 0.0, 1.0);
+    float nozzleFactor = clamp(polarUV.y / NOZZLE_THRESHOLD, 0.0, 1.0);
+    float fragInNozzle = float(polarUV.y / NOZZLE_THRESHOLD < 1.0);
+
+    /* Plume values
+     
+       The plume is composed of three separate values: the base color, the
+       combustion noise, and the nozzle noise.
+
+     * The base color is simply the color of the exhaust. It can be any color
+       and any opacity.
+     * The combustion noise is used to simulate fluctuations in the exhaust
+       caused by combustion instability. This effect scrolls down the length
+       of the plume at a rate designated by the flowVelocity uniform.
+     * The nozzle noise is used to simulate imperfections in the exhaust caused
+       by variances in the nozzle construction. Imperfections in the nozzle
+       result in azimuthal differences in plume density which remain static
+       throughout the burn.
+    */
+    float nozzleValue = 1.0 - 0.2*texture(nozzleNoiseTex, vec2(polarUV.x, 0)).r;
+    float combustValue = texture(combustionNoiseTex, scrollUV(polarUV)).r;
+
+    /* Effect fade
+
+     * The vertical fade factor is a smoothstep interpolation over the length
+       of the plume. This is used to mix the combustion effect in, so that the
+       effects magnify at the end of the plume.
+     * The nozzle noise factor is a smoothstep interpolation at the top of the
+       plume which fades in the effects of the nozzle noise. The nozzle noise
+       begins at 0.01 and fades in fully by 0.2.
+     * the throttle fade factor controls how much influence the engine power
+       level influences the plume density. Since the gasses inside the nozzle
+       are constrained by the nozzle walls, they will probably glow more and
+       thus be more visible, whereas the free plume will fade out more quickly
+       since it can freely expand. The factor is a piecewise function that is
+       determined by the factor relevant to wherever the fragment is within
+       the plume.
+    */
+    float vertFadeFactor = smoothstep(0.0, 1.0, polarUV.y);
+    float nozzleNoiseFactor = smoothstep(0.01, 0.2, polarUV.y);
+    float throttleFadeFactor =
+            fragInNozzle*(nozzleFactor/3)
+            + (1.0 - fragInNozzle)*(plumeFactor+.5);
+
+    float combust = mix(1.0, combustValue, vertFadeFactor);
+    float nozzle = mix(1.0, nozzleValue, nozzleNoiseFactor);
+    float throttle = mix(1.0, power, throttleFadeFactor);
+    float diffusion = (1.0 - plumeFactor);
+
+    // The final plume density is the product of all these factors
+    float plumeDensity = throttle*combust*nozzle*diffusion;
+
+    // Square the magnitude of the fluctuation
+    plumeDensity *= plumeDensity;
+
+    color = vec4(vec3(baseColor), plumeDensity);
+}
+

--- a/bin/OSPData/adera/Shaders/PlumeShader.vert
+++ b/bin/OSPData/adera/Shaders/PlumeShader.vert
@@ -22,55 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#pragma once
+ //#version 430 core
 
-#include <map>
-#include <memory>
+layout(location = 0) in vec4 vertPosition;
+layout(location = 1) in vec2 vertTexCoords;
+layout(location = 5) in vec3 vertNormal;
 
-#include "../FunctonOrder.h"
+out vec3 normal;
+out vec3 fragPos;
 
-#include <entt/entity/registry.hpp>
+layout(location = 0) uniform mat4 projMat;
+layout(location = 1) uniform mat4 modelTransformMat;
+layout(location = 2) uniform mat3 normalMat;
 
-
-namespace osp::active
+void main()
 {
+    gl_Position = projMat * modelTransformMat * vertPosition;
+    normal = normalMat * vertNormal;
 
-class SysNewton;
-
-class ActiveScene;
-
-struct ACompCamera;
-
-struct ACompTransform;
-
-constexpr unsigned gc_heir_physics_level = 1;
-
-enum class ActiveEnt: entt::id_type {};
-
-inline std::ostream& operator<<(std::ostream& os, ActiveEnt e)
-{ return os << static_cast<int>(e); }
-
-using ActiveReg_t = entt::basic_registry<ActiveEnt>;
-
-using UpdateOrder_t = FunctionOrder<void(ActiveScene&)>;
-using UpdateOrderHandle_t = FunctionOrderHandle<void(ActiveScene&)>;
-
-using RenderOrder_t = FunctionOrder<void(ACompCamera const&)>;
-using RenderOrderHandle_t = FunctionOrderHandle<void(ACompCamera const&)>;
-
-struct ACompFloatingOrigin
-{
-    //bool m_dummy;
-};
-
-// not really sure what else to put in here
-class IDynamicSystem
-{
-public:
-    virtual ~IDynamicSystem() = default;
-};
-
-using MapDynamicSys_t = std::map<std::string, std::unique_ptr<IDynamicSystem>,
-                                 std::less<> >;
-
+    // Send vert position to frag shader for UV calculation
+    fragPos = vec3(vertPosition);
 }
+

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -49,7 +49,9 @@ public:
      * Attach a visual exhaust plume effect to MachineRocket
      *
      * Searches the hierarchy under the specified MachineRocket entity and
-     * attaches a visual exhaust effect to the appropriate node
+     * attaches an ACompExhaustPlume to the rocket's plume node. A graphical
+     * exhaust plume effect will be attached to the node by SysExhaustPlume
+     * when it processes the component.
      * @param ent The MachineRocket entity
      */
     void attach_plume_effect(osp::active::ActiveEnt ent);

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -45,6 +45,22 @@ public:
     //void update_sensor();
     void update_physics();
 
+    /**
+     * Attach a visual exhaust plume effect to MachineRocket
+     *
+     * Searches the hierarchy under the specified MachineRocket entity and
+     * attaches a visual exhaust effect to the appropriate node
+     * @param ent The MachineRocket entity
+     */
+    void attach_plume_effect(osp::active::ActiveEnt ent);
+
+    /**
+     * Attach a MachineRocket to an entity
+     * 
+     * Also attempts to attach a plume component to the appropriate child node
+     * @param ent The entity that owns the MachineRocket
+     * @return The new MachineRocket instance
+     */
     osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
 
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -55,6 +55,8 @@ public:
 private:
     osp::ButtonControlHandle m_throttleMax;
     osp::ButtonControlHandle m_throttleMin;
+    osp::ButtonControlHandle m_throttleMore;
+    osp::ButtonControlHandle m_throttleLess;
     osp::ButtonControlHandle m_selfDestruct;
 
     osp::ButtonControlHandle m_pitchUp;

--- a/src/adera/Plume.h
+++ b/src/adera/Plume.h
@@ -24,44 +24,16 @@
  */
 #pragma once
 
-#include <Magnum/Math/Color.h>
-#include <Magnum/GL/Mesh.h>
+#include <string>
+//#include <Magnum/Math/Color.h>
+//#include <Magnum/Magnum.h>
 
-#include "osp/Resource/Resource.h"
-#include "osp/Active/Shader.h"
-#include "../types.h"
-#include "activetypes.h"
-
-namespace osp::active
+struct PlumeEffectData
 {
-
-struct CompDrawableDebug
-{
-    DependRes<Magnum::GL::Mesh> m_mesh;
-    ShaderDrawFnc_t m_shader_draw;
-    Magnum::Color4 m_color;
+    //float flowVelocity;
+    //Magnum::Color4 color;
+    //float zMin;
+    //float zMax;
+    std::string meshName;
 };
 
-struct CompVisibleDebug
-{
-    bool state = true;
-};
-
-class SysDebugRender : public IDynamicSystem
-{
-public:
-
-    static const std::string smc_name;
-
-    SysDebugRender(ActiveScene &rScene);
-    ~SysDebugRender() = default;
-
-    void draw(ACompCamera const& camera);
-
-private:
-    ActiveScene &m_scene;
-
-    RenderOrderHandle_t m_renderDebugDraw;
-};
-
-}

--- a/src/adera/Plume.h
+++ b/src/adera/Plume.h
@@ -25,15 +25,15 @@
 #pragma once
 
 #include <string>
-//#include <Magnum/Math/Color.h>
-//#include <Magnum/Magnum.h>
+#include <Magnum/Math/Color.h>
+#include <Magnum/Magnum.h>
 
 struct PlumeEffectData
 {
-    //float flowVelocity;
-    //Magnum::Color4 color;
-    //float zMin;
-    //float zMax;
-    std::string meshName;
+    float m_flowVelocity;
+    Magnum::Color4 m_color;
+    float m_zMin;
+    float m_zMax;
+    std::string m_meshName;
 };
 

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -1,0 +1,142 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "PlumeShader.h"
+
+#include <Magnum/GL/Version.h>
+#include <Magnum/GL/Shader.h>
+#include <Corrade/Containers/Reference.h>
+#include <Magnum/GL/Texture.h>
+
+using namespace Magnum;
+using namespace osp::active;
+using namespace adera::shader;
+
+void PlumeShader::draw_plume(ActiveEnt e, ActiveScene& rScene, GL::Mesh& rMesh,
+    ACompCamera const& camera, ACompTransform const& transform)
+{
+    auto& shaderInstance = rScene.reg_get<ACompPlumeShaderInstance>(e);
+    PlumeShader& shader = *shaderInstance.m_shaderProgram;
+
+    Magnum::Matrix4 entRelative = camera.m_inverse * transform.m_transformWorld;
+
+    shader
+        .bindNozzleNoiseTexture(*shaderInstance.m_nozzleTex)
+        .bindCombustionNoiseTexture(*shaderInstance.m_combustionTex)
+        .setMeshZBounds(shaderInstance.m_maxZ, shaderInstance.m_minZ)
+        .setBaseColor(shaderInstance.m_color)
+        .setFlowVelocity(shaderInstance.m_flowVelocity)
+        .updateTime(shaderInstance.m_currentTime)
+        .setPower(shaderInstance.m_powerLevel)
+        .setTransformationMatrix(entRelative)
+        .setProjectionMatrix(camera.m_projection)
+        .setNormalMatrix(entRelative.normalMatrix())
+        .draw(rMesh);
+}
+
+void PlumeShader::init()
+{
+    GL::Shader vert{GL::Version::GL430, GL::Shader::Type::Vertex};
+    GL::Shader frag{GL::Version::GL430, GL::Shader::Type::Fragment};
+    vert.addFile("OSPData/adera/Shaders/PlumeShader.vert");
+    frag.addFile("OSPData/adera/Shaders/PlumeShader.frag");
+
+    CORRADE_INTERNAL_ASSERT_OUTPUT(GL::Shader::compile({vert, frag}));
+    attachShaders({vert, frag});
+    CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+    // Set TexSampler2D uniforms
+    setUniform(
+        static_cast<Int>(UniformPos::NozzleNoiseTex),
+        static_cast<Int>(TextureSlot::NozzleNoiseTexUnit));
+    setUniform(
+        static_cast<Int>(UniformPos::CombustionNoiseTex),
+        static_cast<Int>(TextureSlot::CombustionNoiseTexUnit));
+}
+
+PlumeShader::PlumeShader()
+{
+    init();
+}
+
+PlumeShader& PlumeShader::setProjectionMatrix(Matrix4 const& matrix)
+{
+    setUniform(static_cast<Int>(UniformPos::ProjMat), matrix);
+    return *this;
+}
+
+PlumeShader& PlumeShader::setTransformationMatrix(Matrix4 const& matrix)
+{
+    setUniform(static_cast<Int>(UniformPos::ModelTransformMat), matrix);
+    return *this;
+}
+
+PlumeShader& PlumeShader::setNormalMatrix(Matrix3x3 const& matrix)
+{
+    setUniform(static_cast<Int>(UniformPos::NormalMat), matrix);
+    return *this;
+}
+
+PlumeShader& PlumeShader::setMeshZBounds(float topZ, float bottomZ)
+{
+    setUniform(static_cast<Int>(UniformPos::MeshTopZ), topZ);
+    setUniform(static_cast<Int>(UniformPos::MeshBottomZ), bottomZ);
+    return *this;
+}
+
+PlumeShader& PlumeShader::bindNozzleNoiseTexture(Magnum::GL::Texture2D& tex)
+{
+    tex.bind(static_cast<Int>(TextureSlot::NozzleNoiseTexUnit));
+    return *this;
+}
+
+PlumeShader& PlumeShader::bindCombustionNoiseTexture(Magnum::GL::Texture2D& tex)
+{
+    tex.bind(static_cast<Int>(TextureSlot::CombustionNoiseTexUnit));
+    return *this;
+}
+
+PlumeShader& PlumeShader::setBaseColor(const Magnum::Color4 color)
+{
+    setUniform(static_cast<Int>(UniformPos::BaseColor), color);
+    return *this;
+}
+
+PlumeShader& PlumeShader::setFlowVelocity(const float vel)
+{
+    setUniform(static_cast<Int>(UniformPos::FlowVelocity), vel);
+    return *this;
+}
+
+PlumeShader& PlumeShader::updateTime(const float currentTime)
+{
+    setUniform(static_cast<Int>(UniformPos::Time), currentTime);
+    return *this;
+}
+
+PlumeShader& PlumeShader::setPower(const float power)
+{
+    setUniform(static_cast<Int>(UniformPos::Power), power);
+    return *this;
+}

--- a/src/adera/Shaders/PlumeShader.h
+++ b/src/adera/Shaders/PlumeShader.h
@@ -1,0 +1,145 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+#include <Magnum/GL/AbstractShaderProgram.h>
+#include <Magnum/GL/Attribute.h>
+#include <Magnum/GL/Texture.h>
+#include <Magnum/Math/Vector4.h>
+#include <Magnum/Math/Vector3.h>
+#include <Magnum/Math/Vector2.h>
+#include <Magnum/Math/Matrix3.h>
+#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Math/Color.h>
+#include <Magnum/Shaders/Generic.h>
+
+#include "adera/Plume.h"
+#include <osp/Resource/Resource.h>
+#include <osp/Active/activetypes.h>
+#include <osp/Active/ActiveScene.h>
+
+namespace adera::shader
+{
+
+class PlumeShader : public Magnum::GL::AbstractShaderProgram
+{
+public:
+    // Vertex attribs
+    Magnum::Shaders::Generic3D::Position Position;
+    Magnum::Shaders::Generic3D::Normal Normal;
+    Magnum::Shaders::Generic3D::TextureCoordinates TextureCoordinates;
+
+    // Outputs
+    enum : Magnum::UnsignedInt
+    {
+        ColorOutput = 0
+    };
+
+    PlumeShader();
+
+    struct ACompPlumeShaderInstance
+    {
+        // Parent shader
+        osp::DependRes<PlumeShader> m_shaderProgram;
+
+        // Uniform values
+        float m_minZ;
+        float m_maxZ;
+        osp::DependRes<Magnum::GL::Texture2D> m_nozzleTex;
+        osp::DependRes<Magnum::GL::Texture2D> m_combustionTex;
+        Magnum::Color4 m_color;
+        float m_flowVelocity;
+        float m_currentTime;
+        float m_powerLevel;
+
+        // Constructor to auto-initialize from effect data
+        ACompPlumeShaderInstance(
+            osp::DependRes<PlumeShader> parent,
+            osp::DependRes<Magnum::GL::Texture2D> nozzleTex,
+            osp::DependRes<Magnum::GL::Texture2D> combustionTex,
+            PlumeEffectData const& data)
+            : m_shaderProgram(parent)
+            , m_nozzleTex(nozzleTex)
+            , m_combustionTex(combustionTex)
+            , m_minZ(data.m_zMin)
+            , m_maxZ(data.m_zMax)
+            , m_color(data.m_color)
+            , m_flowVelocity(data.m_flowVelocity)
+            , m_currentTime(0.0f)
+            , m_powerLevel(0.0f)
+        {}
+    };
+
+    static void draw_plume(osp::active::ActiveEnt e,
+        osp::active::ActiveScene& rScene,
+        Magnum::GL::Mesh& rMesh,
+        osp::active::ACompCamera const& camera,
+        osp::active::ACompTransform const& transform);
+
+private:
+    // GL init
+    void init();
+
+    // Uniforms
+    enum class UniformPos : Magnum::Int
+    {
+        ProjMat = 0,
+        ModelTransformMat = 1,
+        NormalMat = 2,
+        MeshTopZ = 3,
+        MeshBottomZ = 4,
+        NozzleNoiseTex = 5,
+        CombustionNoiseTex = 6,
+        BaseColor = 7,
+        FlowVelocity = 8,
+        Time = 9,
+        Power = 10
+    };
+
+    // Texture2D slots
+    enum class TextureSlot : Magnum::Int
+    {
+        NozzleNoiseTexUnit = 0,
+        CombustionNoiseTexUnit = 1
+    };
+
+    // Hide irrelevant calls
+    using Magnum::GL::AbstractShaderProgram::drawTransformFeedback;
+    using Magnum::GL::AbstractShaderProgram::dispatchCompute;
+
+    // Private uniform setters
+    PlumeShader& setProjectionMatrix(const Magnum::Matrix4& matrix);
+    PlumeShader& setTransformationMatrix(const Magnum::Matrix4& matrix);
+    PlumeShader& setNormalMatrix(const Magnum::Matrix3x3& matrix);
+
+    PlumeShader& setMeshZBounds(float topZ, float bottomZ);
+    PlumeShader& bindNozzleNoiseTexture(Magnum::GL::Texture2D& rTex);
+    PlumeShader& bindCombustionNoiseTexture(Magnum::GL::Texture2D& rTex);
+    PlumeShader& setBaseColor(const Magnum::Color4 color);
+    PlumeShader& setFlowVelocity(const float vel);
+    PlumeShader& updateTime(const float currentTime);
+    PlumeShader& setPower(const float power);
+};
+
+} // namespace adera::shader

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -98,11 +98,12 @@ void SysExhaustPlume::initialize_plume(ActiveEnt node)
 void SysExhaustPlume::update_plumes(ActiveScene& rScene)
 {
     using adera::active::machines::MachineRocket;
-    auto plumeView = m_scene.get_registry().view<ACompExhaustPlume>();
+    auto plumeView = m_scene.get_registry().view<ACompExhaustPlume, CompVisibleDebug>();
 
     for (ActiveEnt plumeEnt : plumeView)
     {
         ACompExhaustPlume& plume = plumeView.get<ACompExhaustPlume>(plumeEnt);
+        CompVisibleDebug& visibility = plumeView.get<CompVisibleDebug>(plumeEnt);
 
         auto& machine = m_scene.reg_get<MachineRocket>(plume.m_parentMachineRocket);
         const auto& throttle = *machine.request_input(2)->connected_value();
@@ -110,7 +111,11 @@ void SysExhaustPlume::update_plumes(ActiveScene& rScene)
 
         if (throttlePos > 0.0f)
         {
-            std::cout << "ON!\n";
+            visibility.state = true;
+        }
+        else
+        {
+            visibility.state = false;
         }
     }
 }

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -1,0 +1,116 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "SysExhaustPlume.h"
+#include "osp/Active/ActiveScene.h"
+#include "adera/Machines/Rocket.h"
+#include "osp/Resource/AssetImporter.h"
+#include "osp/Active/SysDebugRender.h"
+
+#include <Magnum/Trade/MeshData.h>
+#include <Magnum/MeshTools/Compile.h>
+#include <Magnum/GL/Mesh.h>
+#include <Magnum/GL/Texture.h>
+#include <Magnum/Trade/ImageData.h>
+#include <Magnum/ImageView.h>
+#include <Magnum/GL/Sampler.h>
+#include <Magnum/GL/TextureFormat.h>
+
+using namespace osp::active;
+
+SysExhaustPlume::SysExhaustPlume(ActiveScene& rScene)
+    : m_scene(rScene), m_time(0.0f),
+    m_updatePlume(rScene.get_update_order(), "exhaust_plume", "mach_rocket", "",
+        [this](ActiveScene& rScene){this->update_plumes(rScene);})
+{}
+
+void SysExhaustPlume::initialize_plume(ActiveEnt node)
+{
+    using Magnum::GL::Mesh;
+    using Magnum::GL::Texture2D;
+    using Magnum::Trade::ImageData2D;
+    using namespace Magnum::Math::Literals;
+    using adera::shader::PlumeShader;
+    using ShaderInstance_t = PlumeShader::ACompPlumeShaderInstance;
+
+    auto const& plume = m_scene.reg_get<ACompExhaustPlume>(node);
+
+    if (m_scene.get_registry().try_get<ShaderInstance_t>(node))
+    {
+        return;  // plume already initialized
+    }
+
+    DependRes<PlumeEffectData> plumeEffect = plume.m_effect;
+
+    Package& pkg = m_scene.get_application().debug_find_package("lzdb");
+
+    // Get plume mesh
+    Package& glResources = m_scene.get_context_resources();
+    DependRes<Mesh> plumeMesh = glResources.get<Mesh>(plumeEffect->m_meshName);
+    if (plumeMesh.empty())
+    {
+        plumeMesh = AssetImporter::compile_mesh(plumeEffect->m_meshName, pkg, glResources);
+    }
+
+    // Get plume tex (TEMPORARY: just grab noise1024.png)
+    const std::string texName = "OSPData/adera/noise1024.png";
+    DependRes<Texture2D> n1024 = glResources.get<Texture2D>(texName);
+    if (n1024.empty())
+    {
+        n1024 = AssetImporter::compile_tex(texName, pkg, glResources);
+    }
+
+    // Emplace plume shader instance component from plume effect parameters
+    ShaderInstance_t shader(
+        glResources.get<PlumeShader>("plume_shader"),
+        n1024,
+        n1024,
+        *plumeEffect);
+    m_scene.reg_emplace<ShaderInstance_t>(node, std::move(shader));
+
+    m_scene.reg_emplace<CompDrawableDebug>(node, plumeMesh,
+        &adera::shader::PlumeShader::draw_plume);
+    m_scene.reg_emplace<CompVisibleDebug>(node, false);
+    m_scene.reg_emplace<CompTransparentDebug>(node, true);
+}
+
+void SysExhaustPlume::update_plumes(ActiveScene& rScene)
+{
+    using adera::active::machines::MachineRocket;
+    auto plumeView = m_scene.get_registry().view<ACompExhaustPlume>();
+
+    for (ActiveEnt plumeEnt : plumeView)
+    {
+        ACompExhaustPlume& plume = plumeView.get<ACompExhaustPlume>(plumeEnt);
+
+        auto& machine = m_scene.reg_get<MachineRocket>(plume.m_parentMachineRocket);
+        const auto& throttle = *machine.request_input(2)->connected_value();
+        const auto throttlePos = std::get<wiretype::Percent>(throttle).m_value;
+
+        if (throttlePos > 0.0f)
+        {
+            std::cout << "ON!\n";
+        }
+    }
+}

--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -23,52 +23,44 @@
  * SOFTWARE.
  */
 #pragma once
-
-#include <map>
-#include <memory>
-
-#include "../FunctonOrder.h"
-
-#include <entt/entity/registry.hpp>
-
+#include "osp/Active/physics.h"
+#include <Magnum/Shaders/Phong.h>
+#include "osp/Resource/Resource.h"
 
 namespace osp::active
 {
 
-class SysNewton;
-
-class ActiveScene;
-
-struct ACompCamera;
-
-constexpr unsigned gc_heir_physics_level = 1;
-
-enum class ActiveEnt: entt::id_type {};
-
-inline std::ostream& operator<<(std::ostream& os, ActiveEnt e)
-{ return os << static_cast<int>(e); }
-
-using ActiveReg_t = entt::basic_registry<ActiveEnt>;
-
-using UpdateOrder_t = FunctionOrder<void(ActiveScene&)>;
-using UpdateOrderHandle_t = FunctionOrderHandle<void(ActiveScene&)>;
-
-using RenderOrder_t = FunctionOrder<void(ACompCamera const&)>;
-using RenderOrderHandle_t = FunctionOrderHandle<void(ACompCamera const&)>;
-
-struct ACompFloatingOrigin
+struct ACompExhaustPlume
 {
-    //bool m_dummy;
+    ActiveEnt m_parentMachineRocket{entt::null};
+    //Magnum::Shaders::Phong m_shader;
+    //DependRes<PlumeEffect> m_effect;
 };
 
-// not really sure what else to put in here
-class IDynamicSystem
+class SysExhaustPlume : public IDynamicSystem
 {
 public:
-    virtual ~IDynamicSystem() = default;
+    static inline std::string smc_name = "ExhaustPlume";
+
+    SysExhaustPlume(ActiveScene& scene);
+    ~SysExhaustPlume() = default;
+
+    /**
+     * Initialize plume graphics
+     * 
+     * SysMachineRocket only attaches ACompExhaustPlume to eligible entities;
+     * this function takes such entities, retrieves the appropriate graphics
+     * resources, and configures the graphical components
+     */
+    void initialize_plume(ActiveEnt e);
+
+    void update_plumes(ActiveScene& rScene);
+
+private:
+    ActiveScene& m_scene;
+    float m_time;
+
+    UpdateOrderHandle_t m_updatePlume;
 };
 
-using MapDynamicSys_t = std::map<std::string, std::unique_ptr<IDynamicSystem>,
-                                 std::less<> >;
-
-}
+} // namespace osp::active

--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -24,7 +24,8 @@
  */
 #pragma once
 #include "osp/Active/physics.h"
-#include <Magnum/Shaders/Phong.h>
+#include "adera/Plume.h"
+#include "adera/Shaders/PlumeShader.h"
 #include "osp/Resource/Resource.h"
 
 namespace osp::active
@@ -33,7 +34,7 @@ namespace osp::active
 struct ACompExhaustPlume
 {
     ActiveEnt m_parentMachineRocket{entt::null};
-    //DependRes<PlumeEffect> m_effect;
+    DependRes<PlumeEffectData> m_effect;
 };
 
 class SysExhaustPlume : public IDynamicSystem
@@ -41,7 +42,7 @@ class SysExhaustPlume : public IDynamicSystem
 public:
     static inline std::string smc_name = "ExhaustPlume";
 
-    SysExhaustPlume(ActiveScene& scene);
+    SysExhaustPlume(ActiveScene& rScene);
     ~SysExhaustPlume() = default;
 
     /**

--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -33,7 +33,6 @@ namespace osp::active
 struct ACompExhaustPlume
 {
     ActiveEnt m_parentMachineRocket{entt::null};
-    //Magnum::Shaders::Phong m_shader;
     //DependRes<PlumeEffect> m_effect;
 };
 

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -26,6 +26,7 @@
 
 #include <utility>
 #include <vector>
+#include <stack>
 
 #include "../OSPApplication.h"
 #include "../UserInputHandler.h"
@@ -38,7 +39,8 @@
 //#include "SysNewton.h"
 #include "SysMachine.h"
 //#include "SysVehicle.h"
-//#include "SysWire.h"
+#include "SysWire.h"
+#include "adera/SysExhaustPlume.h"
 
 namespace osp::active
 {
@@ -100,6 +102,17 @@ public:
      * @param ent [in]
      */
     void hier_cut(ActiveEnt ent);
+
+    /**
+     * Traverse the scene hierarchy
+     * 
+     * Calls the specified callable on each entity of the scene hierarchy
+     * @param root The entity whose sub-tree to traverse
+     * @param callable A function that accepts an ActiveEnt as an argument and
+     *                 returns false if traversal should stop, true otherwise
+     */
+    template <typename FUNC_T>
+    void hierarchy_traverse(ActiveEnt root, FUNC_T callable);
 
     /**
      * @return Internal entt::registry
@@ -333,5 +346,52 @@ struct ACompCamera
     void calculate_projection();
 };
 
+enum class EHierarchyTraverseStatus : bool
+{
+    Continue = true,
+    Stop = false
+};
+
+template<typename FUNC_T>
+void ActiveScene::hierarchy_traverse(ActiveEnt root, FUNC_T callable)
+{
+    using osp::active::ACompHierarchy;
+
+    std::stack<ActiveEnt> parentNextSibling;
+    ActiveEnt currentEnt = root;
+
+    while (true)
+    {
+        ACompHierarchy &hier = reg_get<ACompHierarchy>(currentEnt);
+
+        if (callable(currentEnt) == EHierarchyTraverseStatus::Stop) { return; }
+
+        if (hier.m_childCount)
+        {
+            // entity has some children
+            currentEnt = hier.m_childFirst;
+
+
+            // save next sibling for later if it exists
+            if (hier.m_siblingNext != entt::null)
+            {
+                parentNextSibling.push(hier.m_siblingNext);
+            }
+        } else if (hier.m_siblingNext != entt::null)
+        {
+            // no children, move to next sibling
+            currentEnt = hier.m_siblingNext;
+        } else if (parentNextSibling.size())
+        {
+            // last sibling, and not done yet
+            // is last sibling, move to parent's (or ancestor's) next sibling
+            currentEnt = parentNextSibling.top();
+            parentNextSibling.pop();
+        } else
+        {
+            break;
+        }
+    }
+}
 
 }

--- a/src/osp/Active/SysDebugRender.cpp
+++ b/src/osp/Active/SysDebugRender.cpp
@@ -57,8 +57,8 @@ void SysDebugRender::draw(ACompCamera const& camera)
     Renderer::enable(Renderer::Feature::DepthTest);
     Renderer::enable(Renderer::Feature::FaceCulling);
 
-
-    auto drawGroup = m_scene.get_registry().group<CompDrawableDebug>(
+    auto& reg = m_scene.get_registry();
+    auto drawGroup = reg.group<CompDrawableDebug>(
                             entt::get<ACompTransform>);
 
     Matrix4 entRelative;
@@ -66,6 +66,10 @@ void SysDebugRender::draw(ACompCamera const& camera)
     for(auto entity: drawGroup)
     {
         CompDrawableDebug& drawable = drawGroup.get<CompDrawableDebug>(entity);
+        CompVisibleDebug* visible = reg.try_get<CompVisibleDebug>(entity);
+        
+        if (visible && !visible->state) { continue; }
+        
         ACompTransform& transform = drawGroup.get<ACompTransform>(entity);
 
         entRelative = camera.m_inverse * transform.m_transformWorld;

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -45,6 +45,7 @@
 #include "Package.h"
 #include "AssetImporter.h"
 #include "osp/string_concat.h"
+#include "adera/Plume.h"
 
 using Corrade::Containers::Optional;
 using Magnum::Trade::ImageData2D;
@@ -127,6 +128,24 @@ void osp::AssetImporter::load_part(TinyGltfImporter& gltfImporter,
     pkg.add<PrototypePart>(gltfImporter.object3DName(id), std::move(part));
 }
 
+void osp::AssetImporter::load_plume(TinyGltfImporter& gltfImporter,
+    Package& pkg, Magnum::UnsignedInt id, std::string_view resPrefix)
+{
+    using Corrade::Containers::Pointer;
+    using Magnum::Trade::ObjectData3D;
+
+    std::cout << "Plume! Node \"" << gltfImporter.object3DName(id) << "\"\n";
+
+    PlumeEffectData plumeData;
+
+    Pointer<ObjectData3D> rootNode = gltfImporter.object3D(id);
+    unsigned meshID = gltfImporter.object3D(rootNode->children()[0])->instance();
+    std::string meshName = string_concat(resPrefix, gltfImporter.meshName(meshID));
+    plumeData.meshName = meshName;
+
+    pkg.add<PlumeEffectData>(gltfImporter.object3DName(id), std::move(plumeData));
+}
+
 /* Explanation of resPrefix:
    When a mesh is created in blender, the object itself has a name (the one that
    shows up in the scene hierarchy), but the underlying mesh data within that
@@ -162,6 +181,10 @@ void osp::AssetImporter::load_sturdy(TinyGltfImporter& gltfImporter,
         if (nodeName.compare(0, 5, "part_") == 0)
         {
             load_part(gltfImporter, pkg, childID, resPrefix);
+        }
+        else if (nodeName.compare(0, 6, "plume_") == 0)
+        {
+            load_plume(gltfImporter, pkg, childID, resPrefix);
         }
     }
 

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -133,15 +133,37 @@ void osp::AssetImporter::load_plume(TinyGltfImporter& gltfImporter,
 {
     using Corrade::Containers::Pointer;
     using Magnum::Trade::ObjectData3D;
+    using namespace tinygltf;
 
     std::cout << "Plume! Node \"" << gltfImporter.object3DName(id) << "\"\n";
 
-    PlumeEffectData plumeData;
-
+    // Get mesh data
     Pointer<ObjectData3D> rootNode = gltfImporter.object3D(id);
     unsigned meshID = gltfImporter.object3D(rootNode->children()[0])->instance();
     std::string meshName = string_concat(resPrefix, gltfImporter.meshName(meshID));
-    plumeData.meshName = meshName;
+
+    // Get shader params from extras
+    Node const& node = *static_cast<Node const*>(
+        gltfImporter.object3D(id)->importerState());
+
+    Value const& extras = node.extras;
+    float flowVel = extras.Get("flowvelocity").Get<double>();
+    Magnum::Color4 color;
+    Value::Array colorArray = extras.Get("color").Get<Value::Array>();
+    for (int i = 0; i < 4; i++)
+    {
+        Value const& component = colorArray[i];
+        color[i] = component.GetNumberAsDouble();
+    }
+    float zMax = extras.Get("zMax").Get<double>();
+    float zMin = extras.Get("zMin").Get<double>();
+
+    PlumeEffectData plumeData;
+    plumeData.m_meshName = meshName;
+    plumeData.m_flowVelocity = flowVel;
+    plumeData.m_color = color;
+    plumeData.m_zMax = zMax;
+    plumeData.m_zMin = zMin;
 
     pkg.add<PlumeEffectData>(gltfImporter.object3DName(id), std::move(plumeData));
 }

--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -117,6 +117,19 @@ private:
     static void load_part(TinyGltfImporter& gltfImporter,
         Package& package, Magnum::UnsignedInt id, std::string_view resPrefix);
 
+    /**
+     * Load a plume object from a sturdy
+     *
+     * Reads the config from the node with the specified ID into a PlumeEffectData
+     * and stores it in the specified package
+     *
+     * @param gltfImpoter [in] importer used to read node data
+     * @param package [out] package which receives loaded data
+     * @param id [in] ID of node containing plume information
+     */
+    static void load_plume(TinyGltfImporter& gltfImporter,
+        Package& package, Magnum::UnsignedInt id, std::string_view resPrefix);
+
     static void proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
                                Package& package,
                                std::string_view resPrefix,

--- a/src/osp/Resource/Resource.h
+++ b/src/osp/Resource/Resource.h
@@ -122,19 +122,15 @@ public:
 
     DependRes<TYPE_T>& operator=(DependRes<TYPE_T>&& move)
     {
-        // TODO: this sucks, please change it
-        if (!move.m_empty)
-        {
-            move.m_it->second.m_refCount --;
-        }
         if (!m_empty)
         {
-            // existing iterator is being overwritten, release it
-            m_it->second.m_refCount --;
+            // Existing iterator is being overwritten, decrease ref count
+            m_it->second.m_refCount--;
         }
-        m_empty = false;
+        m_empty = move.m_empty;
+        move.m_empty = true;
+
         m_it = std::move(move.m_it);
-        m_it->second.m_refCount ++;
 
         return *this;
     }

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -196,6 +196,12 @@ void testapp::config_controls(OSPMagnum& rOspApp)
     // Set throttle min to X
     rUserInput.config_register_control("vehicle_thr_min", false,
             {{0, (int) Key_t::X, VarTrig_t::PRESSED, false, VarOp_t::OR}});
+    // Set throttle increase to LShift
+    rUserInput.config_register_control("vehicle_thr_more", true,
+	    {{osp::sc_keyboard, (int)Key_t::LeftShift, VarTrig_t::PRESSED, false, VarOp_t::OR}});
+    // Set throttle decrease to LCtrl
+    rUserInput.config_register_control("vehicle_thr_less", true,
+            {{osp::sc_keyboard, (int)Key_t::LeftCtrl, VarTrig_t::PRESSED, false, VarOp_t::OR}});
     // Set self destruct to LeftCtrl+C or LeftShift+A
     rUserInput.config_register_control("vehicle_self_destruct", false,
             {{0, (int) Key_t::LeftCtrl, VarTrig_t::HOLD, false, VarOp_t::AND},

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -97,6 +97,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     auto &sysDebugRender    = scene.dynamic_system_create<osp::active::SysDebugRender>();
     auto &sysArea           = scene.dynamic_system_create<osp::active::SysAreaAssociate>(uni);
     auto &sysVehicle        = scene.dynamic_system_create<osp::active::SysVehicle>();
+    auto &sysExhaustPlume   = scene.dynamic_system_create<osp::active::SysExhaustPlume>();
     auto &sysPlanet         = scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
     auto &sysGravity        = scene.dynamic_system_create<osp::active::SysFFGravity>();
 

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -65,7 +65,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
                                         uni, uni.sat_root());
 
     // Create 10 random vehicles
-    for (int i = 0; i < 10; i ++)
+    /*for (int i = 0; i < 10; i ++)
     {
         // Creates a random mess of spamcans as a vehicle
         Satellite sat = debug_add_random_vehicle(uni, pkg, "TestyMcTestFace Mk"
@@ -77,7 +77,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
         posTraj.m_dirty = true;
 
         stationary.add(sat);
-    }
+    }*/
 
     //Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
     Satellite sat = testapp::debug_add_part_vehicle(uni, pkg, "Placeholder Mk. I");


### PR DESCRIPTION
Rough summary of changes:

1st commit: adds a handy new system called "SysExhaustPlume" which attaches a "plume" component to rocket engines, and screams "ON!" whenever the throttle is greater than zero. Also adds a handy `hierarchy_traverse()` function to ActiveScene that allows an arbitrary callable to be called on each element of the hierarchy.

2nd commit: adds a new function to SysMachineRocket: `attach_plume_effect()`, which attempts to attach a plume effect to each engine on instantiation. Also adds functions to load in plume effect data from a glTF to attach the right one to an engine. Adds a CompVisibleDebug component to the rendering system, and uses all the new features to make a conical mesh with a diffuse texture appear whenever the throttle is on.

3rd commit: adds the plume shader. Modifies the rendering pipeline to support transparency, more convenient drawing of EnTT collections. Adds AssetImpoter functionality to retrieve plume effect parameters from a plume mesh glTF.

4th commit: uses LShift/LCtrl to smoothly vary throttle.

This will all need to be updated again after the existing system PRs get merged, but it shouldn't take much.

Also, since the spamcan aggregations and stomper rocket don't have plumes, it fails to give them one during init. I tested the moon scene and this didn't seem to cause any issues besides printing some messages, but I'll double check tomorrow to make sure it won't break anything.