### PR TITLE
Procedural inertia

### DIFF
--- a/bin/OSPData/adera/ph_capsule.sturdy.gltf
+++ b/bin/OSPData/adera/ph_capsule.sturdy.gltf
@@ -54,7 +54,7 @@
                     }
                 ],
                 "manufacturer" : "ACME Placeholders",
-                "massdry" : 1000,
+                "massdry" : 1000.0,
                 "name" : "P1-ACE \"holder\" capsule"
             },
             "name" : "part_phCapsule"

--- a/bin/OSPData/adera/ph_engine.sturdy.gltf
+++ b/bin/OSPData/adera/ph_engine.sturdy.gltf
@@ -62,13 +62,14 @@
                 "manufacturer" : "ACME Placeholders",
                 "machines" : [
                     {
-                        "type" : "Rocket"
+                        "type" : "Rocket",
+                        "thrust" : 70000.0
                     },
                     {
                         "type" : "FreeEnergyGenerator"
                     }
                 ],
-                "massdry" : 1000,
+                "massdry" : 1000.0,
                 "name" : "PH-314"
             },
             "name" : "part_phEngine"

--- a/bin/OSPData/adera/ph_fuselage.sturdy.gltf
+++ b/bin/OSPData/adera/ph_fuselage.sturdy.gltf
@@ -60,7 +60,7 @@
                     }
                 ],
                 "manufacturer" : "ACME Placeholders",
-                "massdry" : 100,
+                "massdry" : 5000.0,
                 "name" : "Generic Tank 001b44a"
             },
             "name" : "part_phFuselage"

--- a/bin/OSPData/adera/ph_rcs.sturdy.gltf
+++ b/bin/OSPData/adera/ph_rcs.sturdy.gltf
@@ -62,13 +62,14 @@
                 		"type" : "RCSController"
                 	},
                     {
-                        "type" : "Rocket"
+                        "type" : "Rocket",
+                        "thrust" : 7000.0
                     },
                     {
                         "type" : "FreeEnergyGenerator"
                     }
                 ],
-                "massdry" : 10,
+                "massdry" : 5.0,
                 "name" : "Mk. 0 Placeholder RCS Thruster"
             },
             "name" : "part_phLinRCS"

--- a/bin/OSPData/adera/spamcan.sturdy.gltf
+++ b/bin/OSPData/adera/spamcan.sturdy.gltf
@@ -195,7 +195,8 @@
                         "type" : "UserControl"
                     },
                     {
-                        "type" : "Rocket"
+                        "type" : "Rocket",
+                        "thrust" : 1000.0
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/bin/OSPData/adera/stomper.sturdy.gltf
+++ b/bin/OSPData/adera/stomper.sturdy.gltf
@@ -125,7 +125,8 @@
                         "type" : "UserControl"
                     },
                     {
-                        "type" : "Rocket"
+                        "type" : "Rocket",
+                        "thrust" : 1000.0
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -31,6 +31,7 @@
 
 using namespace adera::active::machines;
 using namespace osp::active;
+using namespace osp;
 using Magnum::Vector3;
 using Magnum::Matrix4;
 
@@ -151,7 +152,8 @@ void SysMachineRCSController::update_controls(ActiveScene& rScene)
     }
 }
 
-Machine& SysMachineRCSController::instantiate(ActiveEnt ent)
+Machine& SysMachineRCSController::instantiate(ActiveEnt ent, PrototypeMachine config,
+    BlueprintMachine settings)
 {
     return m_scene.reg_emplace<MachineRCSController>(ent);
 }

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -26,6 +26,7 @@
 
 #include <osp/Active/SysMachine.h>
 #include <Magnum/Math/Vector3.h>
