### PR TITLE
Rework Satellite Type system

### DIFF
--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -101,7 +101,7 @@ void SysAreaAssociate::update_scan(ActiveScene& rScene)
 
         // Satellite is near! Attempt to load it
 
-        sat_activate(sat, view.get(sat));
+        sat_activate(sat);
     }
 
 }
@@ -167,8 +167,8 @@ void SysAreaAssociate::sat_transform_update(ActiveEnt ent)
     satPosTraj.m_dirty = true;
 }
 
-void SysAreaAssociate::activator_add(universe::ITypeSatellite const* type,
-                                         IActivator &activator)
+void SysAreaAssociate::activator_add(TypeSatIndex type,
+                                     IActivator &activator)
 {
     m_activators[type] = &activator;
 }
@@ -199,8 +199,7 @@ void SysAreaAssociate::floating_origin_translate(Vector3 translation)
 }
 
 
-int SysAreaAssociate::sat_activate(universe::Satellite sat,
-                                   universe::UCompActivatable &satAct)
+int SysAreaAssociate::sat_activate(universe::Satellite sat)
 {
 
     if (m_activatedSats.find(sat) != m_activatedSats.end())

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -108,13 +108,12 @@ public:
      * @param type [in] The type of Satellite that will be passed to the Activator
      * @param activator [in]
      */
-    void activator_add(universe::ITypeSatellite const* type,
-                       IActivator &activator);
+    void activator_add(universe::TypeSatIndex type, IActivator &activator);
 
     constexpr universe::Universe& get_universe() { return m_universe; }
 
     using MapActivators
-            = std::map<universe::ITypeSatellite const*, IActivator*>;
+            = std::map<universe::TypeSatIndex, IActivator*>;
 
 private:
 
@@ -140,8 +139,7 @@ private:
      * Attempt to load a satellite
      * @return status, zero for no error
      */
-    int sat_activate(universe::Satellite sat,
-                     universe::UCompActivatable &satAct);
+    int sat_activate(universe::Satellite sat);
 
     int sat_deactivate(ActiveEnt ent,
                        ACompActivatedSat& entAct);

--- a/src/osp/Satellites/SatActiveArea.cpp
+++ b/src/osp/Satellites/SatActiveArea.cpp
@@ -43,9 +43,3 @@ using Magnum::Matrix4;
 using namespace osp::universe;
 
 const std::string SatActiveArea::smc_name = "ActiveArea";
-
-SatActiveArea::SatActiveArea(Universe& universe) :
-        CommonTypeSat<SatActiveArea, UCompActiveArea>(universe)
-{
-
-}

--- a/src/osp/Satellites/SatActiveArea.cpp
+++ b/src/osp/Satellites/SatActiveArea.cpp
@@ -22,24 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <iostream>
-
-#include <Magnum/GL/DefaultFramebuffer.h>
 
 #include "SatActiveArea.h"
 
-#include "../Active/ActiveScene.h"
-#include "../Active/SysNewton.h"
-#include "../Active/SysMachine.h"
+using osp::universe::UCompActiveArea;
+using osp::universe::SatActiveArea;
 
-#include "../Universe.h"
+UCompActiveArea& SatActiveArea::add_active_area(Universe &rUni, Satellite sat)
+{
+    bool typeSetSuccess = rUni.sat_type_try_set(
+                sat, rUni.sat_type_find_index(SatActiveArea::smc_name));
+    assert(typeSetSuccess);
 
-
-// for the 0xrrggbb_rgbf and angle literals
-using namespace Magnum::Math::Literals;
-
-using Magnum::Matrix4;
-
-using namespace osp::universe;
-
-const std::string SatActiveArea::smc_name = "ActiveArea";
+    return rUni.get_reg().emplace<UCompActiveArea>(sat);
+}

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -28,20 +28,11 @@
 
 #include <map>
 
-//#include <Magnum/Math/Color.h>
-//#include <Magnum/PixelFormat.h>
-//#include <Magnum/SceneGraph/Camera.h>
-
 #include "../types.h"
-//#include "../scene.h"
+#include "../Active/activetypes.h"
 
 #include "../Resource/Package.h"
 #include "../Resource/PrototypePart.h"
-
-//#include "../Active/ActiveScene.h"
-//#include "../OSPApplication.h"
-//#include "../UserInputHandler.h"
-//#include "../Active/FtrNewtonBody.h"
 
 namespace osp::universe
 {
@@ -50,56 +41,40 @@ namespace osp::universe
 class OSPMagnum;
 class SatActiveArea;
 
+struct UCompActivatable { };
+
+struct UCompActivationMutable
+{
+    Satellite m_area{entt::null};
+    active::ActiveEnt m_ent{entt::null};
+};
+
+struct UCompActivationRadius
+{
+    float m_radius;
+};
 
 struct UCompActiveArea
 {
-    //active::ActiveEnt m_camera;
 
-    unsigned m_sceneIndex;
+    // for later use
+    //active::MapActiveScene_t::iterator m_scene;
 
     // true when the ActiveArea is moving
     bool m_inMotion;
 };
 
 
-class SatActiveArea : public CommonTypeSat<SatActiveArea, UCompActiveArea>
+class SatActiveArea : CommonTypeSat<SatActiveArea, UCompActiveArea>
 {
+    using Base_t = CommonTypeSat<SatActiveArea, UCompActiveArea>;
 
 public:
 
     static const std::string smc_name;
 
-    SatActiveArea(Universe& universe);
-    ~SatActiveArea() = default;
-
-    /**
-     * Setup magnum scene and sets m_loadedActive to true.
-     * @return only 0 for now
-     */
-    //int activate(OSPApplication& app);
-
-    /**
-     * Do actual drawing of scene. Call only on context thread.
-     */
-    void draw_gl();
-    
-    /**
-     * Load nearby satellites, Maybe request a floating origin translation,
-     * then calls update_physics of ActiveScene
-     */
-    void update_physics(float deltaTime);
-
-    std::string get_name() { return smc_name; };
-
-private:
-
-    //bool m_loadedActive;
-
-    //ActiveEnt m_camera;
-
-    //std::shared_ptr<ActiveScene> m_scene;
-
-    //UserInputHandler& m_userInput;
+    using Base_t::add_get_ucomp_all;
+    using Base_t::add_get_ucomp;
 
 };
 

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -65,17 +65,20 @@ struct UCompActiveArea
 };
 
 
-class SatActiveArea : CommonTypeSat<SatActiveArea, UCompActiveArea>
+class SatActiveArea
 {
-    using Base_t = CommonTypeSat<SatActiveArea, UCompActiveArea>;
-
 public:
 
-    static const std::string smc_name;
+    static constexpr std::string_view smc_name = "ActiveArea";
 
-    using Base_t::add_get_ucomp_all;
-    using Base_t::add_get_ucomp;
-
+    /**
+     * Set the type of a Satellite and add a UCompActiveArea to it
+     * @param rUni [out] Universe containing satellite
+     * @param sat  [in] Satellite add a UCompActiveArea to
+     * @return Reference to UCompActiveArea created
+     */
+    static UCompActiveArea& add_active_area(
+        osp::universe::Universe& rUni, osp::universe::Satellite sat);
 };
 
 }

