### PR TITLE
Simplify build for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,14 @@ ELSE()
   ENDIF()
 ENDIF()
 
+# Force Runtime output directory into build/bin folder; force multiprocessor compilation for all projects
+IF(MSVC)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/$<CONFIG> CACHE PATH "")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIG>/lib CACHE PATH "")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<CONFIG>/lib CACHE PATH "")
+  add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+ENDIF()
+
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/modules/" ${CMAKE_MODULE_PATH})
 
 # Process subdirectory full of third-party libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,12 @@ elseif(MINGW)
 
 endif()
 
+# Set the MSVC debug working directory, enforce conformance mode for osp-magnum
+if(MSVC)
+  set_property(TARGET osp-magnum PROPERTY VS_DEBUGGER_WORKING_DIRECTORY ../../bin)
+  target_compile_options(osp-magnum PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+endif()
+
 # Include ENTT (header only lib)
 target_include_directories(osp-magnum PRIVATE ../3rdparty/entt/src)
 
@@ -125,4 +131,5 @@ if(tidy_path)
                  --checks="clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-*,modernize-*,-modernize-use-trailing-return-type,-modernize-use-auto")
 endif()
 
+# Copy root/bin to build/bin
 FILE (COPY "${CMAKE_SOURCE_DIR}/bin/OSPData/adera/" DESTINATION "${CMAKE_BINARY_DIR}/bin/OSPData/adera")


### PR DESCRIPTION
MSVC creates different directories for Debug and release builds, and it does not copy all the necessary DLLs to the same directory. 

This reduces the need to copy files manually after each build.