### PR TITLE
Pipe wires

### DIFF
--- a/bin/OSPData/adera/ph_engine.sturdy.gltf
+++ b/bin/OSPData/adera/ph_engine.sturdy.gltf
@@ -65,7 +65,7 @@
                         "type" : "Rocket",
                         "thrust" : 150000.0,
                         "Isp" : 100.0,
-                        "fuel" : "lzdb:fuel"
+                        "fueltype" : "lzdb:fuel"
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/bin/OSPData/adera/ph_rcs.sturdy.gltf
+++ b/bin/OSPData/adera/ph_rcs.sturdy.gltf
@@ -65,7 +65,7 @@
                         "type" : "Rocket",
                         "thrust" : 7000.0,
                         "Isp" : 225.0,
-                        "fuel" : "lzdb:monoprop"
+                        "fueltype" : "lzdb:fuel"
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/bin/OSPData/adera/spamcan.sturdy.gltf
+++ b/bin/OSPData/adera/spamcan.sturdy.gltf
@@ -196,7 +196,8 @@
                     },
                     {
                         "type" : "Rocket",
-                        "thrust" : 1000.0
+                        "thrust" : 1000.0,
+                        "fueltype" : "lzdb:fuel"
                     },
                     {
                         "type" : "FreeEnergyGenerator"

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -61,16 +61,15 @@ WireOutput* MachineRocket::request_output(WireOutPort port)
 
 std::vector<WireInput*> MachineRocket::existing_inputs()
 {
-    /*std::vector<WireInput*> inputs;
+    std::vector<WireInput*> inputs;
     inputs.reserve(3 + m_resourceLines.size());
 
     inputs.insert(inputs.begin(), {&m_wiGimbal, &m_wiIgnition, &m_wiThrottle});
     for (auto& resource : m_resourceLines)
     {
-        inputs.push_back(&resource.m_lineIn);
+        inputs.push_back(&resource.m_source);
     }
-    return inputs;*/
-    return {&m_wiGimbal, &m_wiIgnition, &m_wiThrottle};
+    return inputs;
 }
 
 std::vector<WireOutput*> MachineRocket::existing_outputs()
@@ -125,18 +124,23 @@ void SysMachineRocket::update_physics(ActiveScene& rScene)
         bool fail = false;
         for (auto& resource : machine.m_resourceLines)
         {
-            auto const* src = m_scene.reg_try_get<MachineContainer>(resource.m_sourceEnt);
-            if (!src)
+            if (auto const* pipe = resource.m_source.get_if<wiretype::Pipe>();
+                pipe != nullptr)
             {
-                std::cout << "Error: no source found\n";
-                fail = true;
-                break;
+                
+                if (auto const* src = rScene.reg_try_get<MachineContainer>(pipe->m_source);
+                    src != nullptr)
+                {
+                    uint64_t required = resource_units_required(rScene, machine,
+                        pThrotPercent->m_value, resource);
+                    if (src->check_contents().m_quantity > required)
+                    {
+                        continue;
+                    }
+                }
             }
-            if (!src->check_contents().m_quantity > 0)
-            {
-                fail = true;
-                break;
-            }
+            fail = true;
+            break;
         }
         if (fail)
         {
@@ -179,17 +183,17 @@ void SysMachineRocket::update_physics(ActiveScene& rScene)
         rCompRb.m_inertiaDirty = true;
 
         // Perform resource consumption calculation
-        float massFlowRateTot = thrustMag /
-            (phys::constants::g_0 * machine.m_params.m_specImpulse);
         for (MachineRocket::ResourceInput const& resource : machine.m_resourceLines)
         {
-            float massFlowRate = massFlowRateTot * resource.m_massRateFraction;
-            float massFlow = massFlowRate * m_scene.get_time_delta_fixed();
-            uint64_t required = resource.m_type->resource_quantity(massFlow);
-            auto* src = m_scene.reg_try_get<MachineContainer>(resource.m_sourceEnt);
-            uint64_t consumed = src->request_contents(required);
+            // Pipe must be non-null since we checked earlier
+            const auto& pipe = *resource.m_source.get_if<wiretype::Pipe>();
+            auto& src = rScene.reg_get<MachineContainer>(pipe.m_source);
+
+            uint64_t required = resource_units_required(rScene, machine,
+                pThrotPercent->m_value, resource);
+            uint64_t consumed = src.request_contents(required);
             std::cout << "consumed " << consumed << " units of fuel, "
-                << src->check_contents().m_quantity << " remaining\n";
+                << src.check_contents().m_quantity << " remaining\n";
         }
 
         // Set output power level (for plume effect)
@@ -247,39 +251,43 @@ Machine& SysMachineRocket::instantiate(ActiveEnt ent, PrototypeMachine config,
     params.m_maxThrust = std::get<double>(config.m_config["thrust"]);
     params.m_specImpulse = std::get<double>(config.m_config["Isp"]);
 
-    MachineRocket::fuel_list_t inputs;
-    Package& pkg = m_scene.get_application().debug_find_package("lzdb");
-    DependRes<ShipResourceType> fuel = pkg.get<ShipResourceType>("fuel");
+    std::string const& fuelIdent = std::get<std::string>(config.m_config["fueltype"]);
+    Path resPath = decompose_path(fuelIdent);
+    Package& pkg = m_scene.get_application().debug_find_package(resPath.prefix);
+    DependRes<ShipResourceType> fuel = pkg.get<ShipResourceType>(resPath.identifier);
+
+    std::vector<MachineRocket::input_t> inputs;
     if (!fuel.empty())
     {
-        // TMP: finds the first non-empty fuel tank in the ship
-        // Only works as long as the fuselage is added before the engine
-
-        ActiveEnt foundTank = entt::null;
-        auto find_fuel = [this, &foundTank](ActiveEnt e)
-        {
-            if (auto* fuel = this->m_scene.reg_try_get<MachineContainer>(e);
-                fuel != nullptr && fuel->check_contents().m_quantity > 0)
-            {
-                foundTank = e;
-                return EHierarchyTraverseStatus::Stop;
-            }
-            return EHierarchyTraverseStatus::Continue;
-        };
-        auto const& parent = m_scene.reg_get<ACompHierarchy>(ent);
-        m_scene.hierarchy_traverse(parent.m_parent, find_fuel);
-        // endTMP
-
-        ActiveEnt fuelSource = foundTank;
-        MachineRocket::ResourceInput input = {std::move(fuel), 1.0f, fuelSource};
-        inputs.push_back(std::move(input));
+        inputs.push_back({std::move(fuel), 1.0f});
     }
 
     attach_plume_effect(ent);
-    return m_scene.reg_emplace<MachineRocket>(ent, params, inputs);
+    return m_scene.reg_emplace<MachineRocket>(ent, std::move(params), std::move(inputs));
 }
 
 Machine& SysMachineRocket::get(ActiveEnt ent)
 {
     return m_scene.reg_get<MachineRocket>(ent);//emplace(ent);
+}
+
+uint64_t SysMachineRocket::resource_units_required(
+    osp::active::ActiveScene const& scene,
+    MachineRocket const& machine, float throttle,
+    MachineRocket::ResourceInput const& resource)
+{
+    float massFlowRate = resource_mass_flow_rate(machine,
+        throttle, resource);
+    float massFlow = massFlowRate * scene.get_time_delta_fixed();
+    return resource.m_type->resource_quantity(massFlow);
+}
+
+constexpr float SysMachineRocket::resource_mass_flow_rate(MachineRocket const& machine,
+    float throttle, MachineRocket::ResourceInput const& resource)
+{
+    float thrustMag = machine.m_params.m_maxThrust * throttle;
+    float massFlowRateTot = thrustMag /
+        (phys::constants::g_0 * machine.m_params.m_specImpulse);
+
+    return massFlowRateTot * resource.m_massRateFraction;
 }

--- a/src/adera/ShipResources.cpp
+++ b/src/adera/ShipResources.cpp
@@ -30,34 +30,6 @@ using namespace osp;
 using namespace osp::active;
 using namespace adera::active::machines;
 
-/* ShipResourceType */
-
-double ShipResourceType::resource_volume(uint64_t quantity) const
-{
-    double units = static_cast<double>(quantity) / std::pow(2.0, m_quanta);
-    return units * m_volume;
-}
-
-double ShipResourceType::resource_mass(uint64_t quantity) const
-{
-    double units = static_cast<double>(quantity) / std::pow(2.0, m_quanta);
-    return units * m_mass;
-}
-
-uint64_t ShipResourceType::resource_capacity(double volume) const
-{
-    double units = volume / m_volume;
-    double quantaPerUnit = std::pow(2.0, m_quanta);
-    return static_cast<uint64_t>(units * quantaPerUnit);
-}
-
-uint64_t ShipResourceType::resource_quantity(double mass) const
-{
-    double units = mass / m_mass;
-    double quantaPerUnit = std::pow(2.0, m_quanta);
-    return static_cast<uint64_t>(units * quantaPerUnit);
-}
-
 /* MachineContainer */
 
 void MachineContainer::propagate_output(WireOutput* output)
@@ -72,17 +44,17 @@ WireInput* MachineContainer::request_input(WireInPort port)
 
 WireOutput* MachineContainer::request_output(WireOutPort port)
 {
-    return nullptr;
+    return &m_outputs;
 }
 
 std::vector<WireInput*> MachineContainer::existing_inputs()
 {
-    return m_inputs;
+    return {};
 }
 
 std::vector<WireOutput*> MachineContainer::existing_outputs()
 {
-    return m_outputs;
+    return {&m_outputs};
 }
 
 uint64_t MachineContainer::request_contents(uint64_t quantity)
@@ -141,14 +113,15 @@ Machine& SysMachineContainer::instantiate(ActiveEnt ent,
         Package& pkg = m_scene.get_application().debug_find_package(resPath.prefix);
 
         resource.m_type = pkg.get<ShipResourceType>(resPath.identifier);
-        resource.m_quantity = resource.m_type->resource_capacity(capacity);
+        double fuelLevel = std::get<double>(settings.m_config["fuellevel"]);
+        resource.m_quantity = resource.m_type->resource_capacity(capacity * fuelLevel);
     }
 
     m_scene.reg_emplace<ACompMass>(ent, 0.0f);
     // All tanks are cylindrical for now
     m_scene.reg_emplace<ACompShape>(ent, phys::ECollisionShape::CYLINDER);
 
-    return m_scene.reg_emplace<MachineContainer>(ent, capacity, resource);
+    return m_scene.reg_emplace<MachineContainer>(ent, ent, capacity, resource);
 }
 
 Machine& SysMachineContainer::get(ActiveEnt ent)

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -175,7 +175,7 @@ public:
     constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
 
     // TODO
-    constexpr float get_time_delta_fixed() { return 1.0f / 60.0f; }
+    constexpr float get_time_delta_fixed() const { return 1.0f / 60.0f; }
 
     /**
      * Add support for a new machine type by adding an ISysMachine

--- a/src/osp/CommonMath.h
+++ b/src/osp/CommonMath.h
@@ -1,0 +1,48 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "types.h"
+#include <type_traits>
+
+namespace osp::math
+{
+
+template <typename UINT_T>
+constexpr UINT_T uint_2pow(UINT_T exponent)
+{
+    static_assert(std::is_integral<UINT_T>::value, "Unsigned int required");
+    return UINT_T(1) << exponent;
+}
+
+template <typename UINT_T>
+constexpr bool is_power_of_2(UINT_T value)
+{
+    static_assert(std::is_integral<UINT_T>::value, "Unsigned int required");
+    // Test to see if the value contains more than 1 set bit
+    return !(value == 0) && !(value & (value - 1));
+}
+
+} // namespace osp::math

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -238,13 +238,15 @@ void load_a_bunch_of_stuff()
 
     // Load placeholder fuel type
     using adera::active::machines::ShipResourceType;
-    ShipResourceType fuel;
-    fuel.m_identifier = "fuel";
-    fuel.m_displayName = "Rocket fuel";
-    fuel.m_quanta = 16;
-    fuel.m_mass = 1.0f;
-    fuel.m_volume = 0.001f;
-    fuel.m_density = fuel.m_mass / fuel.m_volume;
+    ShipResourceType fuel
+    {
+        "fuel",        // identifier
+        "Rocket fuel", // display name
+        1 << 16,       // quanta per unit
+        1.0f,          // volume per unit (m^3)
+        1000.0f,       // mass per unit (kg)
+        1000.0f        // density (kg/m^3)
+    };
 
     lazyDebugPack.add<ShipResourceType>("fuel", std::move(fuel));
 

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -219,6 +219,7 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
 
     auto& fuselageBP = blueprint.add_part(fuselage, cfOset, idRot, scl);
     fuselageBP.m_machines[1].m_config.emplace("resourcename", "lzdb:fuel");
+    fuselageBP.m_machines[1].m_config.emplace("fuellevel", 0.5);
 
     auto& engBP = blueprint.add_part(engine, cfOset + feOset, idRot, scl);
 
@@ -269,13 +270,23 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
         Parts::CAPSULE, 0, 0,
         Parts::ENGINE, 0, 0);
 
-    // Wire attitude control to RCS control, and RCS control to RCS rocket
+    // Pipe fuel tank to rocket engine
+    // from (output): fuselage MachineContainer m_outputs;
+    // to    (input): entine MachineRocket m_resourcesLines[0]
+    blueprint.add_wire(Parts::FUSELAGE, 0, 0,
+        Parts::ENGINE, 0, 3);
+
     for (auto port : rcsPorts)
     {
+        // Attitude control -> RCS Control
         blueprint.add_wire(Parts::CAPSULE, 0, 0,
             port, 0, 0);
+        // RCS Control -> RCS Rocket
         blueprint.add_wire(port, 0, 0,
             port, 1, 2);
+        // Fuselage tank -> RCS Rocket
+        blueprint.add_wire(Parts::FUSELAGE, 0, 0,
+            port, 1, 3);
     }
 
     // Put blueprint in package


### PR DESCRIPTION
You can call me the white hat of the wiring system. I abuse the system horribly so we can find out how to stop people like me from breaking things.

The new `Pipe` wire type is, to cap's horror, just a wrapper for the `ActiveEnt` at the source end. Right now, this allows for connections between fuel tanks and engines to be programmatically defined in the ship blueprint (good). The MachineRocket at the sink end uses it (in Rocket.cpp:187) to reach into the source and withdraw whatever resources it demands (bad). The primary function of the pipe wire is to allow pipes to be defined in blueprints; we need to figure out what the interface presented to either end of the pipe should be.

Right now, the pipes originate in MachineContainer, and are accepted as an argument by MachineRocket and stored as a member vector, and are iterated over in the main `MachineRocket::update` loop as before. Hopefully this new use case will help stimulate some brainstorming over how to improve the pipe system.