### PR TITLE
Add ShipResources

### DIFF
--- a/src/adera/ShipResources.cpp
+++ b/src/adera/ShipResources.cpp
@@ -1,0 +1,119 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "ShipResources.h"
+#include "osp/Active/ActiveScene.h"
+
+using namespace osp;
+using namespace osp::active;
+using namespace adera::active::machines;
+
+/* MachineContainer */
+
+void MachineContainer::propagate_output(WireOutput* output)
+{
+
+}
+
+WireInput* MachineContainer::request_input(WireInPort port)
+{
+    return nullptr;
+}
+
+WireOutput* MachineContainer::request_output(WireOutPort port)
+{
+    return nullptr;
+}
+
+std::vector<WireInput*> MachineContainer::existing_inputs()
+{
+    return m_inputs;
+}
+
+std::vector<WireOutput*> MachineContainer::existing_outputs()
+{
+    return m_outputs;
+}
+
+/* SysMachineContainer */
+
+SysMachineContainer::SysMachineContainer(ActiveScene& rScene)
+    : SysMachine<SysMachineContainer, MachineContainer>(rScene)
+    , m_updateContainers(rScene.get_update_order(), "mach_container", "", "mach_rocket",
+        [this](ActiveScene& rScene) { this->update_containers(rScene); })
+{ }
+
+void SysMachineContainer::update_containers(ActiveScene& rScene)
+{
+    auto view = rScene.get_registry().view<MachineContainer>();
+
+    for (ActiveEnt ent : view)
+    {
+        auto& container = view.get<MachineContainer>(ent);
+
+        // Do something useful here... or not
+    }
+}
+
+float SysMachineContainer::resource_volume(ShipResourceType type, uint64_t quantity)
+{
+    uint64_t units = quantity / (1ull << type.m_quanta);
+    return static_cast<float>(units) * type.m_volume;
+}
+
+float SysMachineContainer::resource_mass(ShipResourceType type, uint64_t quantity)
+{
+    uint64_t units = quantity / (1ull << type.m_quanta);
+    return static_cast<float>(units) * type.m_mass;
+}
+
+uint64_t SysMachineContainer::resource_capacity(ShipResourceType type, float volume)
+{
+    double units = volume / type.m_volume;
+    double quantaPerUnit = static_cast<double>(1ull << type.m_quanta);
+    return static_cast<uint64_t>(units * quantaPerUnit);
+}
+
+Machine& SysMachineContainer::instantiate(ActiveEnt ent,
+    PrototypeMachine config, BlueprintMachine settings)
+{
+    float capacity = std::get<double>(config.m_config["capacity"]);
+    
+    // Currently disconnected; will be updated when BlueprintMachine is implemented
+    //std::string resName = std::get<std::string>(settings.m_config["resourcename"]);
+    std::string_view resName = "";
+    Path resPath = decompose_path(resName);
+    Package& pkg = m_scene.get_application().debug_find_package(resPath.prefix);
+
+    ShipResource resource;
+    resource.m_type = pkg.get<ShipResourceType>(resPath.identifier);
+    resource.m_quantity = resource_capacity(*resource.m_type, capacity);
+
+    return m_scene.reg_emplace<MachineContainer>(ent, capacity, resource);
+}
+
+Machine& SysMachineContainer::get(ActiveEnt ent)
+{
+    return m_scene.reg_get<MachineContainer>(ent);
+}

