### PR TITLE
Per-object machines, minimally functional fuel consumption

### DIFF
--- a/bin/OSPData/adera/ph_engine.sturdy.gltf
+++ b/bin/OSPData/adera/ph_engine.sturdy.gltf
@@ -63,7 +63,9 @@
                 "machines" : [
                     {
                         "type" : "Rocket",
-                        "thrust" : 70000.0
+                        "thrust" : 70000.0,
+                        "Isp" : 310.0,
+                        "fuel" : "lzdb:fuel"
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/bin/OSPData/adera/ph_fuselage.sturdy.gltf
+++ b/bin/OSPData/adera/ph_fuselage.sturdy.gltf
@@ -8,7 +8,7 @@
         {
             "name" : "Scene",
             "nodes" : [
-                4
+                6
             ]
         }
     ],
@@ -45,23 +45,69 @@
             "name" : "fuselage"
         },
         {
+            "extras" : {
+                "machines" : [
+                    {
+                        "type" : "Container",
+                        "storagetype" : "liquid",
+                        "capacity" : 9.927
+                    }
+                ]
+            },
+            "name" : "tank_lox",
+            "scale" : [
+                1,
+                1,
+                1.5812300443649292
+            ],
+            "translation" : [
+                0,
+                0,
+                -0.8666941523551941
+            ]
+        },
+        {
+            "extras" : {
+                "machines" : [
+                    {
+                        "type" : "Container",
+                        "storagetype" : "liquid",
+                        "capacity" : 5.45
+                    }
+                ]
+            },
+            "name" : "tank_rp1",
+            "scale" : [
+                1,
+                1,
+                0.8682799935340881
+            ],
+            "translation" : [
+                0,
+                0,
+                1.602536678314209
+            ]
+        },
+        {
             "children" : [
                 0,
                 1,
                 2,
-                3
+                3,
+                4,
+                5
             ],
             "extras" : {
                 "country" : "Placeholderland",
                 "description" : "A placeholder fuel tank",
+                "manufacturer" : "ACME Placeholders",
                 "machines" : [
                     {
                         "type" : "FreeEnergyGenerator"
                     }
                 ],
-                "manufacturer" : "ACME Placeholders",
-                "massdry" : 5000.0,
-                "name" : "Generic Tank 001b44a"
+                "name" : "Generic Tank 001b44a",
+                "massdry" : 200
             },
             "name" : "part_phFuselage"
         }

