### PR TITLE
Physical RCS Part 1

### DIFF
--- a/bin/OSPData/adera/ph_rcs.sturdy.gltf
+++ b/bin/OSPData/adera/ph_rcs.sturdy.gltf
@@ -58,6 +58,9 @@
                 "manufacturer" : "ACME Placeholders",
                 "machines" : [
                     {
+                        "type" : "RCSController"
+                    },
+                    {
                         "type" : "Rocket"
                     },
                     {

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -1,0 +1,137 @@
+#include "RCSController.h"
+#include "osp/Active/ActiveScene.h"
+
+#include <Magnum/Math/Vector.h>
+
+using namespace adera::active::machines;
+using namespace osp::active;
+using Magnum::Vector3;
+
+
+MachineRCSController::MachineRCSController()
+    : Machine(true),
+    m_wiCommandOrient(this, "Orient"),
+    m_woThrottle(this, "Throttle")
+{
+    using wiretype::Percent;
+    m_woThrottle.value() = Percent{0.0f};
+}
+
+MachineRCSController::MachineRCSController(MachineRCSController&& move)
+    : osp::active::Machine(std::move(move)), m_wiCommandOrient(std::move(move.m_wiCommandOrient)), m_woThrottle(std::move(move.m_woThrottle))
+{
+
+}
+
+MachineRCSController& MachineRCSController::operator=(MachineRCSController&& move)
+{
+    m_enable = std::move(move.m_enable);
+    return *this;
+}
+
+void MachineRCSController::propagate_output(WireOutput* output)
+{
+
+}
+
+WireInput* MachineRCSController::request_input(osp::WireInPort port)
+{
+    return existing_inputs()[port];
+}
+
+WireOutput* MachineRCSController::request_output(osp::WireOutPort port)
+{
+    return existing_outputs()[port];
+}
+
+std::vector<WireInput*> MachineRCSController::existing_inputs()
+{
+    return {&m_wiCommandOrient};
+}
+
+std::vector<WireOutput*> MachineRCSController::existing_outputs()
+{
+    return {&m_woThrottle};
+}
+
+SysMachineRCSController::SysMachineRCSController(ActiveScene& scene)
+    :SysMachine<SysMachineRCSController, MachineRCSController>(scene),
+    m_updateControls(scene.get_update_order(), "mach_rcs", "wire", "controls",
+        std::bind(&SysMachineRCSController::update_controls, this))
+{
+}
+
+float SysMachineRCSController::thruster_influence(Vector3 posOset, Vector3 direction,
+    Vector3 cmdTransl, Vector3 cmdRot)
+{
+    using Magnum::Math::cross;
+    using Magnum::Math::dot;
+    using Magnum::Math::clamp;
+
+    Vector3 thrust = -direction.normalized();
+    
+    float rotInfluence = 0.0f;
+    float translInfluence = 0.0f;
+
+    if (cmdRot.length() > 0.0f)
+    {
+        Vector3 torque = cross(posOset, thrust).normalized();
+        rotInfluence = dot(torque, cmdRot.normalized());
+    }
+
+    if (cmdTransl.length() > 0.0f)
+    {
+        translInfluence = dot(thrust, cmdTransl.normalized());
+    }
+
+    float total = rotInfluence + translInfluence;
+
+    if (total < .01f)
+    {
+        // Ignore small contributions from imprecision
+        // Real thrusters can't throttle this deep anyways
+        return 0.0f;
+    }
+    return clamp(rotInfluence + translInfluence, 0.0f, 1.0f);
+}
+
+void SysMachineRCSController::update_controls()
+{
+    auto view = m_scene.get_registry().view<MachineRCSController, ACompTransform>();
+
+    for (ActiveEnt ent : view)
+    {
+        auto& machine = view.get<MachineRCSController>(ent);
+        auto& transform = view.get<ACompTransform>(ent);
+
+        using wiretype::AttitudeControl;
+        using Magnum::Vector3;
+
+        if (WireData *gimbal = machine.m_wiCommandOrient.connected_value())
+        {
+            AttitudeControl *attCtrl = std::get_if<AttitudeControl>(gimbal);
+
+            Vector3 commandRot = attCtrl->m_attitude;
+            Vector3 tmpOset{0.0f, 0.0f, -3.12f};
+            Vector3 thrusterPos = transform.m_transform.translation() - tmpOset;
+            Vector3 thrusterDir = transform.m_transform.rotation() * Vector3{0.0f, 0.0f, 1.0f};
+
+            float influence = 0.0f;
+            if (commandRot.length() > 0.0f)
+            {
+                influence = thruster_influence(thrusterPos, thrusterDir, Vector3{0.0f}, commandRot);
+            }
+            std::get<wiretype::Percent>(machine.m_woThrottle.value()).m_value = influence;
+        }
+    }
+}
+
+Machine& SysMachineRCSController::instantiate(ActiveEnt ent)
+{
+    return m_scene.reg_emplace<MachineRCSController>(ent);
+}
+
+Machine& SysMachineRCSController::get(ActiveEnt ent)
+{
+    return m_scene.reg_get<MachineRCSController>(ent);
+}

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -17,18 +17,6 @@ MachineRCSController::MachineRCSController()
     m_woThrottle.value() = Percent{0.0f};
 }
 
-MachineRCSController::MachineRCSController(MachineRCSController&& move)
-    : osp::active::Machine(std::move(move)), m_wiCommandOrient(std::move(move.m_wiCommandOrient)), m_woThrottle(std::move(move.m_woThrottle))
-{
-
-}
-
-MachineRCSController& MachineRCSController::operator=(MachineRCSController&& move)
-{
-    m_enable = std::move(move.m_enable);
-    return *this;
-}
-
 void MachineRCSController::propagate_output(WireOutput* output)
 {
 
@@ -57,7 +45,7 @@ std::vector<WireOutput*> MachineRCSController::existing_outputs()
 SysMachineRCSController::SysMachineRCSController(ActiveScene& scene)
     :SysMachine<SysMachineRCSController, MachineRCSController>(scene),
     m_updateControls(scene.get_update_order(), "mach_rcs", "wire", "controls",
-        std::bind(&SysMachineRCSController::update_controls, this))
+        [this](ActiveScene& rScene) { this->update_controls(rScene); })
 {
 }
 
@@ -95,9 +83,9 @@ float SysMachineRCSController::thruster_influence(Vector3 posOset, Vector3 direc
     return clamp(rotInfluence + translInfluence, 0.0f, 1.0f);
 }
 
-void SysMachineRCSController::update_controls()
+void SysMachineRCSController::update_controls(ActiveScene& rScene)
 {
-    auto view = m_scene.get_registry().view<MachineRCSController, ACompTransform>();
+    auto view = m_scene.get_registry().template view<MachineRCSController, ACompTransform>();
 
     for (ActiveEnt ent : view)
     {

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -1,7 +1,33 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "RCSController.h"
 #include "osp/Active/ActiveScene.h"
 
 #include <Magnum/Math/Vector.h>
+#include <functional>
 
 using namespace adera::active::machines;
 using namespace osp::active;
@@ -13,8 +39,7 @@ MachineRCSController::MachineRCSController()
     m_wiCommandOrient(this, "Orient"),
     m_woThrottle(this, "Throttle")
 {
-    using wiretype::Percent;
-    m_woThrottle.value() = Percent{0.0f};
+    m_woThrottle.value() = wiretype::Percent{0.0f};
 }
 
 void MachineRCSController::propagate_output(WireOutput* output)
@@ -42,9 +67,9 @@ std::vector<WireOutput*> MachineRCSController::existing_outputs()
     return {&m_woThrottle};
 }
 
-SysMachineRCSController::SysMachineRCSController(ActiveScene& scene)
-    :SysMachine<SysMachineRCSController, MachineRCSController>(scene),
-    m_updateControls(scene.get_update_order(), "mach_rcs", "wire", "controls",
+SysMachineRCSController::SysMachineRCSController(ActiveScene& rScene)
+    : SysMachine<SysMachineRCSController, MachineRCSController>(rScene)
+    , m_updateControls(rScene.get_update_order(), "mach_rcs", "wire", "controls",
         [this](ActiveScene& rScene) { this->update_controls(rScene); })
 {
 }
@@ -54,38 +79,45 @@ float SysMachineRCSController::thruster_influence(Vector3 posOset, Vector3 direc
 {
     using Magnum::Math::cross;
     using Magnum::Math::dot;
-    using Magnum::Math::clamp;
 
-    Vector3 thrust = -direction.normalized();
-    
+    // Thrust is applied in opposite direction of thruster nozzle direction
+    Vector3 thrust = std::negate{}(direction.normalized());
+
     float rotInfluence = 0.0f;
-    float translInfluence = 0.0f;
-
     if (cmdRot.length() > 0.0f)
     {
         Vector3 torque = cross(posOset, thrust).normalized();
         rotInfluence = dot(torque, cmdRot.normalized());
     }
 
+    float translInfluence = 0.0f;
     if (cmdTransl.length() > 0.0f)
     {
         translInfluence = dot(thrust, cmdTransl.normalized());
     }
 
+    // Total component of thrust in direction of command
     float total = rotInfluence + translInfluence;
 
     if (total < .01f)
     {
-        // Ignore small contributions from imprecision
-        // Real thrusters can't throttle this deep anyways
+        /* Ignore small contributions from imprecision
+         * Real thrusters can't throttle this deep anyways, so if their
+         * contribution is this small, it'd be a waste of fuel to fire them.
+         */
         return 0.0f;
     }
-    return clamp(rotInfluence + translInfluence, 0.0f, 1.0f);
+    
+    /* Compute thruster throttle output demanded by current command.
+     * In the future, it would be neat to implement PWM so that unthrottlable
+     * thrusters would pulse on and off in order to deliver reduced thrust
+     */
+    return std::clamp(rotInfluence + translInfluence, 0.0f, 1.0f);
 }
 
 void SysMachineRCSController::update_controls(ActiveScene& rScene)
 {
-    auto view = m_scene.get_registry().template view<MachineRCSController, ACompTransform>();
+    auto view = rScene.get_registry().view<MachineRCSController, ACompTransform>();
 
     for (ActiveEnt ent : view)
     {
@@ -99,15 +131,19 @@ void SysMachineRCSController::update_controls(ActiveScene& rScene)
         {
             AttitudeControl *attCtrl = std::get_if<AttitudeControl>(gimbal);
 
+            // TODO: RCS translation is not currently implemented, only rotation
+            Vector3 commandTransl = Vector3{0.0f};
             Vector3 commandRot = attCtrl->m_attitude;
+            // HACK: hard-coded ship CoM, need to compute programmatically
             Vector3 tmpOset{0.0f, 0.0f, -3.12f};
             Vector3 thrusterPos = transform.m_transform.translation() - tmpOset;
             Vector3 thrusterDir = transform.m_transform.rotation() * Vector3{0.0f, 0.0f, 1.0f};
 
             float influence = 0.0f;
-            if (commandRot.length() > 0.0f)
+            if (commandRot.length() > 0.0f || commandTransl.length() > 0.0f)
             {
-                influence = thruster_influence(thrusterPos, thrusterDir, Vector3{0.0f}, commandRot);
+                influence =
+                    thruster_influence(thrusterPos, thrusterDir, commandTransl, commandRot);
             }
             std::get<wiretype::Percent>(machine.m_woThrottle.value()).m_value = influence;
         }

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -12,6 +12,7 @@ class SysMachineRCSController :
     public osp::active::SysMachine<SysMachineRCSController, MachineRCSController>
 {
 public:
+    static inline std::string smc_name = "RCSController";
 
     SysMachineRCSController(osp::active::ActiveScene &rScene);
 
@@ -25,7 +26,7 @@ private:
     float thruster_influence(Magnum::Vector3 posOset, Magnum::Vector3 direction,
         Magnum::Vector3 cmdTransl, Magnum::Vector3 cmdRot);
 
-    osp::active::UpdateOrderHandle m_updateControls;
+    osp::active::UpdateOrderHandle_t m_updateControls;
 };
 
 class MachineRCSController : public osp::active::Machine
@@ -34,8 +35,8 @@ class MachineRCSController : public osp::active::Machine
 
 public:
     MachineRCSController();
-    MachineRCSController(MachineRCSController&& move);
-    MachineRCSController& operator=(MachineRCSController&& move);
+    MachineRCSController(MachineRCSController&& move) = default;
+    MachineRCSController& operator=(MachineRCSController&& move) = default;
     ~MachineRCSController() = default;
 
     void propagate_output(osp::active::WireOutput *output) override;

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <osp/Active/SysMachine.h>
+#include <Magnum/Math/Vector3.h>
+
+namespace adera::active::machines
+{
+
+class MachineRCSController;
+
+class SysMachineRCSController :
+    public osp::active::SysMachine<SysMachineRCSController, MachineRCSController>
+{
+public:
+
+    SysMachineRCSController(osp::active::ActiveScene &rScene);
+
+    void update_controls(osp::active::ActiveScene &rScene);
+
+    osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
+
+    osp::active::Machine& get(osp::active::ActiveEnt ent) override;
+
+private:
+    float thruster_influence(Magnum::Vector3 posOset, Magnum::Vector3 direction,
+        Magnum::Vector3 cmdTransl, Magnum::Vector3 cmdRot);
+
+    osp::active::UpdateOrderHandle m_updateControls;
+};
+
+class MachineRCSController : public osp::active::Machine
+{
+    friend SysMachineRCSController;
+
+public:
+    MachineRCSController();
+    MachineRCSController(MachineRCSController&& move);
+    MachineRCSController& operator=(MachineRCSController&& move);
+    ~MachineRCSController() = default;
+
+    void propagate_output(osp::active::WireOutput *output) override;
+    
+    osp::active::WireInput* request_input(osp::WireInPort port) override;
+    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
+
+    std::vector<osp::active::WireInput*> existing_inputs() override;
+    std::vector<osp::active::WireOutput*> existing_outputs() override;
+
+private:
+    osp::active::WireInput m_wiCommandOrient;
+    osp::active::WireOutput m_woThrottle;
+};
+
+} // adera::active::machines

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -35,8 +35,8 @@ class MachineRCSController : public osp::active::Machine
 
 public:
     MachineRCSController();
-    MachineRCSController(MachineRCSController&& move) = default;
-    MachineRCSController& operator=(MachineRCSController&& move) = default;
+    MachineRCSController(MachineRCSController&& move) noexcept;
+    MachineRCSController& operator=(MachineRCSController&& move) noexcept;
     ~MachineRCSController() = default;
 
     void propagate_output(osp::active::WireOutput *output) override;
@@ -51,5 +51,19 @@ private:
     osp::active::WireInput m_wiCommandOrient;
     osp::active::WireOutput m_woThrottle;
 };
+
+inline MachineRCSController::MachineRCSController(MachineRCSController&& move) noexcept
+    : Machine(std::move(move))
+    , m_wiCommandOrient{this, std::move(move.m_wiCommandOrient)}
+    , m_woThrottle{this, std::move(move.m_woThrottle)}
+{}
+
+inline MachineRCSController& MachineRCSController::operator=(MachineRCSController&& move) noexcept
+{
+    Machine::operator=(std::move(move));
+    m_wiCommandOrient = {this, std::move(move.m_wiCommandOrient)};
+    m_woThrottle = {this, std::move(move.m_woThrottle)};
+    return *this;
+}
 
 } // adera::active::machines

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -1,3 +1,27 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #pragma once
 
 #include <osp/Active/SysMachine.h>
@@ -8,6 +32,14 @@ namespace adera::active::machines
 
 class MachineRCSController;
 
+/**
+ * A system which provides the logic that powers Reaction Control Systems.
+ * Vehicles that use propulsive reaction control will possess a number of rocket
+ * thrusters which need to know whether or not a given maneuver command requires
+ * their contribution. Translation and orientation commands are received from
+ * the command module and output as throttle command values, and the
+ * MachineRockets associated with the RCS thrusters will fire.
+ */
 class SysMachineRCSController :
     public osp::active::SysMachine<SysMachineRCSController, MachineRCSController>
 {
@@ -16,14 +48,37 @@ public:
 
     SysMachineRCSController(osp::active::ActiveScene &rScene);
 
-    void update_controls(osp::active::ActiveScene &rScene);
+    /**
+     * Primary system update function
+     * 
+     * Iterates over MachineRCSControllers and issues throttle commands to the
+     * associated MachineRocket thrusters via wire
+     * 
+     * @param rScene [in] - The scene to update
+     */
+    static void update_controls(osp::active::ActiveScene &rScene);
 
     osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
 
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;
 
 private:
-    float thruster_influence(Magnum::Vector3 posOset, Magnum::Vector3 direction,
+    /**
+     * Command-thrust influence calculator
+     * 
+     * Given a thruster's orientation and position relative to ship center of
+     * mass, and a translation and rotation command, calculates how much
+     * influence the thruster has on the commanded motion. Called on all
+     * vehicle RCS thrusters to decide which are necessary to respond to the
+     * maneuver command.
+     * 
+     * @param posOset   [in] The position of the thruster relative to the ship CoM
+     * @param direction [in] Direction that the thruster points
+     * @param cmdTransl [in] Commanded translation vector
+     * @param cmdRot    [in] Commanded axis of rotation
+     */
+    static float thruster_influence(
+        Magnum::Vector3 posOset, Magnum::Vector3 direction,
         Magnum::Vector3 cmdTransl, Magnum::Vector3 cmdRot);
 
     osp::active::UpdateOrderHandle_t m_updateControls;

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -70,7 +70,7 @@ std::vector<WireOutput*> MachineRocket::existing_outputs()
 
 SysMachineRocket::SysMachineRocket(ActiveScene &scene) :
     SysMachine<SysMachineRocket, MachineRocket>(scene),
-    m_updatePhysics(scene.get_update_order(), "mach_rocket", "wire", "physics",
+    m_updatePhysics(scene.get_update_order(), "mach_rocket", "controls", "physics",
                     std::bind(&SysMachineRocket::update_physics, this))
 {
 

--- a/src/osp/Resource/blueprints.cpp
+++ b/src/osp/Resource/blueprints.cpp
@@ -66,7 +66,7 @@ void BlueprintVehicle::add_part(
 
 void BlueprintVehicle::add_wire(
         unsigned fromPart, unsigned fromMachine, WireOutPort fromPort,
-        unsigned toPart, unsigned toMachine, WireOutPort toPort)
+        unsigned toPart, unsigned toMachine, WireInPort toPort)
 {
     m_wires.emplace_back(fromPart, fromMachine, fromPort,
                          toPart, toMachine, toPort);

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -37,6 +37,7 @@
 
 #include <adera/Machines/UserControl.h>
 #include <adera/Machines/Rocket.h>
+#include <adera/Machines/RCSController.h>
 
 #include <planet-a/Active/SysPlanetA.h>
 #include <planet-a/Satellites/SatPlanet.h>
@@ -67,6 +68,7 @@ using osp::active::ACompFloatingOrigin;
 
 using adera::active::machines::SysMachineUserControl;
 using adera::active::machines::SysMachineRocket;
+using adera::active::machines::SysMachineRCSController;
 
 using planeta::universe::SatPlanet;
 
@@ -104,6 +106,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     // Register machines for that scene
     scene.system_machine_create<SysMachineUserControl>(pMagnumApp->get_input_handler());
     scene.system_machine_create<SysMachineRocket>();
+    scene.system_machine_create<SysMachineRCSController>();
 
     // Make active areas load vehicles and planets
     sysArea.activator_add(&satVehicle, sysVehicle);

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -234,8 +234,6 @@ void load_a_bunch_of_stuff()
 
     osp::AssetImporter::load_image(n256path, lazyDebugPack);
     osp::AssetImporter::load_image(n1024path, lazyDebugPack);
-    /*osp::AssetImporter::compile_tex(n256path, lazyDebugPack);
-    osp::AssetImporter::compile_tex(n1024path, lazyDebugPack);*/
 
     // Add package to the univere
     g_osp.debug_add_package(std::move(lazyDebugPack));

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -204,17 +204,17 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     BlueprintVehicle blueprint;
 
     // Parts
-    auto capsule = pkg.get<PrototypePart>("part_phCapsule");
-    auto fuselage = pkg.get<PrototypePart>("part_phFuselage");
-    auto engine = pkg.get<PrototypePart>("part_phEngine");
-    auto rcs = pkg.get<PrototypePart>("part_phLinRCS");
+    DependRes<PrototypePart> capsule = pkg.get<PrototypePart>("part_phCapsule");
+    DependRes<PrototypePart> fuselage = pkg.get<PrototypePart>("part_phFuselage");
+    DependRes<PrototypePart> engine = pkg.get<PrototypePart>("part_phEngine");
+    DependRes<PrototypePart> rcs = pkg.get<PrototypePart>("part_phLinRCS");
 
     Vector3 cfOset = part_offset(*capsule, "attach_bottom_capsule",
         *fuselage, "attach_top_fuselage");
     Vector3 feOset = part_offset(*fuselage, "attach_bottom_fuselage",
         *engine, "attach_top_eng");
-    Vector3 rcsOsetTop = Vector3{1.0f, 0.0f, 2.0f};
-    Vector3 rcsOsetBtm = Vector3{1.0f, 0.0f, -2.0f};
+    Vector3 rcsOsetTop = cfOset + Vector3{1.0f, 0.0f, 2.0f};
+    Vector3 rcsOsetBtm = cfOset + Vector3{1.0f, 0.0f, -2.0f};
 
     Quaternion idRot;
     Vector3 scl{1};
@@ -233,16 +233,16 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     Quaternion yz270 = rotZ_270 * rotY_090;
 
     // Top RCS ring
-    /*blueprint.add_part(rcs, rcsOsetTop, rotY_090, scl);
+    blueprint.add_part(rcs, rcsOsetTop, rotY_090, scl);
     blueprint.add_part(rcs, rotZ_090.transformVector(rcsOsetTop), yz090, scl);
     blueprint.add_part(rcs, rotZ_180.transformVector(rcsOsetTop), yz180, scl);
-    blueprint.add_part(rcs, rotZ_270.transformVector(rcsOsetTop), yz270, scl);*/
+    blueprint.add_part(rcs, rotZ_270.transformVector(rcsOsetTop), yz270, scl);
 
     // Top RCS ring
-    /*blueprint.add_part(rcs, rcsOsetBtm, rotY_090, scl);
+    blueprint.add_part(rcs, rcsOsetBtm, rotY_090, scl);
     blueprint.add_part(rcs, rotZ_090.transformVector(rcsOsetBtm), yz090, scl);
     blueprint.add_part(rcs, rotZ_180.transformVector(rcsOsetBtm), yz180, scl);
-    blueprint.add_part(rcs, rotZ_270.transformVector(rcsOsetBtm), yz270, scl);*/
+    blueprint.add_part(rcs, rotZ_270.transformVector(rcsOsetBtm), yz270, scl);
 
     enum Parts
     {
@@ -274,6 +274,15 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     blueprint.add_wire(
         Parts::CAPSULE, 0, 0,
         Parts::ENGINE, 0, 0);
+
+    // Wire attitude control to RCS control, and RCS control to RCS rocket
+    for (auto port : rcsPorts)
+    {
+        blueprint.add_wire(Parts::CAPSULE, 0, 0,
+            port, 0, 0);
+        blueprint.add_wire(port, 0, 0,
+            port, 1, 2);
+    }
 
     // Put blueprint in package
     auto depend = pkg.add<BlueprintVehicle>(std::string{name}, std::move(blueprint));


### PR DESCRIPTION
I figured I'll do this one in two parts, and tackle the newton stuff in a second PR since it'll be a bit complicated.

Creates MachineRCSController and SysMachineRCSController, which are used to convert maneuver commands to RCS thruster rocket throttle values. It doesn't doesn't do anything physical yet; it just plays the plume effects on the RCS thrusters according to the maneuver commands. Later it will actually calculate physical thruster forces and get rid of the magical torques currently used.