--- a/src/osp/Satellites/SatVehicle.cpp
+++ b/src/osp/Satellites/SatVehicle.cpp
@@ -24,6 +24,16 @@
  */
 #include "SatVehicle.h"
 
-using namespace osp::universe;
+using osp::universe::UCompVehicle;
+using osp::universe::SatVehicle;
 
-const std::string SatVehicle::smc_name = "Vehicle";
+UCompVehicle& SatVehicle::add_vehicle(
+        Universe &rUni, Satellite sat, DependRes<BlueprintVehicle> blueprint)
+{
+    bool typeSetSuccess = rUni.sat_type_try_set(
+                sat, rUni.sat_type_find_index(SatVehicle::smc_name));
+    assert(typeSetSuccess);
+
+    rUni.get_reg().emplace<UCompActivatable>(sat);
+    return rUni.get_reg().emplace<UCompVehicle>(sat, std::move(blueprint));
+}

--- a/src/osp/Satellites/SatVehicle.cpp
+++ b/src/osp/Satellites/SatVehicle.cpp
@@ -27,9 +27,3 @@
 using namespace osp::universe;
 
 const std::string SatVehicle::smc_name = "Vehicle";
-
-SatVehicle::SatVehicle(Universe& universe) :
-        CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>(universe)
-{
-
-}

