### PR TITLE
Rework SysAreaAssociate

### DIFF
--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -121,12 +121,14 @@ void ActiveScene::hier_set_parent_child(ActiveEnt parent, ActiveEnt child)
 
 void ActiveScene::hier_destroy(ActiveEnt ent)
 {
-    auto &entHier = m_registry.get<ACompHierarchy>(ent);
+    auto *pEntHier = &m_registry.get<ACompHierarchy>(ent);
 
-    // recurse into children. this can be optimized more but i'm lazy
-    while (entHier.m_childCount)
+    // Destroy children first recursively, if there is any
+    while (pEntHier->m_childCount > 0)
     {
-        hier_destroy(entHier.m_childFirst);
+        hier_destroy(pEntHier->m_childFirst);
+        // previous hier_destroy might have caused a reallocation
+        pEntHier = m_registry.try_get<ACompHierarchy>(ent);
     }
 
     hier_cut(ent);

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -26,18 +26,22 @@
 
 #include "ActiveScene.h"
 
+using osp::active::SysAreaAssociate;
 
-using namespace osp::universe;
-using namespace osp::active;
-using namespace osp;
+using osp::active::ACompAreaLink;
+
+using osp::universe::Universe;
+using osp::universe::Satellite;
+
+using osp::universe::UCompActivatable;
+using osp::universe::UCompActivationRadius;
+using osp::universe::UCompActiveArea;
 
 const std::string SysAreaAssociate::smc_name = "AreaAssociate";
 
-SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene, Universe &uni)
- : m_scene(rScene)
- , m_universe(uni)
- , m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
-                [this] (ActiveScene& rScene) { this->update_scan(rScene); })
+SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene)
+ : m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
+                &SysAreaAssociate::update_scan)
 {
 
 }
@@ -46,17 +50,37 @@ void SysAreaAssociate::update_scan(ActiveScene& rScene)
 {
     // scan for nearby satellites, maybe move this somewhere else some day
 
-    if (!m_universe.get_reg().valid(m_areaSat))
+    ACompAreaLink *pArea = try_get_area_link(rScene);
+
+    if (pArea == nullptr)
     {
         return;
     }
 
-    //Universe& uni = m_universe;
-    //std::vector<Satellite>& satellites = uni.
-    auto view = m_universe.get_reg().view<UCompActivatable>();
+    Universe &rUni = pArea->m_rUniverse;
+    Satellite areaSat = pArea->m_areaSat;
 
-    for (Satellite sat : view)
+    auto &areaUComp = rUni.get_reg().get<UCompActiveArea>(areaSat);
+
+    auto viewActRadius = rUni.get_reg().view<UCompActivationRadius,
+                                             UCompActivatable>();
+
+    for (Satellite sat : viewActRadius)
     {
+        auto satRadius = viewActRadius.get<UCompActivationRadius>(sat);
+
+        float distSqr = rUni.sat_calc_pos_meters(areaSat, sat).dot();
+        float radius = areaUComp.m_areaRadius + satRadius.m_radius;
+
+        if ((radius * radius) > distSqr)
+        {
+            std::cout << "nearby!\n";
+        }
+
+    }
+
+    //for (Satellite sat : view)
+    //{
 //        if (SatelliteObject* obj = sat.get_object())
 //        {
 //            //std::cout << "obj: " << obj->get_id().m_name
@@ -101,171 +125,105 @@ void SysAreaAssociate::update_scan(ActiveScene& rScene)
 
         // Satellite is near! Attempt to load it
 
-        sat_activate(sat);
-    }
+        //sat_activate(sat);
+    //}
 
 }
 
-void SysAreaAssociate::connect(universe::Satellite sat)
+ACompAreaLink* SysAreaAssociate::try_get_area_link(ActiveScene &rScene)
 {
-    // do more stuff here eventually
-    m_areaSat = sat;
+    return rScene.get_registry().try_get<ACompAreaLink>(rScene.hier_get_root());
 }
 