+#include <osp/Resource/blueprints.h>
 
 namespace adera::active::machines
 {
@@ -58,7 +59,8 @@ public:
      */
     static void update_controls(osp::active::ActiveScene &rScene);
 
-    osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
+    osp::active::Machine& instantiate(osp::active::ActiveEnt ent,
+        osp::PrototypeMachine config, osp::BlueprintMachine settings) override;
 
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -32,6 +32,7 @@
 #include "osp/Resource/AssetImporter.h"
 #include "adera/Shaders/Phong.h"
 #include "adera/Shaders/PlumeShader.h"
+#include "osp/Resource/blueprints.h"
 #include "adera/SysExhaustPlume.h"
 #include "adera/Plume.h"
 #include <Magnum/Trade/MeshData.h>
@@ -112,7 +113,7 @@ void SysMachineRocket::update_physics(ActiveScene& rScene)
             Percent *pPercent = std::get_if<Percent>(pThrottle);
             if (pPercent == nullptr) { continue; }
 
-            float thrustMag = 10.0f; // temporary
+            float thrustMag = machine.m_thrust;
 
             Matrix4 relTransform = pRbAncestor->m_relTransform;
 
@@ -177,10 +178,14 @@ void SysMachineRocket::attach_plume_effect(ActiveEnt ent)
     m_scene.reg_emplace<ACompExhaustPlume>(plumeNode, ent, plumeEffect);
 }
 
-Machine& SysMachineRocket::instantiate(ActiveEnt ent)
+Machine& SysMachineRocket::instantiate(ActiveEnt ent, PrototypeMachine config,
+    BlueprintMachine settings)
 {
+    // Read engine config
+    float thrust = std::get<double>(config.m_config["thrust"]);
+    
     attach_plume_effect(ent);
-    return m_scene.reg_emplace<MachineRocket>(ent);
+    return m_scene.reg_emplace<MachineRocket>(ent, thrust);
 }
 
 Machine& SysMachineRocket::get(ActiveEnt ent)

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -26,6 +26,7 @@
 
 #include <osp/Active/SysMachine.h>
 #include <osp/Active/physics.h>
+#include <osp/Resource/blueprints.h>
 
 namespace adera::active::machines
 {
@@ -63,7 +64,8 @@ public:
      * @param ent The entity that owns the MachineRocket
      * @return The new MachineRocket instance
      */
-    osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
+    osp::active::Machine& instantiate(osp::active::ActiveEnt ent,
+        osp::PrototypeMachine config, osp::BlueprintMachine settings) override;
 
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;
 
@@ -80,7 +82,7 @@ class MachineRocket : public osp::active::Machine
     friend SysMachineRocket;
 
 public:
-    MachineRocket();
+    MachineRocket(float thrust);
     MachineRocket(MachineRocket &&move) noexcept;
     MachineRocket& operator=(MachineRocket&& move) noexcept;
 
@@ -101,12 +103,12 @@ private:
     osp::active::WireInput m_wiThrottle { this, "Throttle" };
 
     osp::active::ActiveEnt m_rigidBody  { entt::null };
+    float m_thrust{0.0f};
 }; // MachineRocket
 
-//-----------------------------------------------------------------------------
-
-inline MachineRocket::MachineRocket()
+inline MachineRocket::MachineRocket(float thrust)
  : Machine(true)
+ , m_thrust(thrust)
 { }
 
 inline MachineRocket::MachineRocket(MachineRocket&& move) noexcept
@@ -115,6 +117,7 @@ inline MachineRocket::MachineRocket(MachineRocket&& move) noexcept
  , m_wiIgnition(this, std::move(move.m_wiIgnition))
  , m_wiThrottle(this, std::move(move.m_wiThrottle))
  , m_rigidBody(std::move(move.m_rigidBody))
+ , m_thrust(std::exchange(move.m_thrust, 0.0f))
 { }
 
 inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
@@ -124,6 +127,7 @@ inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
     m_wiIgnition = { this, std::move(move.m_wiIgnition) };
     m_wiThrottle = { this, std::move(move.m_wiThrottle) };
     m_rigidBody  = std::move(move.m_rigidBody);
+    m_thrust = std::exchange(move.m_thrust, 0.0f);
     return *this;
 }
 

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -140,7 +140,8 @@ void SysMachineUserControl::update_sensor()
 
 
 