--- a/src/adera/ShipResources.h
+++ b/src/adera/ShipResources.h
@@ -1,0 +1,175 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+#include <string>
+
+#include "osp/Resource/Resource.h"
+#include "osp/Active/SysMachine.h"
+
+namespace adera::active::machines
+{
+
+/**
+ * Represents a type of consumable ship resource
+ *
+ * Resources might be quantized differently depending on the rate at which
+ * they're consumed. This system allows this quantization to be configured
+ * per-resource. Resources will be represented by 64-bit integers to maximize
+ * the available precision to avoid infinite-fuel exploits.
+ * The 64-bit range is divided into two sections by an arbitrary choice of unit.
+ *
+ * A resource is specified by a volume, a mass, and a "quanta" value. The
+ * "quanta" value specifies the number of bits that represents the volume
+ * of resource in the definition. This volume is divided into (2^quanta)
+ * pieces, making 1/(2^quanta) the smallest representable quantity of the
+ * resource. The remaining (64-quanta) bits of precision represent tank
+ * capacity.
+ *
+ * Example resource:
+ * identifier: lox
+ * name: Liquid Oxygen
+ * quanta: 16
+ * mass: 1141.0 (kg) (per 2^quanta)
+ * volume: 1.0 (m^3) (per 2^quanta)
+ *
+ * The smallest representable quantity is unit/(2^quanta), which in this case is:
+ * volume: (1.0 m^3)/(2^16) = 1.5e-5 m^3 (15.2 mL)
+ * or mass: (1141.0 kg)/(2^16) = 0.017 kg (17.4 g)
+ *
+ * A fuel tank with volume 10 m^3 would thus store 655360 units of LOx. With 16
+ * bits dedicated to the subdivision of 1.0 m^3 of LOx, the remaining 48 bits can
+ * represent a maximum fuel capacity up to 281474976710656 m^3 (321 Teratons) of
+ * LOx. If you need to store a volume larger than this, we suggest you
+ * reevaluate the design of your vessel.
+ *
+ * In contrast, a theoretical fuel with incredible energy density may only
+ * be burned at a rate of micrograms per minute. With a quanta of 32 (and a base
+ * volume unit of 1 m^3 as before), value of (1.0 m^3)*2e-10 may be represented,
+ * with the tradeoff that the remaining 32 bits of precision may represent
+ * "only" 4294967292 m^3.
+ *
+ */
+struct ShipResourceType
+{
+    // A short, unique, identifying name readable by both human and machine
+    std::string m_identifier;
+
+    // The full, screen-display name of the resource
+    std::string m_displayName;
+
+    // 1/(2^quanta) is the smallest representable quantity of this resource
+    uint8_t m_quanta;
+
+    // The mass (in kg) of 2^quanta units of this resource
+    float m_mass;
+
+    // The volume (in m^3) of 2^quanta units of this resource
+    float m_volume;
+
+    // The density of this resource (kg/m^3)
+    float m_density;
+};
+
+struct ShipResource
+{
+    osp::DependRes<ShipResourceType> m_type;
+    uint64_t m_quantity;
+};
+
+class MachineContainer;
+
+class SysMachineContainer
+    : public osp::active::SysMachine<SysMachineContainer, MachineContainer>
+{
+public:
+    SysMachineContainer(osp::active::ActiveScene& rScene);
+
+    static void update_containers(osp::active::ActiveScene& rScene);
+
+    static float resource_volume(ShipResourceType type, uint64_t quantity);
+    static float resource_mass(ShipResourceType type, uint64_t quantity);
+    static uint64_t resource_capacity(ShipResourceType type, float volume);
+
+    osp::active::Machine& instantiate(
+        osp::active::ActiveEnt ent,
+        osp::PrototypeMachine config,
+        osp::BlueprintMachine settings) override;
+
+    osp::active::Machine& get(osp::active::ActiveEnt ent) override;
+
+private:
+    
+    osp::active::UpdateOrderHandle_t m_updateContainers;
+}; // class SysMachineContainer
+
+class MachineContainer : public osp::active::Machine
+{
+    friend SysMachineContainer;
+
+public:
+    MachineContainer(float capacity, ShipResource resource);
+    MachineContainer(MachineContainer&& move) noexcept;
+    MachineContainer& operator=(MachineContainer&& move) noexcept;
+    ~MachineContainer() = default;
+
+    void propagate_output(osp::active::WireOutput *output) override;
+
+    osp::active::WireInput* request_input(osp::WireInPort port) override;
+    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
+
+    std::vector<osp::active::WireInput*> existing_inputs() override;
+    std::vector<osp::active::WireOutput*> existing_outputs() override;
+
+private:
+    std::vector<osp::active::WireInput*> m_inputs;
+    std::vector<osp::active::WireOutput*> m_outputs;
+
+    float m_capacity;
+    ShipResource m_contents;
+}; // class MachineContainer
+
+/* MachineContainer */
+inline MachineContainer::MachineContainer(float capacity, ShipResource resource)
+    : Machine(true)
+    , m_capacity(capacity)
+    , m_contents(resource)
+{}
+
+inline MachineContainer::MachineContainer(MachineContainer&& move) noexcept
+    : Machine(std::move(move))
+    , m_capacity(std::move(move.m_capacity))
+    , m_contents(std::move(move.m_contents))
+{}
+
+inline MachineContainer& MachineContainer::operator=(MachineContainer&& move) noexcept
+{
+    m_enable = move.m_enable;
+    m_capacity = move.m_capacity;
+    m_contents = std::move(move.m_contents);
+    
+    return *this;
+}
+
+} // namespace adera::active::machines


### PR DESCRIPTION
"Adds a number of tools for storing and handling consumable on-ship
resources such as fuel, battery charge, etc. ShipResourceType provides a
definition for a specific type of resource and how it's stored
numerically (resource quantities will be represented by 64-bit unsigned
integers; see comments in source for detail). MachineContainer will
represent a container to store such resources."
---
None of this is implemented anywhere in the codebase yet, but I figured I'd split it into its own PR since the next one is going to be kind of large, and get some preliminary feedback. We discussed the underlying data representation a while back. This code will change a bit with the coming PR so if something looks out of place it will either be changed later or I can change it in the next PR.