-void SysAreaAssociate::disconnect()
+void SysAreaAssociate::connect(ActiveScene& rScene, universe::Universe &rUni,
+                               universe::Satellite areaSat)
 {
-    if (!m_activatedSats.empty())
-    {
-        // De-activate all satellites
+    ActiveEnt root = rScene.hier_get_root();
 
-        auto viewAct = m_scene.get_registry().view<ACompActivatedSat>();
+    // Make sure no ACompAreaLink already exists
+    assert(!rScene.get_registry().has<ACompAreaLink>(root));
 
-        for (ActiveEnt ent : viewAct)
-        {
-            sat_deactivate(ent, viewAct.get(ent));
-        }
+    // Create Area Link
+    auto &areaLink = rScene.get_registry().emplace<ACompAreaLink>(root, rUni,
+                                                                  areaSat);
+}
 
+void SysAreaAssociate::disconnect(ActiveScene& rScene)
+{
+//    if (!m_activatedSats.empty())
+//    {
+//        // De-activate all satellites
 
-    }
+//        auto viewAct = m_scene.get_registry().view<ACompActivatedSat>();
 
-    m_areaSat = entt::null;
+//        for (ActiveEnt ent : viewAct)
+//        {
+//            sat_deactivate(ent, viewAct.get(ent));
+//        }
+
+//    }
+
+//    m_areaSat = entt::null;
 }
 
 void SysAreaAssociate::area_move(Vector3s translate)
 {
-    auto &areaPosTraj = m_universe.get_reg()
-            .get<universe::UCompTransformTraj>(m_areaSat);
+//    auto &areaPosTraj = m_universe.get_reg()
+//            .get<universe::UCompTransformTraj>(m_areaSat);
 
-    areaPosTraj.m_position += translate;
+//    areaPosTraj.m_position += translate;
 
-    Vector3 meters = Vector3(translate) / gc_units_per_meter;
+//    Vector3 meters = Vector3(translate) / gc_units_per_meter;
 
-    floating_origin_translate(-meters);
+//    floating_origin_translate(-meters);
 }
 
 void SysAreaAssociate::sat_transform_update(ActiveEnt ent)
 {
-    auto const &entAct = m_scene.reg_get<ACompActivatedSat>(ent);
-    auto const &entTransform = m_scene.reg_get<ACompTransform>(ent);
+//    auto const &entAct = m_scene.reg_get<ACompActivatedSat>(ent);
+//    auto const &entTransform = m_scene.reg_get<ACompTransform>(ent);
 
-    Satellite sat = entAct.m_sat;
-    auto &satPosTraj = m_universe.get_reg()
-            .get<universe::UCompTransformTraj>(sat);
+//    Satellite sat = entAct.m_sat;
+//    auto &satPosTraj = m_universe.get_reg()
+//            .get<universe::UCompTransformTraj>(sat);
 
-    auto const &areaPosTraj = m_universe.get_reg()
-            .get<universe::UCompTransformTraj>(m_areaSat);
+//    auto const &areaPosTraj = m_universe.get_reg()
+//            .get<universe::UCompTransformTraj>(m_areaSat);
 
-    // 1024 units = 1 meter
-    Vector3s posAreaRelative(entTransform.m_transform.translation()
-                             * gc_units_per_meter);
+//    // 1024 units = 1 meter
+//    Vector3s posAreaRelative(entTransform.m_transform.translation()
+//                             * gc_units_per_meter);
 
 
 
-    satPosTraj.m_position = areaPosTraj.m_position + posAreaRelative;
-    satPosTraj.m_rotation = Quaternion::
-            fromMatrix(entTransform.m_transform.rotationScaling());
-    satPosTraj.m_dirty = true;
+//    satPosTraj.m_position = areaPosTraj.m_position + posAreaRelative;
+//    satPosTraj.m_rotation = Quaternion::
+//            fromMatrix(entTransform.m_transform.rotationScaling());
+//    satPosTraj.m_dirty = true;
 }
-
-void SysAreaAssociate::activator_add(TypeSatIndex type,
-                                     IActivator &activator)
-{
-    m_activators[type] = &activator;
-}
-
 
 void SysAreaAssociate::floating_origin_translate(Vector3 translation)
 {
-    auto view = m_scene.get_registry()
-            .view<ACompFloatingOrigin, ACompTransform>();
+//    auto view = m_scene.get_registry()
+//            .view<ACompFloatingOrigin, ACompTransform>();
 
-    for (ActiveEnt ent : view)
-    {
-        auto &entTransform = view.get<ACompTransform>(ent);
-        //auto &entFloatingOrigin = view.get<ACompFloatingOrigin>(ent);
+//    for (ActiveEnt ent : view)
+//    {
+//        auto &entTransform = view.get<ACompTransform>(ent);
+//        //auto &entFloatingOrigin = view.get<ACompFloatingOrigin>(ent);
 
-        if (entTransform.m_controlled)
-        {
-            if (!entTransform.m_mutable)
-            {
-                continue;
-            }
+//        if (entTransform.m_controlled)
+//        {
+//            if (!entTransform.m_mutable)
+//            {
+//                continue;
+//            }
 
-            entTransform.m_transformDirty = true;
-        }
+//            entTransform.m_transformDirty = true;
+//        }
 
-        entTransform.m_transform.translation() += translation;
-    }
+//        entTransform.m_transform.translation() += translation;
+//    }
 }
 