--- a/bin/OSPData/adera/ph_rcs.sturdy.gltf
+++ b/bin/OSPData/adera/ph_rcs.sturdy.gltf
@@ -63,7 +63,9 @@
                 	},
                     {
                         "type" : "Rocket",
-                        "thrust" : 7000.0
+                        "thrust" : 1000.0,
+                        "Isp" : 225.0,
+                        "fuel" : "lzdb:monoprop"
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/src/osp/PhysicsConstants.h
+++ b/src/osp/PhysicsConstants.h
@@ -1,0 +1,32 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+namespace osp::phys::constants
+{
+
+constexpr float g_0 = 9.80665f;
+
+} // namespace osp::phys

--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -91,6 +91,26 @@ public:
     static DependRes<Magnum::GL::Texture2D> compile_tex(
         std::string_view imageDataName, Package& srcPackage, Package& dstPackage);
 private:
+
+    /**
+     * Load machines from node extras
+     * 
+     * Each node in the glTF tree may possess machines, but only the root
+     * PrototypePart stores them. The PrototypePart's machineArray is passed,
+     * alongside the current node (object)'s machineIndexArray.
+     * PrototypeMachines are added to the PrototypePart's master list, and the
+     * index of each machine is added to the machineIndexArray so that the
+     * current node/object can keep track of which machines belong to it.
+     *
+     * @param extras            [in] An extras node from a glTF file
+     * @param machineArray      [out] A machine array from a PrototypePart
+     * 
+     * @return A machineIndexArray which is used by PrototypeObjects to store
+     * the indices of the machineArray elements which belong to it
+     */
+    static std::vector<unsigned> load_machines(tinygltf::Value const& extras,
+        std::vector<PrototypeMachine>& machineArray);
+
     /**
      * Load only associated config files, and add resource paths to the package
      * But for now, this function just loads everything.

--- a/src/osp/Resource/PrototypePart.h
+++ b/src/osp/Resource/PrototypePart.h
@@ -87,6 +87,8 @@ struct PrototypeObject
     std::variant<DrawableData, ColliderData> m_objectData;
 
     // Put more OSP-specific data in here
+
+    std::vector<unsigned> m_machineIndices;
 };
 
 using config_node_t = std::variant<double, int, std::string>;

--- a/src/osp/Resource/blueprints.cpp
+++ b/src/osp/Resource/blueprints.cpp
@@ -27,7 +27,7 @@
 
 using namespace osp;
 
-void BlueprintVehicle::add_part(
+BlueprintPart& BlueprintVehicle::add_part(
         DependRes<PrototypePart>& prototype,
         const Vector3& translation,
         const Quaternion& rotation,
@@ -56,12 +56,23 @@ void BlueprintVehicle::add_part(
 
     // now we have a part index.
 
-    // just create a new part blueprint will all the data
+    // Create and default initialize object blueprint machines
+    size_t numMachines = prototype->get_machines().size();
+    std::vector<BlueprintMachine> machineBPs;
+    machineBPs.resize(numMachines);
 
-    BlueprintPart blueprint{partIndex, translation, rotation, scale};
+    BlueprintPart blueprint
+    {
+        partIndex,
+        translation,
+        rotation,
+        scale,
+        std::move(machineBPs)
+    };
 
     m_blueprints.push_back(std::move(blueprint));
 
+    return m_blueprints.back();
 }
 
 void BlueprintVehicle::add_wire(

--- a/src/osp/Resource/blueprints.h
+++ b/src/osp/Resource/blueprints.h
@@ -35,6 +35,12 @@ namespace osp
 using WireInPort = uint16_t;
 using WireOutPort = uint16_t;
 
+struct BlueprintMachine
+{
+    // TODO specific settings for a machine
+    std::map<std::string, config_node_t> m_config;
+};
+
 /**
  * Specific information on a part in a vehicle:
  * * Which kind of part
@@ -52,6 +58,8 @@ struct BlueprintPart
 
     // put some sort of config here
 
+    // Configuration of individual machines
+    std::vector<BlueprintMachine> m_machines;
 };
 
 /**
@@ -80,11 +88,6 @@ struct BlueprintWire
     WireInPort m_toPort;
 };
 
-struct BlueprintMachine
-{
-    // TODO specific settings for a machine
-};
-
 /**
  * Specific information on a vehicle
  * * List of part blueprints
@@ -106,8 +109,9 @@ public:
      * @param translation
      * @param rotation
      * @param scale
+     * @return Resulting blueprint part
      */
-    void add_part(DependRes<PrototypePart>& part,
+    BlueprintPart& add_part(DependRes<PrototypePart>& part,
                   const Vector3& translation,
                   const Quaternion& rotation,
                   const Vector3& scale);
@@ -122,9 +126,9 @@ public:
      * @param toPort
      */
     void add_wire(unsigned fromPart, unsigned fromMachine, WireOutPort fromPort,
-                  unsigned toPart, unsigned toMachine, WireOutPort toPort);
+                  unsigned toPart, unsigned toMachine, WireInPort toPort);
 
-    constexpr std::vector<DependRes<PrototypePart> >& get_prototypes()
+    constexpr std::vector<DependRes<PrototypePart>>& get_prototypes()
     { return m_prototypes; }
 
     constexpr std::vector<BlueprintPart>& get_blueprints()
@@ -135,7 +139,7 @@ public:
 
 private:
     // Unique part Resources used
-    std::vector<DependRes<PrototypePart> > m_prototypes;
+    std::vector<DependRes<PrototypePart>> m_prototypes;
 
     // Arrangement of Individual Parts
     std::vector<BlueprintPart> m_blueprints;

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -38,6 +38,7 @@
 #include <adera/Machines/UserControl.h>
 #include <adera/Machines/Rocket.h>
 #include <adera/Machines/RCSController.h>
+#include <adera/ShipResources.h>
 
 #include <planet-a/Active/SysPlanetA.h>
 #include <planet-a/Satellites/SatPlanet.h>
@@ -69,6 +70,7 @@ using osp::active::ACompFloatingOrigin;
 using adera::active::machines::SysMachineUserControl;
 using adera::active::machines::SysMachineRocket;
 using adera::active::machines::SysMachineRCSController;
+using adera::active::machines::SysMachineContainer;
 
 using planeta::universe::SatPlanet;
 
@@ -104,6 +106,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     scene.system_machine_create<SysMachineUserControl>(pMagnumApp->get_input_handler());
     scene.system_machine_create<SysMachineRocket>();
     scene.system_machine_create<SysMachineRCSController>();
+    scene.system_machine_create<SysMachineContainer>();
 
     // Make active areas load vehicles and planets
     //sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -216,8 +216,11 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     Quaternion rotZ_270 = Quaternion::rotation(3 * qtrTurn, Vector3{0, 0, 1});
 
     blueprint.add_part(capsule, Vector3{0}, idRot, scl);
-    blueprint.add_part(fuselage, cfOset, idRot, scl);
-    blueprint.add_part(engine, cfOset + feOset, idRot, scl);
+
+    auto& fuselageBP = blueprint.add_part(fuselage, cfOset, idRot, scl);
+    fuselageBP.m_machines[1].m_config.emplace("resourcename", "lzdb:fuel");
+
+    auto& engBP = blueprint.add_part(engine, cfOset + feOset, idRot, scl);
 
     Quaternion yz090 = rotZ_090 * rotY_090;
     Quaternion yz180 = rotZ_180 * rotY_090;


### PR DESCRIPTION
This one makes up for the last PR, now you see why I split it into two :)