--- a/src/osp/Satellites/SatVehicle.h
+++ b/src/osp/Satellites/SatVehicle.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include "SatActiveArea.h"
+
 #include "../Universe.h"
 
 #include "../Resource/Resource.h"
@@ -38,17 +40,15 @@ struct UCompVehicle
     DependRes<BlueprintVehicle> m_blueprint;
 };
 
-class SatVehicle : public CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>
+class SatVehicle : CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>
 {
-
+    using Base_t = CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>;
 public:
 
     static const std::string smc_name;
 
-    SatVehicle(Universe& universe);
-    ~SatVehicle() = default;
-    virtual std::string get_name() { return smc_name; };
-
+    using Base_t::add_get_ucomp;
+    using Base_t::add_get_ucomp_all;
 };
 
 }

--- a/src/osp/Satellites/SatVehicle.h
+++ b/src/osp/Satellites/SatVehicle.h
@@ -40,15 +40,22 @@ struct UCompVehicle
     DependRes<BlueprintVehicle> m_blueprint;
 };
 
-class SatVehicle : CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>
+class SatVehicle
 {
-    using Base_t = CommonTypeSat<SatVehicle, UCompVehicle, UCompActivatable>;
 public:
 
-    static const std::string smc_name;
+    static constexpr std::string_view smc_name = "Vehicle";
 
-    using Base_t::add_get_ucomp;
-    using Base_t::add_get_ucomp_all;
+    /**
+     * Set the type of a Satellite and add a UCompVehicle to it
+     * @param rUni      [out] Universe containing satellite
+     * @param sat       [in] Satellite add a vehicle to
+     * @param blueprint [in] Vehicle data to open when activated
+     * @return Reference to UCompVehicle created
+     */
+    static UCompVehicle& add_vehicle(
+        osp::universe::Universe& rUni, osp::universe::Satellite sat,
+        DependRes<BlueprintVehicle> blueprint);
 };
 
 }

--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -50,6 +50,16 @@ void Universe::sat_remove(Satellite sat)
     m_registry.destroy(sat);
 }
 
+bool Universe::sat_try_set_type(Satellite sat, TypeSatIndex type)
+{
+    auto &satType = m_registry.get<UCompType>(sat);
+    if (satType.m_type == TypeSatIndex::Invalid)
+    {
+        satType.m_type = type;
+        return true;
+    }
+    return false; // Type is already set
+}
 
 Vector3s Universe::sat_calc_pos(Satellite referenceFrame, Satellite target) const
 {
@@ -86,3 +96,15 @@ TypeSatIndex Universe::sat_type_find_index(std::string_view name)
 
     return TypeSatIndex::Invalid;
 }
+
+bool Universe::sat_type_try_set(Satellite sat, TypeSatIndex type)
+{
+    auto &satType = m_registry.get<UCompType>(sat);
+    if (satType.m_type != TypeSatIndex::Invalid)
+    {
+        return false;
+    }
+    satType.m_type = type;
+    return true;
+}
+

--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -75,4 +75,14 @@ Vector3 Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target
     return Vector3(sat_calc_pos(referenceFrame, target)) / 1024.0f;
 }
 
+TypeSatIndex Universe::sat_type_find_index(std::string_view name)
+{
+    auto foundIt = m_typeSatIndices.find(name);
 
+    if (foundIt != m_typeSatIndices.end())
+    {
+        return foundIt->second;
+    }
+
+    return TypeSatIndex::Invalid;
+}

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -29,10 +29,3 @@
 using namespace planeta::universe;
 
 const std::string SatPlanet::smc_name = "Planet";
-
-SatPlanet::SatPlanet(osp::universe::Universe &universe) :
-        CommonTypeSat<SatPlanet, UCompPlanet,
-                      osp::universe::UCompActivatable>(universe)
-{
-
-}

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -22,10 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <iostream>
 
 #include "SatPlanet.h"
 
-using namespace planeta::universe;
+using osp::universe::Universe;
+using osp::universe::Satellite;
+using osp::universe::UCompActivatable;
 