-
-int SysAreaAssociate::sat_activate(universe::Satellite sat)
-{
-
-    if (m_activatedSats.find(sat) != m_activatedSats.end())
-    {
-        // satellite already loaded
-        return 1;
-    }
-
-    auto &ureg = m_universe.get_reg();
-
-    auto &satType = ureg.get<UCompType>(sat);
-
-    //auto &areaSatAA = reg.get<UCompType>(m_areaSat);
-
-    // see if there's a loading function for the satellite object
-    auto funcMapIt =  m_activators.find(satType.m_type);
-
-    if(funcMapIt == m_activators.end())
-    {
-        // no loading function exists for this satellite object type
-        return -1;
-    }
-
-    //(ActiveScene& scene, osp::universe::SatActiveArea& area,
-    //                universe::Satellite areaSat, universe::Satellite loadMe
-
-    // Get activator and call the activate function
-    IActivator *activator = funcMapIt->second;
-    StatusActivated status
-            = activator->activate_sat(m_scene, *this, m_areaSat, sat);
-
-    if (status.m_status)
-    {
-        // Load failed
-        return status.m_status;
-    }
-
-    // Load success
-
-    // Add the activated satellite component
-    auto &activated = m_scene.reg_emplace<ACompActivatedSat>(status.m_entity);
-
-    activated.m_sat = sat;
-    activated.m_activator = funcMapIt;
-    activated.m_mutable = status.m_mutable;
-
-    //sat.set_loader(m_sat->get_object());
-    m_activatedSats.emplace(sat);
-
-    return 0;
-}
-
-int SysAreaAssociate::sat_deactivate(ActiveEnt ent, ACompActivatedSat& entAct)
-{
-    IActivator *activator = entAct.m_activator->second;
-
-    // this should never happen
-    if (!m_activatedSats.contains(entAct.m_sat))
-    {
-        return 1;
-    }
-
-    activator->deactivate_sat(m_scene, *this, m_areaSat, entAct.m_sat, ent);
-
-    m_activatedSats.erase(entAct.m_sat);
-
-    return 0;
-}
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -34,39 +34,47 @@
 namespace osp::active
 {
 
-class SysAreaAssociate;
-struct ACompActivatedSat;
-
-struct StatusActivated
+struct ActivateSatellites
 {
-    int m_status; // 0 for no errors
-    ActiveEnt m_entity;
-    bool m_mutable;
+    using MapSatToEnt_t = std::unordered_map<universe::Satellite, ActiveEnt>;
+    // Satellites that are currently inside the active area
+    //std::unordered_set<universe::Satellite> m_inside;
+    MapSatToEnt_t m_inside;
+
+    std::vector<MapSatToEnt_t::iterator> m_enter;
+    std::vector<MapSatToEnt_t::iterator> m_leave;
 };
+
+struct ACompAreaLink
+{
+    ACompAreaLink(universe::Universe& rUniverse, universe::Satellite areaSat)
+     : m_areaSat(areaSat)
+     , m_rUniverse(rUniverse)
+    { }
+
+    universe::Satellite m_areaSat;
+
+    std::reference_wrapper<universe::Universe> m_rUniverse;
+    std::vector<ActivateSatellites> m_activated;
+
+};
+
+struct ACompActivatedSat
+{
+    universe::Satellite m_sat;
+};
+
 
 /**
- * An interface that 'activates' and 'deactivates' a type of ITypeSatellite
- * into an ActiveScene.
+ * System used to associate an ActiveScene to a UCompActiveArea in the Universe
  */
-class IActivator
-{
-public:
-    virtual StatusActivated activate_sat(
-            ActiveScene &scene, SysAreaAssociate &area,
-            universe::Satellite areaSat, universe::Satellite tgtSat) = 0;
-    virtual int deactivate_sat(
-            ActiveScene &scene, SysAreaAssociate &area,
-            universe::Satellite areaSat, universe::Satellite tgtSat,
-            ActiveEnt tgtEnt) = 0;
-};
-
 class SysAreaAssociate : public IDynamicSystem
 {
 public:
 
     static const std::string smc_name;
 
-    SysAreaAssociate(ActiveScene &rScene, universe::Universe &uni);
+    SysAreaAssociate(ActiveScene &rScene);
     ~SysAreaAssociate() = default;
 
     /**
@@ -75,7 +83,9 @@ public:
      * What this is suppose to do in the future:
      * Scan for nearby Satellites and attempt to activate them
      */
-    void update_scan(ActiveScene& rScene);
+    static void update_scan(ActiveScene& rScene);
+
+    static ACompAreaLink* try_get_area_link(ActiveScene &rScene);
 
     /**
      * Connect this AreaAssociate to an ActiveArea Satellite. This sets the
@@ -83,13 +93,14 @@ public:
      *
      * @param sat [in] Satellite containing a UCompActiveArea
      */
-    void connect(universe::Satellite sat);
+    static void connect(ActiveScene& rScene, universe::Universe &rUni,
+                        universe::Satellite areaSat);
 
     /**
      * Deactivate all Activated Satellites and cut ties with ActiveArea
      * Satellite
      */
-    void disconnect();
+    static void disconnect(ActiveScene& rScene);
 
     /**
      * Move the ActiveArea satellite, and translate everything in the
@@ -103,30 +114,8 @@ public:
      */
     void sat_transform_update(ActiveEnt ent);
 
-    /**
-     * Add an Activator, to add support for a type of satellite
-     * @param type [in] The type of Satellite that will be passed to the Activator
-     * @param activator [in]
-     */
-    void activator_add(universe::TypeSatIndex type, IActivator &activator);
-
-    constexpr universe::Universe& get_universe() { return m_universe; }
-
-    using MapActivators
-            = std::map<universe::TypeSatIndex, IActivator*>;
-
 private:
 
-    ActiveScene &m_scene;
-
-    universe::Satellite m_areaSat;
-    universe::Universe &m_universe;
-
-    MapActivators m_activators;
-    //std::vector<universe::Satellite> m_activatedSats;
-    entt::sparse_set<universe::Satellite> m_activatedSats;
-
-    //UpdateOrderHandle_t m_updateFloatingOrigin;
     UpdateOrderHandle_t m_updateScan;
 
     /**
@@ -135,24 +124,6 @@ private:
      */
     void floating_origin_translate(Vector3 translation);
 
-    /**
-     * Attempt to load a satellite
-     * @return status, zero for no error
-     */
-    int sat_activate(universe::Satellite sat);
-
-    int sat_deactivate(ActiveEnt ent,
-                       ACompActivatedSat& entAct);
-};
-
-struct ACompActivatedSat
-{
-    SysAreaAssociate::MapActivators::iterator m_activator;
-    universe::Satellite m_sat;
-
-    // Set true if the Satellite will be modified by the existance of this
-    // entity, such as updating position. TODO: this does nothing yet
-    bool m_mutable;
 };
 
 }

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -86,27 +86,34 @@ public:
     ~SysAreaAssociate() = default;
 
     /**
-     * Attempt to activate all the Satellites in the Universe for now.
+     * Scans the universe for Satellites to activate or deactivate, tracking
+     * changes into a ACompAreaLink stored in the scene.
      *
-     * What this is suppose to do in the future:
-     * Scan for nearby Satellites and attempt to activate them
+     * @param rScene [in/out] Scene to update
      */
     static void update_scan(ActiveScene& rScene);
 
