### PR TITLE
Use entt type name

### DIFF
--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -45,8 +45,6 @@ class SysMachineRCSController :
     public osp::active::SysMachine<SysMachineRCSController, MachineRCSController>
 {
 public:
-    static inline std::string smc_name = "RCSController";
-
     SysMachineRCSController(osp::active::ActiveScene &rScene);
 
     /**
@@ -135,3 +133,14 @@ inline MachineRCSController& MachineRCSController::operator=(MachineRCSControlle
 }
 
 } // adera::active::machines
+
+namespace entt
+{
+    template<>
+    struct type_name<adera::active::machines::SysMachineRCSController>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "RCSController";
+        }
+    };
+} // namespace entt

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -39,9 +39,6 @@ class SysMachineRocket :
         public osp::active::SysMachine<SysMachineRocket, MachineRocket>
 {
 public:
-
-    static inline std::string smc_name = "Rocket";
-
     SysMachineRocket(osp::active::ActiveScene &scene);
 
     //void update_sensor();
@@ -169,3 +166,14 @@ inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
 }
 
 } // namespace adera::active::machines
+
+namespace entt
+{
+    template<>
+    struct type_name<adera::active::machines::SysMachineRocket>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Rocket";
+        }
+    };
+} // namespace entt

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -32,8 +32,6 @@ using namespace adera::active::machines;
 using namespace osp::active;
 using namespace osp;
 
-const std::string SysMachineUserControl::smc_name = "UserControl";
-
 void MachineUserControl::propagate_output(WireOutput* output)
 {
     std::cout << "propagate test: " << output->get_name() << "\n";

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -40,9 +40,6 @@ class SysMachineUserControl :
         public osp::active::SysMachine<SysMachineUserControl, MachineUserControl>
 {
 public:
-
-    static const std::string smc_name;
-
     SysMachineUserControl(osp::active::ActiveScene &scene,
                           osp::UserInputHandler& userControl);
 
@@ -125,3 +122,14 @@ inline MachineUserControl& MachineUserControl::operator=(MachineUserControl&& mo
 }
 
 } // namespace adera::active::machines
+
+namespace entt
+{
+    template<>
+    struct type_name<adera::active::machines::SysMachineUserControl>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "UserControl";
+        }
+    };
+} // namespace entt

--- a/src/adera/ShipResources.h
+++ b/src/adera/ShipResources.h
@@ -117,8 +117,6 @@ class SysMachineContainer
     : public osp::active::SysMachine<SysMachineContainer, MachineContainer>
 {
 public:
-    static inline std::string smc_name = "Container";
-
     SysMachineContainer(osp::active::ActiveScene& rScene);
 
     static void update_containers(osp::active::ActiveScene& rScene);
@@ -205,3 +203,14 @@ inline MachineContainer& MachineContainer::operator=(MachineContainer&& move) no
 }
 
 } // namespace adera::active::machines
+
+namespace entt
+{
+    template<>
+    struct type_name<adera::active::machines::SysMachineContainer>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Container";
+        }
+    };
+} // namespace entt

--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -40,8 +40,6 @@ struct ACompExhaustPlume
 class SysExhaustPlume : public IDynamicSystem
 {
 public:
-    static inline std::string smc_name = "ExhaustPlume";
-
     SysExhaustPlume(ActiveScene& rScene);
     ~SysExhaustPlume() = default;
 
@@ -64,3 +62,14 @@ private:
 };
 
 } // namespace osp::active
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysExhaustPlume>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "ExhaustPlume";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -275,7 +275,7 @@ private:
 template<class SYSMACH_T, typename... ARGS_T>
 void ActiveScene::system_machine_create(ARGS_T &&... args)
 {
-    system_machine_add(SYSMACH_T::smc_name,
+    system_machine_add(entt::type_name<SYSMACH_T>::value(),
                        std::make_unique<SYSMACH_T>(*this, args...));
 }
 
@@ -286,7 +286,7 @@ DYNSYS_T& ActiveScene::dynamic_system_create(ARGS_T &&... args)
     auto ptr = std::make_unique<DYNSYS_T>(*this, std::forward<ARGS_T>(args)...);
     DYNSYS_T &refReturn = *ptr;
 
-    auto pair = m_dynamicSys.emplace(DYNSYS_T::smc_name, std::move(ptr));
+    auto pair = m_dynamicSys.emplace(entt::type_name<DYNSYS_T>::value(), std::move(ptr));
 
     return refReturn;
 }
@@ -294,7 +294,7 @@ DYNSYS_T& ActiveScene::dynamic_system_create(ARGS_T &&... args)
 template<class SYSTEM_T>
 SYSTEM_T& ActiveScene::dynamic_system_find()
 {
-    MapDynamicSys_t::iterator it = dynamic_system_find(SYSTEM_T::smc_name);
+    MapDynamicSys_t::iterator it = dynamic_system_find(entt::type_name<SYSTEM_T>::value());
     assert(it != m_dynamicSys.end());
     return static_cast<SYSTEM_T&>(*(it->second));
 }

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -37,8 +37,6 @@ using osp::universe::UCompActivatable;
 using osp::universe::UCompActivationRadius;
 using osp::universe::UCompActiveArea;
 
-const std::string SysAreaAssociate::smc_name = "AreaAssociate";
-
 SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene)
  : m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
                 &SysAreaAssociate::update_scan)

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -72,9 +72,6 @@ struct ACompActivatedSat
 class SysAreaAssociate : public IDynamicSystem
 {
 public:
-
-    static const std::string smc_name;
-
     SysAreaAssociate(ActiveScene &rScene);
     ~SysAreaAssociate() = default;
 
@@ -144,3 +141,14 @@ private:
 };
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysAreaAssociate>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "AreaAssociate";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/SysDebugRender.cpp
+++ b/src/osp/Active/SysDebugRender.cpp
@@ -39,8 +39,6 @@ using namespace std::placeholders;
 // for the 0xrrggbb_rgbf and _deg literals
 using namespace Magnum::Math::Literals;
 
-const std::string SysDebugRender::smc_name = "DebugRender";
-
 SysDebugRender::SysDebugRender(ActiveScene &rScene) :
         m_scene(rScene),
         m_renderDebugDraw(rScene.get_render_order(), "debug", "", "",
@@ -94,4 +92,3 @@ void SysDebugRender::draw(ACompCamera const& camera)
     Renderer::setFaceCullingMode(Renderer::PolygonFacing::Back);
     draw_group(transparentObjects, camera);
 }
-

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -57,9 +57,6 @@ struct CompVisibleDebug
 class SysDebugRender : public IDynamicSystem
 {
 public:
-
-    static const std::string smc_name;
-
     SysDebugRender(ActiveScene &rScene);
     ~SysDebugRender() = default;
 
@@ -90,3 +87,14 @@ inline void SysDebugRender::draw_group(T& rCollection, ACompCamera const& camera
 }
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysDebugRender>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "DebugRender";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/SysForceFields.cpp
+++ b/src/osp/Active/SysForceFields.cpp
@@ -28,8 +28,6 @@
 
 using namespace osp::active;
 
-const std::string SysFFGravity::smc_name = "FFGravity";
-
 SysFFGravity::SysFFGravity(ActiveScene &scene)
  : m_scene(scene)
  , m_updateForce(scene.get_update_order(), "ff_gravity", "", "physics",

--- a/src/osp/Active/SysForceFields.h
+++ b/src/osp/Active/SysForceFields.h
@@ -62,22 +62,25 @@ struct ACompFFGravity : public BaseACompFF
 class SysFFGravity : public SysForceField
 {
 public:
-
-    static const std::string smc_name;
-
     SysFFGravity(ActiveScene &scene);
     ~SysFFGravity() = default;
 
     void update_force(ActiveScene& rScene);
 
 private:
-
-
     ActiveScene &m_scene;
-
     UpdateOrderHandle_t m_updateForce;
 };
 
-
-
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysFFGravity>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "FFGravity";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/SysNewton.h
+++ b/src/osp/Active/SysNewton.h
@@ -93,11 +93,7 @@ using ACompPhysicsWorld_t = ACompNwtWorld;
 
 class SysNewton : public IDynamicSystem
 {
-
 public:
-
-    static inline std::string smc_name = "NewtonPhysics";
-
     SysNewton(ActiveScene &scene);
     SysNewton(SysNewton const& copy) = delete;
     SysNewton(SysNewton&& move) = delete;
@@ -310,3 +306,13 @@ using SysPhysics_t = SysNewton;
 
 }
 
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysNewton>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "NewtonPhysics";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -49,8 +49,6 @@ using osp::universe::UCompVehicle;
 // for the 0xrrggbb_rgbf literalsm
 using namespace Magnum::Math::Literals;
 
-const std::string SysVehicle::smc_name = "Vehicle";
-
 SysVehicle::SysVehicle(ActiveScene &scene)
  : m_updateActivation(
        scene.get_update_order(), "vehicle_activate", "", "vehicle_modification",

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -82,9 +82,6 @@ struct ACompPart
 class SysVehicle : public IDynamicSystem
 {
 public:
-
-    static const std::string smc_name;
-
     SysVehicle(ActiveScene &scene);
     SysVehicle(SysNewton const& copy) = delete;
     SysVehicle(SysNewton&& move) = delete;
@@ -209,5 +206,15 @@ private:
     UpdateOrderHandle_t m_updateVehicleModification;
 };
 
-
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysVehicle>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Vehicle";
+        }
+    };
+} // namespace entt

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -30,9 +30,6 @@
 using namespace osp;
 using namespace osp::active;
 
-
-const std::string SysWire::smc_name = "Wire";
-
 WireData* WireInput::connected_value()
 {
     WireOutput* woConnected = list();

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -273,9 +273,6 @@ private:
 class SysWire : public IDynamicSystem
 {
 public:
-
-    static const std::string smc_name;
-
     struct DependentOutput
     {
         IWireElement *m_element;
@@ -348,3 +345,15 @@ inline WireOutput::WireOutput(IWireElement *element, WireOutput&& move)
 { }
 
 } // namespace osp::active
+
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::active::SysWire>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Wire";
+        }
+    };
+} // namespace entt

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -78,9 +78,6 @@ struct UCompActiveArea
 class SatActiveArea
 {
 public:
-
-    static constexpr std::string_view smc_name = "ActiveArea";
-
     /**
      * Set the type of a Satellite and add a UCompActiveArea to it
      * @param rUni [out] Universe containing satellite
@@ -92,3 +89,14 @@ public:
 };
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::universe::SatActiveArea>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "ActiveArea";
+        }
+    };
+} // namespace entt

--- a/src/osp/Satellites/SatVehicle.h
+++ b/src/osp/Satellites/SatVehicle.h
@@ -43,9 +43,6 @@ struct UCompVehicle
 class SatVehicle
 {
 public:
-
-    static constexpr std::string_view smc_name = "Vehicle";
-
     /**
      * Set the type of a Satellite and add a UCompVehicle to it
      * @param rUni      [out] Universe containing satellite
@@ -59,3 +56,14 @@ public:
 };
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<osp::universe::SatVehicle>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Vehicle";
+        }
+    };
+} // namespace entt

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -68,8 +68,6 @@ using namespace Magnum::Math::Literals;
 
 using osp::universe::Satellite;
 
-const std::string SysPlanetA::smc_name = "PlanetA";
-
 SysPlanetA::SysPlanetA(osp::active::ActiveScene &scene,
                        osp::UserInputHandler &userInput)
  : m_scene(scene)

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -57,9 +57,6 @@ struct ACompPlanet
 class SysPlanetA : public osp::active::IDynamicSystem
 {
 public:
-
-    static const std::string smc_name;
-
     SysPlanetA(osp::active::ActiveScene &scene,
                osp::UserInputHandler &userInput);
     ~SysPlanetA() = default;
@@ -97,3 +94,14 @@ private:
 };
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<planeta::active::SysPlanetA>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "PlanetA";
+        }
+    };
+} // namespace entt

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -31,9 +31,6 @@
 namespace planeta::universe
 {
 
-//using namespace osp;
-//using namespace osp::universe;
-
 struct UCompPlanet
 {
     double m_radius;
@@ -61,9 +58,6 @@ struct UCompPlanet
 class SatPlanet
 {
 public:
-
-    static constexpr std::string_view smc_name = "Planet";
-
     /**
      * Set the type of a Satellite and add a UCompPlanet to it
      * @param rUni                 [out] Universe containing satellite
@@ -81,3 +75,14 @@ public:
 };
 
 }
+
+namespace entt
+{
+    template<>
+    struct type_name<planeta::universe::SatPlanet>
+    {
+        [[nodiscard]] static constexpr std::string_view value() noexcept {
+            return "Planet";
+        }
+    };
+} // namespace entt


### PR DESCRIPTION
This PR includes https://github.com/TheOpenSpaceProgram/osp-magnum/pull/69, and should only be looked at after 69 is merged.

Instead of manually defining static const std::string = "", use the entt::type_name type instead.