-const std::string SatPlanet::smc_name = "Planet";
+using planeta::universe::UCompPlanet;
+using planeta::universe::SatPlanet;
+
+UCompPlanet& SatPlanet::add_planet(
+        osp::universe::Universe& rUni, Satellite sat, double radius, float mass,
+        float resolutionSurfaceMax, float resolutionScreenMax)
+{
+    bool typeSetSuccess = rUni.sat_type_try_set(
+                sat, rUni.sat_type_find_index(SatPlanet::smc_name));
+    assert(typeSetSuccess);
+
+    rUni.get_reg().emplace<UCompActivatable>(sat);
+    return rUni.get_reg().emplace<UCompPlanet>(
+                sat, radius, resolutionSurfaceMax, resolutionScreenMax, mass);
+}

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -27,6 +27,7 @@
 #include <osp/Satellites/SatActiveArea.h>
 #include <osp/Universe.h>
 
+
 namespace planeta::universe
 {
 
@@ -58,18 +59,25 @@ struct UCompPlanet
 
 
 class SatPlanet
- : osp::universe::CommonTypeSat<SatPlanet, UCompPlanet,
-                                osp::universe::UCompActivatable>
 {
-    using Base_t = osp::universe::CommonTypeSat<SatPlanet, UCompPlanet,
-                                                osp::universe::UCompActivatable>;
 public:
 
-    static const std::string smc_name;
+    static constexpr std::string_view smc_name = "Planet";
 
-    using Base_t::add_get_ucomp;
-    using Base_t::add_get_ucomp_all;
-
+    /**
+     * Set the type of a Satellite and add a UCompPlanet to it
+     * @param rUni                 [out] Universe containing satellite
+     * @param sat                  [in] Satellite add a planet to
+     * @param radius               [in] Radius of planet in meters
+     * @param mass                 [in] Mass of planet in kg
+     * @param resolutionSurfaceMax [in] See UCompPlanet definition
+     * @param resolutionScreenMax  [in] See UCompPlanet definition
+     * @return Reference to new UCompPlanet added
+     */
+    static UCompPlanet& add_planet(
+        osp::universe::Universe& rUni, osp::universe::Satellite sat,
+        double radius, float mass, float resolutionSurfaceMax,
+        float resolutionScreenMax);
 };
 
 }

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -24,8 +24,8 @@
  */
 #pragma once
 
+#include <osp/Satellites/SatActiveArea.h>
 #include <osp/Universe.h>
-
 
 namespace planeta::universe
 {
@@ -57,21 +57,18 @@ struct UCompPlanet
 };
 
 
-class SatPlanet : public osp::universe::CommonTypeSat<
-        SatPlanet, UCompPlanet,
-        osp::universe::UCompActivatable>
+class SatPlanet
+ : osp::universe::CommonTypeSat<SatPlanet, UCompPlanet,
+                                osp::universe::UCompActivatable>
 {
+    using Base_t = osp::universe::CommonTypeSat<SatPlanet, UCompPlanet,
+                                                osp::universe::UCompActivatable>;
 public:
 
     static const std::string smc_name;
 
-    SatPlanet(osp::universe::Universe& universe);
-    ~SatPlanet() = default;
-
-    virtual std::string get_name() { return smc_name; };
-
-private:
-
+    using Base_t::add_get_ucomp;
+    using Base_t::add_get_ucomp_all;
 
 };
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -110,7 +110,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     Satellite areaSat = rUni.sat_create();
 
     // assign sat as an ActiveArea
-    UCompActiveArea &area = SatActiveArea::add_get_ucomp(rUni, areaSat);
+    UCompActiveArea &area = SatActiveArea::add_active_area(rUni, areaSat);
 
     // Link ActiveArea to scene using the AreaAssociate
     sysArea.connect(areaSat);

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -76,10 +76,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 {
 
     // Get needed variables
-    Universe &uni = rOspApp.get_universe();
-    auto &satAA = uni.sat_type_find<SatActiveArea>();
-    auto &satVehicle = uni.sat_type_find<SatVehicle>();
-    auto &satPlanet = uni.sat_type_find<SatPlanet>();
+    Universe &rUni = rOspApp.get_universe();
 
     // Create the application
     pMagnumApp = std::make_unique<OSPMagnum>(args, rOspApp);
@@ -95,7 +92,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     auto &sysPhysics        = scene.dynamic_system_create<osp::active::SysPhysics_t>();
     auto &sysWire           = scene.dynamic_system_create<osp::active::SysWire>();
     auto &sysDebugRender    = scene.dynamic_system_create<osp::active::SysDebugRender>();
-    auto &sysArea           = scene.dynamic_system_create<osp::active::SysAreaAssociate>(uni);
+    auto &sysArea           = scene.dynamic_system_create<osp::active::SysAreaAssociate>(rUni);
     auto &sysVehicle        = scene.dynamic_system_create<osp::active::SysVehicle>();
     auto &sysExhaustPlume   = scene.dynamic_system_create<osp::active::SysExhaustPlume>();
     auto &sysPlanet         = scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
@@ -106,14 +103,14 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     scene.system_machine_create<SysMachineRocket>();
 
     // Make active areas load vehicles and planets
-    sysArea.activator_add(&satVehicle, sysVehicle);
-    sysArea.activator_add(&satPlanet, sysPlanet);
+    sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);
+    sysArea.activator_add(rUni.sat_type_find_index<SatPlanet>(), sysPlanet);
 
     // create a Satellite with an ActiveArea