+    /**
+     * Attempt to get an ACompAreaLink from an ActiveScene
+     * @return ACompAreaLink in scene, nullptr if not found
+     */
     static ACompAreaLink* try_get_area_link(ActiveScene &rScene);
 
     /**
-     * Connect this AreaAssociate to an ActiveArea Satellite. This sets the
-     * region of space in the universe the ActiveScene will represent
+     * Connect the ActiveScene to the Universe using the scene's ACompAreaLink,
+     * and a Satellite containing a UCompActiveArea.
      *
-     * @param sat [in] Satellite containing a UCompActiveArea
+     * @param rScene  [in/out] Scene containing ACompAreaLink
+     * @param rUni    [ref] Universe the ActiveArea satellite is contained in.
+     *                      This is stored in ACompAreaLink.
+     * @param areaSat [in] ActiveArea Satellite
      */
     static void connect(ActiveScene& rScene, universe::Universe &rUni,
                         universe::Satellite areaSat);
 
     /**
      * Deactivate all Activated Satellites and cut ties with ActiveArea
-     * Satellite
+     * Satellite (TODO)
      */
     static void disconnect(ActiveScene& rScene);
 
@@ -117,11 +124,15 @@ public:
     static void area_move(ActiveScene& rScene, Vector3s translate);
 
     /**
-     * Update position of ent's associated Satellite in the Universe, based on
-     * a transform in ActiveScene.
+     * Set the transform of a Satellite based on a transform (in meters)
+     * Satellite.
+     * @param rUni        [in/out] Universe containing satellites
+     * @param relativeSat [in] Satellite that transform is relative to
+     * @param tgtSat      [in] Satellite to set transform of
+     * @param transform   [in] Transform to set
      */
