### PR TITLE
Fueltank physics

### DIFF
--- a/bin/OSPData/adera/ph_engine.sturdy.gltf
+++ b/bin/OSPData/adera/ph_engine.sturdy.gltf
@@ -63,8 +63,8 @@
                 "machines" : [
                     {
                         "type" : "Rocket",
-                        "thrust" : 70000.0,
-                        "Isp" : 310.0,
+                        "thrust" : 150000.0,
+                        "Isp" : 100.0,
                         "fuel" : "lzdb:fuel"
                     },
                     {

--- a/bin/OSPData/adera/ph_rcs.sturdy.gltf
+++ b/bin/OSPData/adera/ph_rcs.sturdy.gltf
@@ -63,7 +63,7 @@
                 	},
                     {
                         "type" : "Rocket",
-                        "thrust" : 1000.0,
+                        "thrust" : 7000.0,
                         "Isp" : 225.0,
                         "fuel" : "lzdb:monoprop"
                     },

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -111,6 +111,20 @@ public:
     std::vector<osp::active::WireInput*> existing_inputs() override;
     std::vector<osp::active::WireOutput*> existing_outputs() override;
 
+    /**
+     * Return normalized power output level of the rocket this frame
+     *
+     * Returns a value [0,1] corresponding to the current output power of the
+     * engine. This value is equal to the throttle input level, unless the
+     * engine has run out of fuel, has a nonlinear throttle response, or some
+     * similar reason. Used primarily by SysExhaustPlume to determine what the
+     * exhaust plume effect should look like.
+     *
+     * @return normalized float [0,1] representing engine power output
+     */
+    float current_output_power() const
+    { return m_powerOutput; }
+
 private:
     osp::active::WireInput m_wiGimbal   { this, "Gimbal"   };
     osp::active::WireInput m_wiIgnition { this, "Ignition" };
@@ -118,8 +132,10 @@ private:
 
     osp::active::ActiveEnt m_rigidBody  { entt::null };
     fuel_list_t m_resourceLines;
-
     Parameters m_params;
+
+    // Rocket power output for the current frame
+    float m_powerOutput{0.0f};
 }; // MachineRocket
 
 inline MachineRocket::MachineRocket(Parameters params, fuel_list_t& resources)
@@ -136,6 +152,7 @@ inline MachineRocket::MachineRocket(MachineRocket&& move) noexcept
    , m_rigidBody(std::move(move.m_rigidBody))
    , m_params(std::move(move.m_params))
    , m_resourceLines(std::move(move.m_resourceLines))
+   , m_powerOutput(std::exchange(move.m_powerOutput, 0.0f))
 { }
 
 inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
@@ -147,6 +164,7 @@ inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
     m_rigidBody  = std::move(move.m_rigidBody);
     m_params = std::move(move.m_params);
     m_resourceLines = std::move(move.m_resourceLines);
+    m_powerOutput = std::exchange(move.m_powerOutput, 0.0f);
     return *this;
 }
 

--- a/src/adera/ShipResources.h
+++ b/src/adera/ShipResources.h
@@ -27,6 +27,7 @@
 
 #include "osp/Resource/Resource.h"
 #include "osp/Active/SysMachine.h"
+#include "osp/CommonPhysics.h"
 
 namespace adera::active::machines
 {
@@ -130,7 +131,6 @@ public:
     osp::active::Machine& get(osp::active::ActiveEnt ent) override;
 
 private:
-    
     osp::active::UpdateOrderHandle_t m_updateContainers;
 }; // class SysMachineContainer
 
@@ -168,6 +168,12 @@ public:
      * @return The amount of resource that was received
      */
     uint64_t request_contents(uint64_t quantity);
+
+    /**
+     * Compute the current mass of the container contents
+     * @return The current mass, in kg
+     */
+    float compute_mass() const noexcept;
 private:
     std::vector<osp::active::WireInput*> m_inputs;
     std::vector<osp::active::WireOutput*> m_outputs;

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -122,14 +122,13 @@ void SysExhaustPlume::update_plumes(ActiveScene& rScene)
         CompVisibleDebug& visibility = plumeView.get<CompVisibleDebug>(plumeEnt);
 
         auto& machine = m_scene.reg_get<MachineRocket>(plume.m_parentMachineRocket);