-Machine& SysMachineUserControl::instantiate(ActiveEnt ent)
+Machine& SysMachineUserControl::instantiate(ActiveEnt ent,
+    PrototypeMachine config, BlueprintMachine settings)
 {
     return m_scene.reg_emplace<MachineUserControl>(ent);
 }

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -48,7 +48,8 @@ public:
 
     void update_sensor();
 
-    osp::active::Machine& instantiate(osp::active::ActiveEnt ent) override;
+    osp::active::Machine& instantiate(osp::active::ActiveEnt ent,
+        osp::PrototypeMachine config, osp::BlueprintMachine settings) override;
 
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;
 

--- a/src/osp/Active/SysMachine.h
+++ b/src/osp/Active/SysMachine.h
@@ -106,7 +106,8 @@ public:
     virtual ~ISysMachine() = default;
 
     // TODO: make some config an argument
-    virtual Machine& instantiate(ActiveEnt ent) = 0;
+    virtual Machine& instantiate(ActiveEnt ent,
+        PrototypeMachine config, BlueprintMachine settings) = 0;
 
     virtual Machine& get(ActiveEnt ent) = 0;
 };
@@ -123,7 +124,9 @@ public:
     SysMachine(ActiveScene &scene) : m_scene(scene) {}
     ~SysMachine() = default;
 
-    virtual Machine& instantiate(ActiveEnt ent) = 0;
+    virtual Machine& instantiate(ActiveEnt ent, 
+        PrototypeMachine config,
+        BlueprintMachine settings) = 0;
 
 private:
     ActiveScene &m_scene;

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -147,8 +147,8 @@ StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
                 continue;
             }
 
-            // TODO: pass the blueprint configs into this function
-            Machine& machine = sysMachine->second->instantiate(partEntity);
+            BlueprintMachine blueMach;  // TODO unused so far
+            Machine& machine = sysMachine->second->instantiate(partEntity, protoMachine, blueMach);
 
             // Add the machine to the part
             partMachines.m_machines.emplace_back(partEntity, sysMachine);
@@ -213,7 +213,7 @@ StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
     // temporary: make the whole thing a single rigid body
     auto& vehicleBody = scene.reg_emplace<ACompRigidBody_t>(vehicleEnt);
     scene.reg_emplace<ACompCollisionShape>(vehicleEnt,
-        nullptr, ECollisionShape::COMBINED);
+        nullptr, phys::ECollisionShape::COMBINED);
     //scene.dynamic_system_find<SysPhysics>().create_body(vehicleEnt);
 
     return {0, vehicleEnt, true};