-    static void sat_transform_update(
-            universe::Universe& rUni, universe::Satellite areaSat,
+    static void sat_transform_set_relative(
+            universe::Universe& rUni, universe::Satellite relativeSat,
             universe::Satellite tgtSat, Matrix4 transform);
 
 private:
@@ -129,8 +140,11 @@ private:
     UpdateOrderHandle_t m_updateScan;
 
     /**
-     * Translate everything in the ActiveScene
-     * @param translation
+     * Translate all entities in an ActiveScene that contain an
+     * ACompFloatingOrigin
+     *
+     * @param rScene      [out] Scene containing entities that can be translated
+     * @param translation [in] Meters to translate entities by
      */
     static void floating_origin_translate(ActiveScene& rScene, Vector3 translation);
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -349,24 +349,24 @@ void SysVehicle::update_activate(ActiveScene &rScene)
     TypeSatIndex type = rUni.sat_type_find_index<universe::SatVehicle>();
     ActivationTracker& activations = pArea->get_tracker(type);
 
+    // Delete vehicles that have gone too far from the ActiveArea range
     for (auto const &[sat, ent] : activations.m_leave)
     {
         rScene.hier_destroy(ent);
     }
 
-    //for (auto const &[sat, ent] : activations.m_inside)
-
-    // Update positions of vehicles in universe
+    // Update transforms of already-activated vehicle satellites
     auto view = rScene.get_registry().view<ACompVehicle, ACompTransform,
                                            ACompActivatedSat>();
     for (ActiveEnt vehicleEnt : view)
     {
         auto &vehicleTf = view.get<ACompTransform>(vehicleEnt);
         auto &vehicleSat = view.get<ACompActivatedSat>(vehicleEnt);
-        SysAreaAssociate::sat_transform_update(
+        SysAreaAssociate::sat_transform_set_relative(
             rUni, pArea->m_areaSat, vehicleSat.m_sat, vehicleTf.m_transform);
     }
 
+    // Activate nearby vehicle satellites that have just entered the ActiveArea
     for (auto &entered : activations.m_enter)
     {
         universe::Satellite sat = entered->first;

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -54,6 +54,7 @@ SysVehicle::SysVehicle(ActiveScene &scene)
        [this] (ActiveScene& rScene) { this->update_vehicle_modification(rScene); })
 { }
 
+/*
 StatusActivated SysVehicle::activate_sat(ActiveScene &scene,
                                          SysAreaAssociate &area,
                                          universe::Satellite areaSat,
@@ -226,7 +227,7 @@ int SysVehicle::deactivate_sat(ActiveScene &scene, SysAreaAssociate &area,
     area.sat_transform_update(tgtEnt);
     return 0;
 }
-
+*/
 
 ActiveEnt SysVehicle::part_instantiate(PrototypePart& part,
                                        ActiveEnt rootParent)

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -108,14 +108,17 @@ public:
                            universe::Satellite tgtSat, ActiveEnt tgtEnt);
 
     /**
+     * Deal with activating and deactivating nearby vehicle Satellites in the
+     * Universe, and also update transforms of currently activated vehicles.
      *
-     * @param rScene
+     * @param rScene [in/out] Scene containing vehicles to update
      */
     static void update_activate(ActiveScene& rScene);
 
     /**
+     * Deal with vehicle separations and part deletions
      *
-     * @param rScene [in/out]
+     * @param rScene [in/out] Scene containing vehicles to update
      */
     static void update_vehicle_modification(ActiveScene& rScene);
 

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -32,18 +32,6 @@
 #include "../Resource/Package.h"
 #include "../Resource/blueprints.h"
 
-// forward declare
-namespace osp
-{
-    class PrototypePart;
-}
-
-// forward declare
-namespace osp::universe
-{
-    class SatActiveArea;
-}
-
 namespace osp::active
 {
 
@@ -108,15 +96,34 @@ public:
      * @param rootParent Entity to put part into
      * @return Pointer to object created
      */
-    ActiveEnt part_instantiate(PrototypePart& part, ActiveEnt rootParent);
+    static ActiveEnt part_instantiate(ActiveScene& rScene, PrototypePart& part,
+                                      ActiveEnt rootParent);
 
-    // Handle deleted parts and separations
-    void update_vehicle_modification(ActiveScene& rScene);
+    static ActiveEnt activate(ActiveScene &rScene, universe::Universe &rUni,
+                              universe::Satellite areaSat,
+                              universe::Satellite tgtSat);
+
+    static void deactivate(ActiveScene &rScene, universe::Universe &rUni,
+                           universe::Satellite areaSat,
+                           universe::Satellite tgtSat, ActiveEnt tgtEnt);
+
+    /**
+     *
+     * @param rScene
+     */
+    static void update_activate(ActiveScene& rScene);
+
+    /**
+     *
+     * @param rScene [in/out]
+     */
+    static void update_vehicle_modification(ActiveScene& rScene);
 
 private:
-    ActiveScene& m_scene;
+    //ActiveScene& m_scene;
     //AppPackages& m_packages;
 
+    UpdateOrderHandle_t m_updateActivation;
     UpdateOrderHandle_t m_updateVehicleModification;
 };
 

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -90,7 +90,7 @@ struct ACompPart
     unsigned m_separationIsland{0};
 };
 
