### PR TITLE
Add Release Artifact to GitHub CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,3 +24,14 @@ jobs:
       run: |
         scan-build --exclude 3rdparty/newton-dynamics -o scanlogs cmake -B build -DCMAKE_BUILD_TYPE=Release -DOSP_ENABLE_IWYU=y -DOSP_ENABLE_CLANG_TIDY=y
         scan-build --exclude 3rdparty/newton-dynamics -o scanlogs cmake --build build --parallel --config Release --target osp-magnum
+        
+    - name: Prepare Artifact
+      run: |
+        mv build/3rdparty/newton-dynamics/lib/ build/lib
+        
+    - uses: actions/upload-artifact@v2
+      with: 
+        name: release
+        path: |
+          build/bin
+          build/lib

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,3 +23,12 @@ jobs:
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=x64-windows -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
         cmake --build build --parallel --config Release --target osp-magnum
+    
+    - name: Prepare Artifact
+      run: |
+        move build\bin\OSPData build\bin\Release\OSPData
+  
+    - uses: actions/upload-artifact@v2
+      with: 
+        name: release
+        path: build\bin\Release


### PR DESCRIPTION
This tells the CI to upload binaries after they compile for both Windows and Linux. I'm not quite sure if I'm doing this properly. 

Windows version is tested to work in wine.

Linux version needs to set bin/osp-magnum as executable, then in bin run `LD_LIBRARY_PATH=../lib osp-magnum`