@@ -326,7 +326,7 @@ ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
         }
         else if (currentPrototype.m_type == ObjectType::COLLIDER)
         {
-            ACompCollisionShape collision = m_scene.reg_emplace<ACompCollisionShape>(currentEnt);
+            ACompCollisionShape& collision = m_scene.reg_emplace<ACompCollisionShape>(currentEnt);
             const ColliderData& cd = std::get<ColliderData>(currentPrototype.m_objectData);
             collision.m_shape = cd.m_type;
 
@@ -398,7 +398,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                         = m_scene.reg_emplace<ACompRigidBody_t>(islandEnt);
                 auto &islandShape
                         = m_scene.reg_emplace<ACompCollisionShape>(islandEnt);
-                islandShape.m_shape = ECollisionShape::COMBINED;
+                islandShape.m_shape = phys::ECollisionShape::COMBINED;
 
                 auto &vehicleTransform = m_scene.reg_get<ACompTransform>(vehicleEnt);
                 islandTransform.m_transform = vehicleTransform.m_transform;

--- a/src/osp/CommonPhysics.cpp
+++ b/src/osp/CommonPhysics.cpp
@@ -1,0 +1,109 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "CommonPhysics.h"
+
+#include <iostream>
+#include <assert.h>
+
+namespace osp::phys
+{
+
+float col_shape_volume(ECollisionShape shape, Vector3 scale)
+{
+    static constexpr float sc_pi = Magnum::Math::Constants<Magnum::Float>::pi();
+    switch (shape)
+    {
+    case ECollisionShape::NONE:
+        return 0.0f;
+    case ECollisionShape::SPHERE:
+        // Default radius: 1
+        return (4.0f / 3.0f) * sc_pi * scale.x() * scale.x() * scale.x();
+    case ECollisionShape::BOX:
+        // Default width: 2
+        return 2.0f*scale.x() * 2.0f*scale.y() * 2.0f*scale.z();
+    case ECollisionShape::CYLINDER:
+        // Default radius: 1, default height: 2
+        return sc_pi * scale.x() * scale.x() * 2.0f*scale.z();
+    case ECollisionShape::CAPSULE:
+    case ECollisionShape::CONVEX_HULL:
+    case ECollisionShape::TERRAIN:
+    case ECollisionShape::COMBINED:
+    default:
+        std::cout << "Error: unsupported shape for volume calc\n";
+        return 0.0f;
+    }
+}
+
+Matrix3 transform_inertia_tensor(Matrix3 I, float mass, Vector3 translation, Matrix3 rotation)
+{
+    // Apply rotation via similarity transformation
+    I = rotation.transposed() * I * rotation;
+
+    // Translate via tensor generalized parallel axis theorem
+    using Magnum::Math::dot;
+    const Vector3 r = translation;
+    const Matrix3 outerProductR = {r * r.x(), r * r.y(), r * r.z()};
+    const Matrix3 E3 = Matrix3{};
+
+    return I + mass * (dot(r, r) * E3 - outerProductR);
+}
+
+Vector3 collider_inertia_tensor(ECollisionShape shape, Vector3 scale, float mass)
+{
+    switch (shape)
+    {
+    case ECollisionShape::CYLINDER:
+    {
+        // Default cylinder dimensions: radius 1, height 2
+        const float height = 2.0f * scale.z();
+        // If sclY != sclX I will be mad
+        const float radius = scale.x();
+        return cylinder_inertia_tensor(radius, height, mass);
+    }
+    case ECollisionShape::BOX:
+    {
+        // Default box dimensions: 2x2x2
+        const Vector3 dimensions = 2.0f * scale;
+        return cuboid_inertia_tensor(dimensions, mass);
+    }
+    case ECollisionShape::SPHERE:
+    {
+        // Default sphere: radius = 1
+        const Vector3 semiaxes = scale;
+        return ellipsoid_inertia_tensor(semiaxes, mass);
+    }
+    case ECollisionShape::CAPSULE:
+    case ECollisionShape::CONVEX_HULL:
+    case ECollisionShape::TERRAIN:
+    case ECollisionShape::COMBINED:
+    default:
+        std::cout << "ERROR: unknown collision shape\n";
+        assert(false);
+        return Vector3{0.0f};
+    }
+}
+
+} // namespace osp::phys

--- a/src/osp/CommonPhysics.h
+++ b/src/osp/CommonPhysics.h
@@ -1,0 +1,170 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "types.h"
+
+namespace osp::phys
+{
+
+// Formerly PrototypePart
+enum class ECollisionShape : uint8_t
+{
+    NONE = 0,
+    COMBINED = 1,
+    SPHERE = 2,
+    BOX = 3,
+    CAPSULE = 4,
+    CYLINDER = 5,
+    //MESH = 6,
+    CONVEX_HULL = 7,
+    TERRAIN = 8
+};
+
+float col_shape_volume(ECollisionShape shape, Vector3 scale);
+
+// Formerly SysNewton
+/**
+ * Generic rigid body state
+ */
+struct DataRigidBody
+{
+    // Modify these
+    Vector3 m_inertia{1, 1, 1};
+    Vector3 m_netForce{0, 0, 0};
+    Vector3 m_netTorque{0, 0, 0};
+
+    float m_mass{1.0f};
+    Vector3 m_velocity{0, 0, 0};
+    Vector3 m_rotVelocity{0, 0, 0};
+    Vector3 m_centerOfMassOffset{0, 0, 0};
+
+    bool m_colliderDirty{false}; // set true if collider is modified
+};
+
+/**
+ * Transform an inertia tensor
+ *
+ * Transforms an inertia tensor using the parallel axis theorem.
+ * See "Tensor generalization" section on
+ * https://en.wikipedia.org/wiki/Parallel_axis_theorem for more information.
+ *
+ * @param I           [in] The original inertia tensor
+ * @param mass        [in] The total mass of the object
+ * @param translation [in] The translation part of the transformation
+ * @param rotation    [in] The rotation part of the transformation
+ *
+ * @return The transformed inertia tensor
+ */
+Matrix3 transform_inertia_tensor(Matrix3 I, float mass,
+    Vector3 translation, Matrix3 rotation);
+
+/**
+ * Compute the inertia tensor for a collider shape
+ * 
+ * Automatically selects the correct function necessary to compute the inertia
+ * for the given shape
+ * 
+ * @param shape [in] The shape of the collider
+ * @param scale [in] The (x, y, z) scale of the collider
+ * @param mass  [in] The total mass of the collider
+ * 
+ * @return The moment of inertia about the principle axes (x, y, z)
+ */
+Vector3 collider_inertia_tensor(ECollisionShape shape, Vector3 scale, float mass);
+
+/**
+ * Compute the inertia tensor for a cylinder
+ *
+ * Computes the moment of inertia about the principal axes of a cylinder
+ * with specified mass, height, and radius, whose axis of symmetry lies
+ * along the z-axis
+ *
+ * @return The moment of inertia about the 3 principal axes (x, y, z)
+ */
+constexpr Vector3 cylinder_inertia_tensor(float radius, float height, float mass)
+{
+    float r2 = radius * radius;
+    float h2 = height * height;
+    float xx = (1.0f / 12.0f) * (3.0f*r2 + h2);
+    float yy = xx;
+    float zz = r2 / 2.0f;
+
+    return Vector3{mass*xx, mass*yy, mass*zz};
+}
+
+/**
+ * Compute the inertia tensor for a cuboid
+ *
+ * Computes the moment of inertia about the principal axes of a rectangular
+ * prism with specified mass, and dimensions (x, y, z)
+ *
+ * @param dimensions [in] Vector containing x, y, and z dimensions of the box
+ * @param mass [in] mass of the box
+ *
+ * @return The moment of inertia about the 3 principal axes (x, y, z)
+ */
+constexpr Vector3 cuboid_inertia_tensor(const Vector3 dimensions, float mass)
+{
+    float x2 = dimensions.x() * dimensions.x();
+    float y2 = dimensions.y() * dimensions.y();
+    float z2 = dimensions.z() * dimensions.z();
+
+    float xx = y2 + z2;
+    float yy = x2 + z2;
+    float zz = x2 + y2;
+
+    // Pre-multiply constant to avoid non-constexpr operator*(float, Vector3)
+    float c = (1.0f / 12.0f) * mass;
+    return Vector3{c*xx, c*yy, c*zz};
+}
+
+/**
+ * Compute the inertia tensor for an ellipsoid
+ * 
+ * Computes the moment of inertia about the principle axes of an ellipsoid
+ * with specified mass and semiaxes (a, b, c) corresponding to (x, y, z)
+ * 
+ * @param semiaxes [in] The radii of the ellipsoid in the x, y, and z directions
+ * @param mass     [in] Mass of the ellipsoid
+ * 
+ * @return The moment of inertia about the 3 principle axes (x, y, z)
+ */
+constexpr Vector3 ellipsoid_inertia_tensor(const Vector3 semiaxes, float mass)
+{
+    float a2 = semiaxes.x() * semiaxes.x();
+    float b2 = semiaxes.y() * semiaxes.y();
+    float c2 = semiaxes.z() * semiaxes.z();
+
+    float xx = b2 + c2;
+    float yy = a2 + c2;
+    float zz = a2 + b2;
+
+    // Pre-multiply constant to avoid non-constexpr operator*(float, Vector3)
+    float c = (1.0f / 5.0f) * mass;
+    return Vector3{c*xx, c*yy, c*zz};
+}
+
+} // namespace osp::phys

--- a/src/osp/Resource/PrototypePart.h
+++ b/src/osp/Resource/PrototypePart.h
@@ -30,6 +30,7 @@
 #include <variant>
 
 #include "../types.h"
+#include "osp/CommonPhysics.h"
 
 namespace osp
 {
@@ -42,18 +43,6 @@ enum class ObjectType
     //ATTACHMENT  //
 };
 
-enum class ECollisionShape : uint8_t
-{
-    NONE,
-    COMBINED,
-    SPHERE,
-    BOX,
-    CAPSULE,
-    CYLINDER,
-    //MESH,
-    CONVEX_HULL,
-    TERRAIN
-};
 
 //const uint32_t gc_OBJ_MESH      = 1 << 2;
 //const uint32_t gc_OBJ_COLLIDER  = 1 << 3;
@@ -71,7 +60,7 @@ struct DrawableData
 
 struct ColliderData
 {
-    ECollisionShape m_type;
+    phys::ECollisionShape m_type;
     unsigned m_meshData;
 };
 
@@ -100,12 +89,12 @@ struct PrototypeObject
     // Put more OSP-specific data in here
 };
 