-class SysVehicle : public IDynamicSystem, public IActivator
+class SysVehicle : public IDynamicSystem
 {
 public:
 
@@ -101,15 +101,6 @@ public:
     SysVehicle(SysNewton&& move) = delete;
     ~SysVehicle() = default;
 
-    //static int area_activate_vehicle(ActiveScene& scene,
-    //                                 SysAreaAssociate &area,
-    //                                 universe::Satellite areaSat,
-    //                                 universe::Satellite loadMe);
-    StatusActivated activate_sat(ActiveScene &scene, SysAreaAssociate &area,
-            universe::Satellite areaSat, universe::Satellite tgtSat);
-    int deactivate_sat(ActiveScene &scene, SysAreaAssociate &area,
-            universe::Satellite areaSat, universe::Satellite tgtSat,
-            ActiveEnt tgtEnt);
 
     /**
      * Create a Physical Part from a PrototypePart and put it in the world

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -41,27 +41,37 @@ namespace osp::universe
 class OSPMagnum;
 class SatActiveArea;
 
+/**
+ * Tag for satellites that can be activated
+ */
 struct UCompActivatable { };
 
-struct UCompActivationMutable
+/**
+ * Added to a satellite when it is being modified by an ActiveArea
+ */
+struct UCompActivatedMutable
 {
     Satellite m_area{entt::null};
-    active::ActiveEnt m_ent{entt::null};
+    //active::ActiveEnt m_ent{entt::null};
 };
+
+//-----------------------------------------------------------------------------
+
+struct UCompActivationAlways { };
 
 struct UCompActivationRadius
 {
-    float m_radius;
+    float m_radius{ 8.0f };
 };
+
+//-----------------------------------------------------------------------------
 
 struct UCompActiveArea
 {
-
-    // for later use
-    //active::MapActiveScene_t::iterator m_scene;
+    float m_areaRadius{ 1024.0f };
 
     // true when the ActiveArea is moving
-    bool m_inMotion;
+    bool m_inMotion{false};
 };
 
 

--- a/src/osp/Satellites/SatVehicle.cpp
+++ b/src/osp/Satellites/SatVehicle.cpp
@@ -35,5 +35,7 @@ UCompVehicle& SatVehicle::add_vehicle(
     assert(typeSetSuccess);
 
     rUni.get_reg().emplace<UCompActivatable>(sat);
+    rUni.get_reg().emplace<UCompActivationRadius>(sat);
+
     return rUni.get_reg().emplace<UCompVehicle>(sat, std::move(blueprint));
 }

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -137,6 +137,12 @@ public:
     noexcept { return m_typeSatNames; }
 
     /**
+     * @return Number of reistered satellites
+     */
+    std::underlying_type<TypeSatIndex>::type sat_type_count() const noexcept
+    { return m_typeSatIndices.size(); }
+
+    /**
      * Find index of a registered satellite by name
      * @param name [in] Name of satellite to find
      * @return Index of type, TypeSatIndex::Invalid if not found.

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -53,6 +53,7 @@ using osp::universe::Satellite;
 
 const std::string SysPlanetA::smc_name = "PlanetA";
 
+/*
 StatusActivated SysPlanetA::activate_sat(
         osp::active::ActiveScene &scene,
         osp::active::SysAreaAssociate &area,
@@ -90,7 +91,7 @@ StatusActivated SysPlanetA::activate_sat(
     rPlanetForceField.m_Gmass = loadMePlanet.m_mass * sc_GravConst;
 
     return {0, planetEnt, false};
-}
+}*/
 
 SysPlanetA::SysPlanetA(osp::active::ActiveScene &scene,
                        osp::UserInputHandler &userInput)
@@ -104,16 +105,6 @@ SysPlanetA::SysPlanetA(osp::active::ActiveScene &scene,
  , m_debugUpdate(userInput.config_get("debug_planet_update"))
 { }
 
-
-int SysPlanetA::deactivate_sat(osp::active::ActiveScene &scene,
-                               osp::active::SysAreaAssociate &area,
-                               osp::universe::Satellite areaSat,
-                               osp::universe::Satellite tgtSat,
-                               osp::active::ActiveEnt tgtEnt)
-{
-    // TODO: Delete the planet entity from the scene
-    return 0;
-}
 
 void SysPlanetA::draw(osp::active::ACompCamera const& camera)
 {
@@ -246,18 +237,18 @@ void SysPlanetA::update_geometry(ActiveScene& rScene)
 
         //if (m_debugUpdate.triggered() || true)
 
-        planet_update_geometry(ent);
+        planet_update_geometry(ent, rScene);
     }
 }
 
-void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt)
+void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt,
+                                        osp::active::ActiveScene& rScene)
 {
-    auto &rPlanetPlanet = m_scene.reg_get<ACompPlanet>(planetEnt);
-    auto const &planetTf = m_scene.reg_get<ACompTransform>(planetEnt);
-    auto const &planetActivated = m_scene.reg_get<ACompActivatedSat>(planetEnt);
+    auto &rPlanetPlanet = rScene.reg_get<ACompPlanet>(planetEnt);
+    auto const &planetTf = rScene.reg_get<ACompTransform>(planetEnt);
+    auto const &planetActivated = rScene.reg_get<ACompActivatedSat>(planetEnt);
 
-    // TODO: de-spaghettify systems. make systems entirely stateless
-    osp::universe::Universe const &uni = m_scene.dynamic_system_find<SysAreaAssociate>().get_universe();
+    osp::universe::Universe const &uni = rScene.reg_get<ACompAreaLink>(rScene.hier_get_root()).m_rUniverse;
 
     Satellite planetSat = planetActivated.m_sat;
     auto &planetUComp = uni.get_reg().get<universe::UCompPlanet>(planetSat);
@@ -265,8 +256,8 @@ void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt)
     PlanetGeometryA &rPlanetGeo = *(rPlanetPlanet.m_planet);
 
     // Temporary: use the first camera in the scene as the viewer