At a high level, the changes primarily add the ability for machines to be owned by non-part objects. The new `PrototypeObject::m_machineIndices` array allows a PrototypeObject to keep track of the machines it owns. When a PrototypeObject is created in `AssetImporter::proto_add_obj_recurse()`, its machines are loaded by `AssetImporter::load_machines()`. This function takes a reference to the ProtoObject's index array, and the parent PrototypePart's machine array. PrototypeMachines are added to the PrototypePart's master list, and the indices of the machines populate the PrototypeObject's index array. When a part is instantiated in `SysVehicle::activate_sat()`, the `SysVehicle::part_instantiate()` function creates an array of objects which track the relationships between the new object `ActiveEnt`s and the PrototypePart's machine array, since the PrototypePart and PrototypeObject information is discarded once the entities have been loaded into the scene. A new function `SysVehicle::part_instantiate_machines()` takes this array, and uses it to add the appropriate machines to the various entities in the scene. This deferred action is necessary because machines may depend on the entire part's subhierarchy existing; the example given in the code is how `MachineRocket` needs the plume effect node to exist when it's instantiated.

The rest of the stuff is just a quick way of adding functional fuel consumption to `MachineRocket`. It's handled by an ugly and hardcoded solution right now (hardcoded tank ID, storing tank entity ID as `MachineRocket` member). This will change in the next PR, which generalized everything with a new "Pipe" wire type. If it's unacceptable to do the hardcoding (it currently renders the "moon" scene vessels immobile) I can include the next few commits in this PR as well, but it's already a large amount of code and making the PR 70% larger is going to suck.

The current functionality is basically that the 10m^3 fuselage tank is used to store a generic "fuel" which is drained by the rocket engines. When the fuel is depleted the engines cease to provide thrust, although the plumes keep working. The next PR will smooth out this proof of concept into a generalized system.