### PR TITLE
Add `sudo apt-get update` to linux workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt install -y libglfw3-dev libsdl2-dev libopenal-dev libglvnd-core-dev iwyu clang-tidy clang-tools
 
     - name: Build OSP-Magnum


### PR DESCRIPTION
CI workflow for linux is getting error 404 for installing dependencies. Adding a `sudo apt-get update` fixed it.