-        const auto& throttle = *machine.request_input(2)->connected_value();
-        const auto throttlePos = std::get<wiretype::Percent>(throttle).m_value;
+        float powerLevel = machine.current_output_power();
 
         plumeShader.m_currentTime = m_time;
 
-        if (throttlePos > 0.0f)
+        if (powerLevel > 0.0f)
         {
-            plumeShader.m_powerLevel = throttlePos;
+            plumeShader.m_powerLevel = powerLevel;
             visibility.m_state = true;
         }
         else

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -207,8 +207,8 @@ ActiveEnt SysVehicle::activate(ActiveScene &rScene, universe::Universe &rUni,
 
     // temporary: make the whole thing a single rigid body
     auto& vehicleBody = rScene.reg_emplace<ACompRigidBody_t>(vehicleEnt);
-    rScene.reg_emplace<ACompCollisionShape>(vehicleEnt,
-        nullptr, phys::ECollisionShape::COMBINED);
+    rScene.reg_emplace<ACompShape>(vehicleEnt, phys::ECollisionShape::COMBINED);
+    rScene.reg_emplace<ACompCollider>(vehicleEnt, nullptr);
     //scene.dynamic_system_find<SysPhysics>().create_body(vehicleEnt);
 
     return vehicleEnt;
@@ -261,11 +261,32 @@ void SysVehicle::part_instantiate_machines(ActiveScene& rScene, ActiveEnt partEn
     }
 }
 
+// Traverses the hierarchy and sums the volume of all ACompShapes it finds
+float SysVehicle::compute_hier_volume(ActiveScene& rScene, ActiveEnt part)
+{
+    float volume = 0.0f;
+    auto checkVol = [&rScene, &volume](ActiveEnt ent)
+    {
+        auto const* shape = rScene.get_registry().try_get<ACompShape>(ent);
+        if (shape)
+        {
+            auto const& xform = rScene.reg_get<ACompTransform>(ent);
+            volume += shape_volume(shape->m_shape, xform.m_transform.scaling());
+        }
+        return EHierarchyTraverseStatus::Continue;
+    };
+
+    rScene.hierarchy_traverse(part, std::move(checkVol));
+
+    return volume;
+}
+
 std::pair<ActiveEnt, std::vector<SysVehicle::MachineDef>> SysVehicle::part_instantiate(
     ActiveScene& rScene, PrototypePart& part, BlueprintPart& blueprint, ActiveEnt rootParent)
 {
     std::vector<PrototypeObject> const& prototypes = part.get_objects();
     std::vector<ActiveEnt> newEntities(prototypes.size());
+    ActiveEnt& rootEntity = newEntities[0];
 
     /* A list of MachineDefs, which catalog all part machines and the ActiveEnts
      * that are created to represent the objects that own them
@@ -278,7 +299,7 @@ std::pair<ActiveEnt, std::vector<SysVehicle::MachineDef>> SysVehicle::part_insta
     for (size_t i = 0; i < prototypes.size(); i++)
     {
         PrototypeObject const& currentPrototype = prototypes[i];
-        ActiveEnt parentEnt;
+        ActiveEnt parentEnt = entt::null;
 
         // Get parent
         if (currentPrototype.m_parentIndex == i)
@@ -365,21 +386,54 @@ std::pair<ActiveEnt, std::vector<SysVehicle::MachineDef>> SysVehicle::part_insta
         }
         else if (currentPrototype.m_type == ObjectType::COLLIDER)
         {
-            ACompCollisionShape& collision = rScene.reg_emplace<ACompCollisionShape>(currentEnt);
+            // Emplace collider, collision volume
+            ACompShape& collision = rScene.reg_emplace<ACompShape>(currentEnt);
+            rScene.reg_emplace<ACompCollider>(currentEnt);
             const ColliderData& cd = std::get<ColliderData>(currentPrototype.m_objectData);
             collision.m_shape = cd.m_type;
-
         }
 
         // Save the list of machines this object owns
         machineMapping.emplace_back(currentEnt, currentPrototype.m_machineIndices);
     }
 
-    // Create mass
-    rScene.reg_emplace<ACompMass>(newEntities[0], part.get_mass());
+    /* Create masses
+     * 
+     * To allow the physics system to treat all massive objects homogeneously,
+     * the dry mass of the part must be distributed over its child collider
+     * volumes. We assume (for now) that the mass is distributed uniformly over
+     * the volumes.
+     * 
+     * We check the entities for ACompColliders, as we're interested in the
+     * part's physical volume. If we don't check for this component, we would
+     * double-count the volume in regions that also contain other shapes, like
+     * fuel tank volumes.
+     */
+    float partVolume = compute_hier_volume(rScene, rootEntity);
+    float partDensity = part.get_mass() / partVolume;
+
+    auto applyMasses = [&rScene, partDensity](ActiveEnt ent)
+    {
+        if (auto const* shape = rScene.reg_try_get<ACompShape>(ent);
+            shape != nullptr)
+        {
+            if (!rScene.get_registry().has<ACompCollider>(ent))
+            {
+                return EHierarchyTraverseStatus::Continue;
+            }
+            Matrix4 const& transform = rScene.reg_get<ACompTransform>(ent).m_transform;
+            float volume = phys::shape_volume(shape->m_shape, transform.scaling());
+            float mass = volume * partDensity;
+
+            rScene.reg_emplace<ACompMass>(ent, mass);
+        }
+        return EHierarchyTraverseStatus::Continue;
+    };
+
+    rScene.hierarchy_traverse(rootEntity, applyMasses);
 
     // return root object
-    return {newEntities[0], machineMapping};
+    return {rootEntity, machineMapping};
 }
 
 void SysVehicle::update_activate(ActiveScene &rScene)