-    ActiveEnt cam = m_scene.get_registry().view<ACompCamera>().front();
-    auto const &camTf = m_scene.reg_get<ACompTransform>(cam);
+    ActiveEnt cam = rScene.get_registry().view<ACompCamera>().front();
+    auto const &camTf = rScene.reg_get<ACompTransform>(cam);
 
     // Set this somewhere else. Radius at which detail falloff will start
     // This will essentially be the physics area size

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -201,11 +201,13 @@ void SysPlanetA::update_activate(ActiveScene &rScene)
     TypeSatIndex type = rUni.sat_type_find_index<universe::SatPlanet>();
     ActivationTracker& activations = pArea->get_tracker(type);
 
+    // Delete planets that have exited the ActiveArea
     for (auto const &[sat, ent] : activations.m_leave)
     {
         rScene.hier_destroy(ent);
     }
 
+    // Activate planets that have just entered the ActiveArea
     for (auto &entered : activations.m_enter)
     {
         Satellite sat = entered->first;

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -54,8 +54,7 @@ struct ACompPlanet
 };
 
 
-class SysPlanetA : public osp::active::IDynamicSystem,
-                   public osp::active::IActivator
+class SysPlanetA : public osp::active::IDynamicSystem
 {
 public:
 
@@ -65,25 +64,14 @@ public:
                osp::UserInputHandler &userInput);
     ~SysPlanetA() = default;
 
-    osp::active::StatusActivated activate_sat(
-            osp::active::ActiveScene &scene,
-            osp::active::SysAreaAssociate &area,
-            osp::universe::Satellite areaSat,
-            osp::universe::Satellite tgtSat);
-
-    int deactivate_sat(osp::active::ActiveScene &scene,
-                       osp::active::SysAreaAssociate &area,
-                       osp::universe::Satellite areaSat,
-                       osp::universe::Satellite tgtSat,
-                       osp::active::ActiveEnt tgtEnt);
-
     void draw(osp::active::ACompCamera const& camera);
 
     void debug_create_chunk_collider(osp::active::ActiveEnt ent,
                                      ACompPlanet &planet,
                                      chindex_t chunk);
 
-    void planet_update_geometry(osp::active::ActiveEnt planetEnt);
+    static void planet_update_geometry(osp::active::ActiveEnt planetEnt,
+                                osp::active::ActiveScene& rScene);
 
     void update_geometry(osp::active::ActiveScene& rScene);
 

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -64,6 +64,10 @@ public:
                osp::UserInputHandler &userInput);
     ~SysPlanetA() = default;
 
+    static osp::active::ActiveEnt activate(
+            osp::active::ActiveScene &rScene, osp::universe::Universe &rUni,
+            osp::universe::Satellite areaSat, osp::universe::Satellite tgtSat);
+
     void draw(osp::active::ACompCamera const& camera);
 
     void debug_create_chunk_collider(osp::active::ActiveEnt ent,
@@ -73,6 +77,8 @@ public:
     static void planet_update_geometry(osp::active::ActiveEnt planetEnt,
                                 osp::active::ActiveScene& rScene);
 
+    static void update_activate(osp::active::ActiveScene& rScene);
+
     void update_geometry(osp::active::ActiveScene& rScene);
 
     void update_physics(osp::active::ActiveScene& rScene);
@@ -81,6 +87,7 @@ private:
 
     osp::active::ActiveScene &m_scene;
 
+    osp::active::UpdateOrderHandle_t m_updateActivate;
     osp::active::UpdateOrderHandle_t m_updateGeometry;
     osp::active::UpdateOrderHandle_t m_updatePhysics;
 

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -42,7 +42,7 @@ UCompPlanet& SatPlanet::add_planet(
     assert(typeSetSuccess);
 
     rUni.get_reg().emplace<UCompActivatable>(sat);
-    rUni.get_reg().emplace<UCompActivationRadius>(sat, radius);
+    rUni.get_reg().emplace<UCompActivationRadius>(sat, float(radius));
 
     return rUni.get_reg().emplace<UCompPlanet>(
                 sat, radius, resolutionSurfaceMax, resolutionScreenMax, mass);

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -28,6 +28,7 @@
 using osp::universe::Universe;
 using osp::universe::Satellite;
 using osp::universe::UCompActivatable;
+using osp::universe::UCompActivationRadius;
 
 using planeta::universe::UCompPlanet;
 using planeta::universe::SatPlanet;
@@ -41,6 +42,8 @@ UCompPlanet& SatPlanet::add_planet(
     assert(typeSetSuccess);
 
     rUni.get_reg().emplace<UCompActivatable>(sat);
+    rUni.get_reg().emplace<UCompActivationRadius>(sat, radius);
+
     return rUni.get_reg().emplace<UCompPlanet>(
                 sat, radius, resolutionSurfaceMax, resolutionScreenMax, mass);
 }

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -142,7 +142,7 @@ void DebugCameraController::update_physics_pre()
         std::cout << "Floating origin translation!\n";
 
         // Move the active area to center on the camera
-        m_scene.dynamic_system_find<SysAreaAssociate>().area_move(tra);
+        SysAreaAssociate::area_move(m_scene, tra);
     }
 }
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -91,14 +91,14 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     // Register dynamic systems needed for flight scene
 