-    Satellite areaSat = uni.sat_create();
+    Satellite areaSat = rUni.sat_create();
 
     // assign sat as an ActiveArea
-    UCompActiveArea &area = satAA.add_get_ucomp(areaSat);
+    UCompActiveArea &area = SatActiveArea::add_get_ucomp(rUni, areaSat);
 
     // Link ActiveArea to scene using the AreaAssociate
     sysArea.connect(areaSat);

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -251,9 +251,9 @@ void load_a_bunch_of_stuff()
 void register_universe_types()
 {
     osp::universe::Universe &uni = g_osp.get_universe();
-    uni.type_register<osp::universe::SatActiveArea>(uni);
-    uni.type_register<osp::universe::SatVehicle>(uni);
-    uni.type_register<planeta::universe::SatPlanet>(uni);
+    uni.sat_type_register<osp::universe::SatActiveArea>();
+    uni.sat_type_register<osp::universe::SatVehicle>();
+    uni.sat_type_register<planeta::universe::SatPlanet>();
 }
 
 void debug_print_help()
@@ -357,12 +357,16 @@ void debug_print_hier()
 
 void debug_print_sats()
 {
+    using osp::universe::Universe;
     using osp::universe::UCompTransformTraj;
     using osp::universe::UCompType;
 
-    osp::universe::Universe const &universe = g_osp.get_universe();
+    Universe const &rUni = g_osp.get_universe();
 
-    auto const view = universe.get_reg().view<const UCompTransformTraj,
+    std::vector<std::string_view> const& typeSatNames
+            = g_osp.get_universe().sat_type_get_names();
+
+    auto const view = rUni.get_reg().view<const UCompTransformTraj,
                                               const UCompType>();
 
     for (osp::universe::Satellite sat : view)
@@ -373,9 +377,10 @@ void debug_print_sats()
         osp::Vector3s const &pos = posTraj.m_position;
 
         std::cout << "SATELLITE: \"" << posTraj.m_name << "\" \n";
-        if (type.m_type != nullptr)
+        if (type.m_type != osp::universe::TypeSatIndex::Invalid)
         {
-            std::cout << " * Type: " << type.m_type->get_name() << "\n";
+            std::cout << " * Type: " << typeSatNames[size_t(type.m_type)]
+                      << "\n";
         }
 
         if (posTraj.m_trajectory != nullptr)

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -364,7 +364,7 @@ void debug_print_sats()
     Universe const &rUni = g_osp.get_universe();
 
     std::vector<std::string_view> const& typeSatNames
-            = g_osp.get_universe().sat_type_get_names();
+            = rUni.sat_type_get_names();
 
     auto const view = rUni.get_reg().view<const UCompTransformTraj,
                                               const UCompType>();

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -57,8 +57,6 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
     Package &rPkg = ospApp.debug_find_package("lzdb");
 
     // Get the planet system used to create a UCompPlanet
-    SatPlanet &typePlanet = static_cast<planeta::universe::SatPlanet&>(
-            *rUni.sat_type_find("Planet")->second);
 
     // Create trajectory that will make things added to the universe stationary
     auto &stationary = rUni.trajectory_create<TrajStationary>(
@@ -95,7 +93,7 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
             Satellite sat = rUni.sat_create();
 
             // assign sat as a planet
-            UCompPlanet &planet = typePlanet.add_get_ucomp(sat);
+            UCompPlanet &planet = SatPlanet::add_get_ucomp(rUni, sat);
 
             // Create the real world moon
             planet.m_radius = 1.737E+6;

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -92,15 +92,17 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
         {
             Satellite sat = rUni.sat_create();
 
-            // assign sat as a planet
-            UCompPlanet &planet = SatPlanet::add_get_ucomp(rUni, sat);
-
             // Create the real world moon
-            planet.m_radius = 1.737E+6;
-            planet.m_mass = 7.347673E+22;
+            float radius = 1.737E+6;
+            float mass = 7.347673E+22;
 
-            planet.m_resolutionScreenMax = 0.056f;
-            planet.m_resolutionSurfaceMax = 12.0f;
+            float resolutionScreenMax = 0.056f;
+            float resolutionSurfaceMax = 12.0f;
+
+            // assign sat as a planet
+            UCompPlanet &planet = SatPlanet::add_planet(
+                        rUni, sat, radius, mass, resolutionSurfaceMax,
+                        resolutionScreenMax);
 
             auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -53,16 +53,12 @@ using planeta::universe::UCompPlanet;
 
 void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
 {
-    Universe &uni = ospApp.get_universe();
+    Universe &rUni = ospApp.get_universe();
     Package &pkg = ospApp.debug_find_package("lzdb");
 
-    // Get the planet system used to create a UCompPlanet
-    SatPlanet &typePlanet = static_cast<planeta::universe::SatPlanet&>(
-            *uni.sat_type_find("Planet")->second);
-
     // Create trajectory that will make things added to the universe stationary
-    auto &stationary = uni.trajectory_create<TrajStationary>(
-                                        uni, uni.sat_root());
+    auto &stationary = rUni.trajectory_create<TrajStationary>(
+                                        rUni, rUni.sat_root());
 
     // Create 10 random vehicles
     /*for (int i = 0; i < 10; i ++)
@@ -80,8 +76,8 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
     }*/
 
     //Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
-    Satellite sat = testapp::debug_add_part_vehicle(uni, pkg, "Placeholder Mk. I");
-    auto& posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+    Satellite sat = testapp::debug_add_part_vehicle(rUni, pkg, "Placeholder Mk. I");
+    auto& posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_position = osp::Vector3s(22 * 1024l * 5l, 0l, 0l);
     posTraj.m_dirty = true;
     stationary.add(sat);
@@ -93,10 +89,10 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
     {
         for (int z = -0; z < 1; z ++)
         {
-            Satellite sat = uni.sat_create();
+            Satellite sat = rUni.sat_create();
 
             // assign sat as a planet
-            UCompPlanet &planet = typePlanet.add_get_ucomp(sat);
+            UCompPlanet &planet = SatPlanet::add_get_ucomp(rUni, sat);
 
             // Configure planet as a 256m radius sphere of black hole
             planet.m_radius = 256;
@@ -105,7 +101,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
             planet.m_resolutionScreenMax = 0.056f;
             planet.m_resolutionSurfaceMax = 2.0f;
 
-            auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+            auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 
             // space planets 400m apart from each other
             // 1024 units = 1 meter

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -91,15 +91,17 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
         {
             Satellite sat = rUni.sat_create();
 
-            // assign sat as a planet
-            UCompPlanet &planet = SatPlanet::add_get_ucomp(rUni, sat);
-
             // Configure planet as a 256m radius sphere of black hole
-            planet.m_radius = 256;
-            planet.m_mass = 7.03E7 * 99999999; // volume of sphere * density
+            float radius = 256;
+            float mass = 7.03E7 * 99999999; // volume of sphere * density
 
-            planet.m_resolutionScreenMax = 0.056f;
-            planet.m_resolutionSurfaceMax = 2.0f;
+            float resolutionScreenMax = 0.056f;
+            float resolutionSurfaceMax = 2.0f;
+
+            // assign sat as a planet
+            UCompPlanet &planet = SatPlanet::add_planet(
+                        rUni, sat, radius, mass, resolutionSurfaceMax,
+                        resolutionScreenMax);
 
             auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -92,10 +92,8 @@ osp::universe::Satellite testapp::debug_add_deterministic_vehicle(
     auto& posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_name = name;
 
-    // Make it into a vehicle
-
-    UCompVehicle &vehicle = SatVehicle::add_get_ucomp(uni, sat);
-    vehicle.m_blueprint = std::move(depend);
+    // Make the satellite into a vehicle
+    SatVehicle::add_vehicle(uni, sat, std::move(depend));
 
     return sat;
 }
@@ -152,11 +150,8 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
     auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_name = name;
 
-    // Make it into a vehicle
-    UCompVehicle &UCompVehicle = SatVehicle::add_get_ucomp(uni, sat);
-
-    // set the SatVehicle's blueprint to the one just made
-    UCompVehicle.m_blueprint = std::move(depend);
+    // Make the satellite into a vehicle
+    SatVehicle::add_vehicle(uni, sat, std::move(depend));
 
     return sat;
 
@@ -280,11 +275,8 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     auto& posTraj = uni.get_reg().get<osp::universe::UCompTransformTraj>(sat);
     posTraj.m_name = name;
 
-    // Make it into a vehicle
-    osp::universe::UCompVehicle& compVeh = SatVehicle::add_get_ucomp(uni, sat);
-
-    // Set the SatVehicle's blueprint to the one just made
-    compVeh.m_blueprint = std::move(depend);
+    // Make the satellite into a vehicle
+    SatVehicle::add_vehicle(uni, sat, std::move(depend));
 
     return sat;
 }

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -93,10 +93,8 @@ osp::universe::Satellite testapp::debug_add_deterministic_vehicle(
     posTraj.m_name = name;
 
     // Make it into a vehicle
-    auto& typeVehicle = *static_cast<SatVehicle*>(
-            uni.sat_type_find("Vehicle")->second.get());
 
-    UCompVehicle &vehicle = typeVehicle.add_get_ucomp(sat);
+    UCompVehicle &vehicle = SatVehicle::add_get_ucomp(uni, sat);
     vehicle.m_blueprint = std::move(depend);
 
     return sat;
@@ -155,9 +153,7 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
     posTraj.m_name = name;
 
     // Make it into a vehicle
-    auto &typeVehicle = *static_cast<SatVehicle*>(
-            uni.sat_type_find("Vehicle")->second.get());
-    UCompVehicle &UCompVehicle = typeVehicle.add_get_ucomp(sat);
+    UCompVehicle &UCompVehicle = SatVehicle::add_get_ucomp(uni, sat);
 
     // set the SatVehicle's blueprint to the one just made
     UCompVehicle.m_blueprint = std::move(depend);
@@ -285,9 +281,7 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     posTraj.m_name = name;
 
     // Make it into a vehicle
-    auto& typeVehicle = *static_cast<osp::universe::SatVehicle*>(
-        uni.sat_type_find("Vehicle")->second.get());
-    osp::universe::UCompVehicle& compVeh = typeVehicle.add_get_ucomp(sat);
+    osp::universe::UCompVehicle& compVeh = SatVehicle::add_get_ucomp(uni, sat);
 
     // Set the SatVehicle's blueprint to the one just made
     compVeh.m_blueprint = std::move(depend);


### PR DESCRIPTION
Satellites have a type to determine if it's a planet, vehicle, star, or whatever. This is mostly just a hint at what components the Satellite contains. Types can be registered at runtime by initializing `ITypeSatellite`-derived class (see main.cpp `register_universe_types()` function ). Satellites are assigned types by adding a `UCompType` to them, which contains a pointer to an `ITypeSatellite`. Types are separate instances so that they can be added and removed polymorphically; but as it turns out, this is over-complicated and really isn't needed.

If a function needs to create a planet in the universe, it has to know what a planet is. If a function needs to create a vehicle in the universe, it has to know what a vehicle is. There is no point in being able to create a 'something' polymorphically.

This PR will gut much of Universe.h. It removes ITypeSatellite entirely, replacing it with an integer enum class `TypeSatIndex`. The index of a type depends on which types were registered first. The first type ever registered is 0, next type is 1, third is 2, etc...

Many functions had been made static as a result. Obtaining instances of `ITypeSatellite`s through `sat_type_find` is no longer needed. The Sat*.cpp source files are now very empty, but there is a strong possibility that new functions will be added to them. These changes will simply many things needed for the next upcoming PR related to SysAreaAssociate.