@@ -472,7 +526,9 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                 auto &islandBody
                         = rScene.reg_emplace<ACompRigidBody_t>(islandEnt);
                 auto &islandShape
-                        = rScene.reg_emplace<ACompCollisionShape>(islandEnt);
+                        = rScene.reg_emplace<ACompShape>(islandEnt);
+                auto &islandCollider
+                        = rScene.reg_emplace<ACompCollider>(islandEnt, nullptr);
                 islandShape.m_shape = phys::ECollisionShape::COMBINED;
 
                 auto &vehicleTransform = rScene.reg_get<ACompTransform>(vehicleEnt);

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -133,6 +133,20 @@ private:
     };
 
     /**
+     * Compute the volume of a part
+     *
+     * Traverses the immediate children of the specified entity and sums the
+     * volumes of any detected collision volumes. Cannot account for overlapping
+     * collider volumes.
+     *
+     * @param rScene [in] ActiveScene containing relevant scene data
+     * @param part   [in] The part
+     *
+     * @return The part's collider volume
+     */
+    static float compute_hier_volume(ActiveScene& rScene, ActiveEnt part);
+
+    /**
      * Create a Physical Part from a PrototypePart and put it in the world
      *
      * @param part [in] The part prototype to instantiate

--- a/src/osp/CommonPhysics.cpp
+++ b/src/osp/CommonPhysics.cpp
@@ -31,7 +31,7 @@
 namespace osp::phys
 {
 
-float col_shape_volume(ECollisionShape shape, Vector3 scale)
+float shape_volume(ECollisionShape shape, Vector3 scale)
 {
     static constexpr float sc_pi = Magnum::Math::Constants<Magnum::Float>::pi();
     switch (shape)
@@ -53,7 +53,7 @@ float col_shape_volume(ECollisionShape shape, Vector3 scale)
     case ECollisionShape::COMBINED:
     default:
         std::cout << "Error: unsupported shape for volume calc\n";
-        return 0.0f;
+        assert(false);
     }
 }
 

--- a/src/osp/CommonPhysics.h
+++ b/src/osp/CommonPhysics.h
@@ -43,7 +43,24 @@ enum class ECollisionShape : uint8_t
     TERRAIN = 8
 };
 
-float col_shape_volume(ECollisionShape shape, Vector3 scale);
+/**
+ * Compute the volume of an ECollisionShape
+ * 
+ * Given the type of shape and the scale in X,Y,Z, computes the volume of the
+ * primitive shape. Axis-aligned shapes (e.g. cylinder, capsule) are aligned
+ * along the z-axis.
+ * 
+ * As this function is meant to deal with shapes that are defined within parts
+ * in Blender, the default size of each primitive is inherited from Blender's
+ * default empty, which is a bounding box with dimensions 2x2x2 meters. See
+ * function implementation for shape-specific details.
+ * 
+ * @param shape [in] The primitive shape to compute
+ * @param scale [in] The scale in X,Y,Z to apply to the shape
+ * 
+ * @return the volume of the shape in m^3
+ */
+float shape_volume(ECollisionShape shape, Vector3 scale);
 
 // Formerly SysNewton
 /**
@@ -62,6 +79,7 @@ struct DataRigidBody
     Vector3 m_centerOfMassOffset{0, 0, 0};
 
     bool m_colliderDirty{false}; // set true if collider is modified
+    bool m_inertiaDirty{false}; // set true if rigidbody is modified
 };
 
 /**

--- a/src/osp/types.h
+++ b/src/osp/types.h
@@ -42,6 +42,7 @@ using Magnum::Vector2;
 using Magnum::Vector2i;
 
 using Magnum::Vector3;
+using Magnum::Vector4;
 using Magnum::Quaternion;
 using Magnum::Matrix3;
 using Magnum::Matrix4;

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -44,7 +44,8 @@ using osp::active::ACompTransform;
 using osp::active::ACompFloatingOrigin;
 using osp::active::ACompRigidBody_t;
 using osp::active::ACompFFGravity;
-using osp::active::ACompCollisionShape;
+using osp::active::ACompShape;
+using osp::active::ACompCollider;
 using osp::active::ACompAreaLink;
 using osp::active::ACompActivatedSat;
 using osp::active::SysAreaAssociate;
@@ -169,7 +170,8 @@ void SysPlanetA::debug_create_chunk_collider(osp::active::ActiveEnt ent,
     // Create entity and required components
     ActiveEnt fish = m_scene.hier_create_child(m_scene.hier_get_root());
     auto &fishTransform = m_scene.reg_emplace<ACompTransform>(fish);
-    auto &fishShape = m_scene.reg_emplace<ACompCollisionShape>(fish);
+    auto &fishShape = m_scene.reg_emplace<ACompShape>(fish);
+    auto &fishCollide = m_scene.reg_emplace<ACompCollider>(fish);
     auto &fishBody = m_scene.reg_emplace<ACompRigidBody_t>(fish);
     m_scene.reg_emplace<ACompFloatingOrigin>(fish);
 
@@ -181,7 +183,7 @@ void SysPlanetA::debug_create_chunk_collider(osp::active::ActiveEnt ent,
     auto itsChunk = planet.m_planet->iterate_chunk(chunk);
 
     // Send them to the physics engine
-    physics.shape_create_tri_mesh_static(fishShape,
+    physics.shape_create_tri_mesh_static(fishShape, fishCollide,
                                          itsChunk.first, itsChunk.second);
 
     // create the rigid body


### PR DESCRIPTION
Fuel tanks are upgraded to store their masses and keep them up-to-date based on their current contents.

- Added `MachineContainer::compute_mass()` which returns the mass of the current contents of the container

- ACompMass is now automatically assigned to MachineContainers; SysMachineContainer keeps them up to date.

- Added ACompContainerShape, which represents the shape of MachineContainers for mass distribution calc

- Added `MachineRocket::current_power_output()` which reports the most recent power level produced by the engine; SysExhaustPlume now reads from this function rather than getting itself tangled up in throttle wire values, which wouldn't handle situations like the engine being off at full throttle due to lack of fuel.

Newton:
Now that containers have dynamically updated masses, rigidbodies can now be dynamically updated to account for shifting fuel mass distribution. When MachineRocket draws fuel from a container, it sets a flag which causes SysNewton to recalculate the mass distribution of the ship (which should ultimately change when we upgrade the wire/pipe system, so that these manual details aren't necessary).

- `struct DataRigidBody` received a new `m_rigidbodyDirty` member which behaves just like `m_colliderDirty`, but instead triggers the rigidbody inertia to be recalculated in `SysNewton::update_world()`.

- Add `SysNewton::update_rigidbody_inertia()` which encapsulates the logic for sending inertia data to Newton, previously located in `create_body()`

- `compute_mass_inertia()` now accepts a center of mass offset as parameter; previously the inertia was calculated from the part's origin, but now the CoM can be precomputed and passed for more physically accurate inertial calculations

- Renamed `compute_body_CoM()` to `compute_hier_CoM()` since its task is really to generally calculate the center of mass of all ACompMasses in a hierarchy subtree.

- Renamed `compute_body_inertia()` to `compute_rigidbody_inertia()`