+using config_node_t = std::variant<double, int, std::string>;
 
 struct PrototypeMachine
 {
     std::string m_type;
-
-    // TODO: some sort of data
+    std::map<std::string, config_node_t> m_config;
 };
 
 /**

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -155,7 +155,7 @@ void SysPlanetA::debug_create_chunk_collider(osp::active::ActiveEnt ent,
                                              chindex_t chunk)
 {
 
-    using osp::ECollisionShape;
+    using osp::phys::ECollisionShape;
 
     auto &physics = m_scene.dynamic_system_find<SysPhysics_t>();
 


### PR DESCRIPTION
Adds machinery to procedurally compute moments of inertia. This is more difficult than procedurally computing center of mass, because a point-model of the vessel is insufficient to model it properly; the volume of parts needs to be considered for realistic physics. A decent way of doing this quickly (and in general, if some potential pitfalls are accounted for) is to approximate the mass distribution of parts by spreading their mass evenly over their collider volume, which is what this PR adds.

To compliment these changes, I've also added sturdy-defined engine thrusts. I know there is a more complicated system developed in the past, but this will suffice for now.

Changelog:

* Added realistic masses, engine thrusts to part sturdies [part files]
* Updated PrototypeMachine, which stores a map of config values (e.g. thrust, for an engine)
* AssetImporter reads in arbitrary machine config data; properly discriminates between collider types. Collider shapes don't yet work for actual collisions, but are used for inertia calculations
* SysNewton received a bunch of new functions for calculating inertia. `compute_body_inertia()` calculates the inertia for a whole rigidbody by calling `compute_part_inertia()` to compute the inertia of each part.
* New CommonPhysics files contain helper functions used to calculate the inertia tensors of collision shapes, and transform the results to compute composite inertias
* SysMachine::instantiate now accepts a `PrototypeMachine` and `BlueprintMachine` argument, which are used during instantiation to configure the machine settings/parameters [See SysMachine]
* SysVehicle, SysUserControl, SysMachineRocket updated to comply with the above, although only SysMachineRocket leverages it (the peak engine thrust is now a constructor parameter) [See  `SysMachineRocket::instantiate`]
* Added convenient `ActiveScene::reg_try_get()` equivalent to `reg_get()` so that we don't have to always call `rScene.get_registry().try_get<>()`


Since some of the physics stuff went into CommonPhysics and the new `osp::phys` namespace, there are a bunch of random changes scattered about; sorry about that.

The main changes take place in PrototypePart.cpp, AssetImporter.cpp, and SysNewton.h/.cpp; the rest of the changes are simply updating `instantiate()` functions, and changing Rocket.h/.cpp to now accept and store a thrust parameter.