-    auto &sysPhysics        = scene.dynamic_system_create<osp::active::SysPhysics_t>();
-    auto &sysWire           = scene.dynamic_system_create<osp::active::SysWire>();
-    auto &sysDebugRender    = scene.dynamic_system_create<osp::active::SysDebugRender>();
-    auto &sysArea           = scene.dynamic_system_create<osp::active::SysAreaAssociate>(rUni);
-    auto &sysVehicle        = scene.dynamic_system_create<osp::active::SysVehicle>();
-    auto &sysExhaustPlume   = scene.dynamic_system_create<osp::active::SysExhaustPlume>();
-    auto &sysPlanet         = scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
-    auto &sysGravity        = scene.dynamic_system_create<osp::active::SysFFGravity>();
+    scene.dynamic_system_create<osp::active::SysPhysics_t>();
+    scene.dynamic_system_create<osp::active::SysWire>();
+    scene.dynamic_system_create<osp::active::SysDebugRender>();
+    scene.dynamic_system_create<osp::active::SysAreaAssociate>();
+    scene.dynamic_system_create<osp::active::SysVehicle>();
+    scene.dynamic_system_create<osp::active::SysExhaustPlume>();
+    scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
+    scene.dynamic_system_create<osp::active::SysFFGravity>();
 
     // Register machines for that scene
     scene.system_machine_create<SysMachineUserControl>(pMagnumApp->get_input_handler());
@@ -106,8 +106,8 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     scene.system_machine_create<SysMachineRCSController>();
 
     // Make active areas load vehicles and planets
-    sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);
-    sysArea.activator_add(rUni.sat_type_find_index<SatPlanet>(), sysPlanet);
+    //sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);
+    //sysArea.activator_add(rUni.sat_type_find_index<SatPlanet>(), sysPlanet);
 
     // create a Satellite with an ActiveArea
     Satellite areaSat = rUni.sat_create();
@@ -116,7 +116,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     UCompActiveArea &area = SatActiveArea::add_active_area(rUni, areaSat);
 
     // Link ActiveArea to scene using the AreaAssociate
-    sysArea.connect(areaSat);
+    osp::active::SysAreaAssociate::connect(scene, rUni, areaSat);
 
     // Add default-constructed physics world to scene
     scene.get_registry().emplace<osp::active::ACompPhysicsWorld_t>(scene.hier_get_root());
@@ -155,7 +155,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     std::cout << "Magnum Application closed\n";
 
     // Disconnect ActiveArea
-    sysArea.disconnect();
+    osp::active::SysAreaAssociate::disconnect(scene);
 
     // destruct the application, this closes the window
     pMagnumApp.reset();

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -61,19 +61,19 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
                                         rUni, rUni.sat_root());
 
     // Create 10 random vehicles
-    /*for (int i = 0; i < 10; i ++)
+    for (int i = 0; i < 1; i ++)
     {
         // Creates a random mess of spamcans as a vehicle
-        Satellite sat = debug_add_random_vehicle(uni, pkg, "TestyMcTestFace Mk"
+        Satellite sat = debug_add_random_vehicle(rUni, pkg, "TestyMcTestFace Mk"
                                                  + std::to_string(i));
 
-        auto &posTraj = uni.get_reg().get<UCompTransformTraj>(sat);
+        auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 
         posTraj.m_position = osp::Vector3s(i * 1024l * 5l, 0l, 0l);
         posTraj.m_dirty = true;
 
         stationary.add(sat);
-    }*/
+    }
 
     //Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
     Satellite sat = testapp::debug_add_part_vehicle(rUni, pkg, "Placeholder Mk. I");
@@ -87,7 +87,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
 
     for (int x = -0; x < 1; x ++)
     {
-        for (int z = -0; z < 1; z ++)
+        for (int z = -1; z < 1; z ++)
         {
             Satellite sat = rUni.sat_create();
 


### PR DESCRIPTION

This PR guts `SysAreaAssociate`. This system is responsible for ~~loading~~ activating nearby Satellites into the ActiveScene. Satellites, like planets and vehicles, are stored in the Universe as simple representations, with no meshes, no node hierarchies, and no rigid body physics. Only when the user gets close to them (entering the ActiveArea), do they need to be 'activated' into the scene.

In accordance to Issue #46, many functions were made static, and state is moved into a new component: `ACompAreaLink`. The `IActivator` interface used by `SysVehicle` and `SysPlanet` is also removed. This was previously used as a callback for `SysAreaAssociate` to activate and deactivate Satellites right away. (Just as a nearby Satellite is detected, it calls the activate function right away, adding new entities and components to the scene.)

Instead of callbacks, this new system stores [just entered], and [just exited] event vectors in `ACompAreaLink`, which also keeps track of which Satellites are currently inside the area. It is up to another system function to read these events where their component pools can be modified predictably. This makes the application more cache-friendly, and easier for future concurrency.

Other changes:
* Fix reallocation error in ActiveScene::hier_destroy