### PR TITLE
Remove Satellite Types

### DIFF
--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -34,28 +34,15 @@
 namespace osp::active
 {
 
-struct ActivationTracker
-{
-    using MapSatToEnt_t = std::unordered_map<universe::Satellite, ActiveEnt>;
-
-    // Satellites that are currently inside the active area
-    // possibly replace with a single entt sparse_set in ACompAreaLink
-    MapSatToEnt_t m_inside;
-
-    std::vector<MapSatToEnt_t::iterator> m_enter;
-    std::vector<std::pair<universe::Satellite, ActiveEnt>> m_leave;
-};
 
 struct ACompAreaLink
 {
+    using MapSatToEnt_t = std::unordered_map<universe::Satellite, ActiveEnt>;
+    
     ACompAreaLink(universe::Universe& rUniverse, universe::Satellite areaSat)
      : m_areaSat(areaSat)
      , m_rUniverse(rUniverse)
-     , m_activated(rUniverse.sat_type_count())
     { }
-
-    ActivationTracker& get_tracker(universe::TypeSatIndex type)
-    { return m_activated[std::size_t(type)]; }
 
     universe::Universe& get_universe() noexcept
     { return m_rUniverse.get(); }
@@ -63,7 +50,13 @@ struct ACompAreaLink
     universe::Satellite m_areaSat;
 
     std::reference_wrapper<universe::Universe> m_rUniverse;
-    std::vector<ActivationTracker> m_activated;
+
+    // Satellites that are currently inside the active area
+    // possibly replace with a single entt sparse_set in ACompAreaLink
+    MapSatToEnt_t m_inside;
+
+    std::vector<MapSatToEnt_t::iterator> m_enter;
+    std::vector<std::pair<universe::Satellite, ActiveEnt>> m_leave;
 
 };
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -44,7 +44,7 @@ using namespace osp::active;
 
 using osp::universe::Universe;
 using osp::universe::Satellite;
-using osp::universe::TypeSatIndex;
+using osp::universe::UCompVehicle;
 
 // for the 0xrrggbb_rgbf literalsm
 using namespace Magnum::Math::Literals;
@@ -446,12 +446,15 @@ void SysVehicle::update_activate(ActiveScene &rScene)
     }
 
     Universe &rUni = pArea->get_universe();
-    TypeSatIndex type = rUni.sat_type_find_index<universe::SatVehicle>();
-    ActivationTracker& activations = pArea->get_tracker(type);
 
     // Delete vehicles that have gone too far from the ActiveArea range
-    for (auto const &[sat, ent] : activations.m_leave)
+    for (auto const &[sat, ent] : pArea->m_leave)
     {
+        if (!rUni.get_reg().has<UCompVehicle>(sat))
+        {
+            continue;
+        }
+
         rScene.hier_destroy(ent);
     }
 
@@ -467,10 +470,15 @@ void SysVehicle::update_activate(ActiveScene &rScene)
     }
 
     // Activate nearby vehicle satellites that have just entered the ActiveArea
-    for (auto &entered : activations.m_enter)
+    for (auto &entered : pArea->m_enter)
     {
         universe::Satellite sat = entered->first;
         ActiveEnt &rEnt = entered->second;
+
+        if (!rUni.get_reg().has<UCompVehicle>(sat))
+        {
+            continue;
+        }
 
         rEnt = activate(rScene, rUni, pArea->m_areaSat, sat);
     }

--- a/src/osp/Satellites/SatActiveArea.cpp
+++ b/src/osp/Satellites/SatActiveArea.cpp
@@ -30,9 +30,5 @@ using osp::universe::SatActiveArea;
 
 UCompActiveArea& SatActiveArea::add_active_area(Universe &rUni, Satellite sat)
 {
-    bool typeSetSuccess = rUni.sat_type_try_set(
-                sat, rUni.sat_type_find_index(SatActiveArea::smc_name));
-    assert(typeSetSuccess);
-
     return rUni.get_reg().emplace<UCompActiveArea>(sat);
 }

--- a/src/osp/Satellites/SatVehicle.cpp
+++ b/src/osp/Satellites/SatVehicle.cpp
@@ -30,10 +30,6 @@ using osp::universe::SatVehicle;
 UCompVehicle& SatVehicle::add_vehicle(
         Universe &rUni, Satellite sat, DependRes<BlueprintVehicle> blueprint)
 {
-    bool typeSetSuccess = rUni.sat_type_try_set(
-                sat, rUni.sat_type_find_index(SatVehicle::smc_name));
-    assert(typeSetSuccess);
-
     rUni.get_reg().emplace<UCompActivatable>(sat);
     rUni.get_reg().emplace<UCompActivationRadius>(sat);
 

--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -41,24 +41,12 @@ Satellite Universe::sat_create()
 {
     Satellite sat = m_registry.create();
     m_registry.emplace<UCompTransformTraj>(sat);
-    m_registry.emplace<UCompType>(sat);
     return sat;
 }
 
 void Universe::sat_remove(Satellite sat)
 {
     m_registry.destroy(sat);
-}
-
-bool Universe::sat_try_set_type(Satellite sat, TypeSatIndex type)
-{
-    auto &satType = m_registry.get<UCompType>(sat);
-    if (satType.m_type == TypeSatIndex::Invalid)
-    {
-        satType.m_type = type;
-        return true;
-    }
-    return false; // Type is already set
 }
 
 Vector3s Universe::sat_calc_pos(Satellite referenceFrame, Satellite target) const
@@ -83,28 +71,5 @@ Vector3 Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target
 {
     // 1024 units = 1 meter. this can change
     return Vector3(sat_calc_pos(referenceFrame, target)) / 1024.0f;
-}
-
-TypeSatIndex Universe::sat_type_find_index(std::string_view name)
-{
-    auto foundIt = m_typeSatIndices.find(name);
-
-    if (foundIt != m_typeSatIndices.end())
-    {
-        return foundIt->second;
-    }
-
-    return TypeSatIndex::Invalid;
-}
-
-bool Universe::sat_type_try_set(Satellite sat, TypeSatIndex type)
-{
-    auto &satType = m_registry.get<UCompType>(sat);
-    if (satType.m_type != TypeSatIndex::Invalid)
-    {
-        return false;
-    }
-    satType.m_type = type;
-    return true;
 }
 

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -41,11 +41,6 @@ class ISystemTrajectory;
 
 enum class Satellite : entt::id_type {};
 
-enum class TypeSatIndex : uint16_t
-{
-    Invalid = std::numeric_limits<uint16_t>::max()
-};
-
 /**
  * A model of deep space. This class stores the data of astronomical objects
  * represented in the universe, known as Satellites. Planets, stars, comets,
@@ -69,7 +64,6 @@ enum class TypeSatIndex : uint16_t
  */
 class Universe
 {
-    using MapTypeSats_t = std::map<std::string_view, TypeSatIndex, std::less<>>;
 
 public:
 
@@ -102,8 +96,6 @@ public:
      */
     void sat_remove(Satellite sat);
 
-    bool sat_try_set_type(Satellite sat, TypeSatIndex type);
-
     /**
      * Calculate position between two satellites.
      * @param referenceFrame [in]
@@ -121,54 +113,6 @@ public:
     Vector3 sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const;
 
     /**
-     * Register an ITypeSatellite so the universe can recognize that this type
-     * of Satellite can exist.
-     * @tparam TYPESAT_T Unique ITypeSatellite to register
-     * @tparam ARGS_T Arguments to forward to TYPESAT_T's constructor
-     * @return reference to new TYPESAT_T just created
-     */
-    template<typename TYPESAT_T>
-    TypeSatIndex sat_type_register();
-
-    /**
-     * @return Names of registered satellites. Access using a TypeSatIndex
-     */
-    constexpr std::vector<std::string_view> const& sat_type_get_names() const
-    noexcept { return m_typeSatNames; }
-
-    /**
-     * @return Number of reistered satellites
-     */
-    std::underlying_type<TypeSatIndex>::type sat_type_count() const noexcept
-    { return m_typeSatIndices.size(); }
-
-    /**
-     * Find index of a registered satellite by name
-     * @param name [in] Name of satellite to find
-     * @return Index of type, TypeSatIndex::Invalid if not found.
-     */
-    TypeSatIndex sat_type_find_index(std::string_view name);
-
-    /**
-     * Find index of a registered satellite by type. The type should contain a
-     * static member string named smc_name
-     * @tparam SATTYPE_T Satellite type containing smc_name
-     * @return Index of type, TypeSatIndex::Invalid if not found.
-     */
-    template<typename SATTYPE_T>
-    TypeSatIndex sat_type_find_index()
-    { return sat_type_find_index(SATTYPE_T::smc_name); }
-
-    /**
-     * Attempt to set the type of a Satellite. If a type is already set, then
-     * the type will not be set successfully.
-     * @param sat  [in] Satellite to set type of
-     * @param type [in] Type to set to
-     * @return True if type is set succesfully, or else false
-     */
-    bool sat_type_try_set(Satellite sat, TypeSatIndex type);
-
-    /**
      * Create a Trajectory, and add it to the universe.
      * @tparam TRAJECTORY_T Type of Trajectory to construct
      * @return Reference to new trajectory just created
@@ -184,30 +128,11 @@ private:
 
     Satellite m_root;
 
-    // TODO: change to std::vector<>
     std::vector<std::unique_ptr<ISystemTrajectory>> m_trajectories;
-
-    // TODO: get rid of satellite types entirely, they suck
-    MapTypeSats_t m_typeSatIndices;
-    std::vector<std::string_view> m_typeSatNames;
 
     Registry_t m_registry;
 
 };
-
-template<typename TYPESAT_T>
-TypeSatIndex Universe::sat_type_register()
-{
-    TypeSatIndex newIndex = static_cast<TypeSatIndex>(m_typeSatIndices.size());
-    auto const &[it, success] = m_typeSatIndices.emplace(TYPESAT_T::smc_name,
-                                                         newIndex);
-    if (success)
-    {
-        m_typeSatNames.emplace_back(TYPESAT_T::smc_name);
-        return newIndex;
-    }
-    return TypeSatIndex::Invalid;
-}
 
 template<typename TRAJECTORY_T, typename ... ARGS_T>
 TRAJECTORY_T& Universe::trajectory_create(ARGS_T&& ... args)
@@ -245,10 +170,6 @@ struct UCompVelocity
     Vector3 m_velocity;
 };
 
-struct UCompType
-{
-    TypeSatIndex m_type{TypeSatIndex::Invalid};
-};
 
 // TODO: move to different files and de-OOPify trajectories too
 

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 
 using planeta::active::SysPlanetA;
+using planeta::universe::UCompPlanet;
 
 using osp::active::ActiveScene;
 using osp::active::ActiveEnt;
@@ -50,11 +51,9 @@ using osp::active::ACompAreaLink;
 using osp::active::ACompActivatedSat;
 using osp::active::SysAreaAssociate;
 using osp::active::SysPhysics_t;
-using osp::active::ActivationTracker;
 
 using osp::universe::Universe;
 using osp::universe::Satellite;
-using osp::universe::TypeSatIndex;
 
 using Magnum::GL::Renderer;
 using osp::Matrix4;
@@ -200,20 +199,29 @@ void SysPlanetA::update_activate(ActiveScene &rScene)
     }
 
     Universe &rUni = pArea->get_universe();
-    TypeSatIndex type = rUni.sat_type_find_index<universe::SatPlanet>();
-    ActivationTracker& activations = pArea->get_tracker(type);
-
+    
     // Delete planets that have exited the ActiveArea
-    for (auto const &[sat, ent] : activations.m_leave)
+    for (auto const &[sat, ent] : pArea->m_leave)
     {
+        if (!rUni.get_reg().has<UCompPlanet>(sat))
+        {
+            continue;
+        }
+
         rScene.hier_destroy(ent);
     }
 
     // Activate planets that have just entered the ActiveArea
-    for (auto &entered : activations.m_enter)
+    for (auto &entered : pArea->m_enter)
     {
         Satellite sat = entered->first;
         ActiveEnt &rEnt = entered->second;
+
+        if (!rUni.get_reg().has<UCompPlanet>(sat))
+        {
+            continue;
+        }
+
         rEnt = activate(rScene, rUni, pArea->m_areaSat, sat);
     }
 }

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -37,10 +37,6 @@ UCompPlanet& SatPlanet::add_planet(
         osp::universe::Universe& rUni, Satellite sat, double radius, float mass,
         float resolutionSurfaceMax, float resolutionScreenMax)
 {
-    bool typeSetSuccess = rUni.sat_type_try_set(
-                sat, rUni.sat_type_find_index(SatPlanet::smc_name));
-    assert(typeSetSuccess);
-
     rUni.get_reg().emplace<UCompActivatable>(sat);
     rUni.get_reg().emplace<UCompActivationRadius>(sat, float(radius));
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -55,11 +55,6 @@ void config_controls();
 void load_a_bunch_of_stuff();
 
 /**
- * Register satellite types into the universe to add support for them.
- */
-void register_universe_types();
-
-/**
  * Try to everything in the universe
  */
 bool destroy_universe();
@@ -100,7 +95,6 @@ int main(int argc, char** argv)
 
     load_a_bunch_of_stuff();
 
-    register_universe_types();
 
     create_simple_solar_system(g_osp);
 
@@ -265,14 +259,6 @@ void load_a_bunch_of_stuff()
     std::cout << "Resource loading complete\n\n";
 }
 
-void register_universe_types()
-{
-    osp::universe::Universe &uni = g_osp.get_universe();
-    uni.sat_type_register<osp::universe::SatActiveArea>();
-    uni.sat_type_register<osp::universe::SatVehicle>();
-    uni.sat_type_register<planeta::universe::SatPlanet>();
-}
-
 void debug_print_help()
 {
     std::cout
@@ -407,38 +393,36 @@ void debug_print_sats()
 {
     using osp::universe::Universe;
     using osp::universe::UCompTransformTraj;
-    using osp::universe::UCompType;
 
     Universe const &rUni = g_osp.get_universe();
 
-    std::vector<std::string_view> const& typeSatNames
-            = rUni.sat_type_get_names();
-
-    auto const view = rUni.get_reg().view<const UCompTransformTraj,
-                                              const UCompType>();
+    Universe::Registry_t const &reg = rUni.get_reg();
+    auto const view = reg.view<const UCompTransformTraj>();
 
     for (osp::universe::Satellite sat : view)
     {
         auto const &posTraj = view.get<const UCompTransformTraj>(sat);
-        auto const &type = view.get<const UCompType>(sat);
 
         osp::Vector3s const &pos = posTraj.m_position;
 
-        std::cout << "SATELLITE: \"" << posTraj.m_name << "\" \n";
-        if (type.m_type != osp::universe::TypeSatIndex::Invalid)
-        {
-            std::cout << " * Type: " << typeSatNames[size_t(type.m_type)]
-                      << "\n";
-        }
+        std::cout << "* SATELLITE: \"" << posTraj.m_name << "\"\n";
+
+        rUni.get_reg().visit(sat, [&reg] (entt::type_info info) {
+            Universe::Registry_t::poly_storage storage = reg.storage(info);
+            std::cout << "  * UComp: " << storage->value_type().name() << "\n";
+        });
 
         if (posTraj.m_trajectory != nullptr)
         {
-            std::cout << " * Trajectory: "
+            std::cout << "  * Trajectory: "
                       << posTraj.m_trajectory->get_type_name() << "\n";
         }
 
-        std::cout << " * Position: ["
-                  << pos.x() << ", " << pos.y() << ", " << pos.z() << "]\n";
+        auto posM = osp::Vector3(pos) / 1024.0f;
+        std::cout << "  * Position: ["
+                  << pos.x() << ", " << pos.y() << ", " << pos.z() << "], ["
+                  << posM.x() << ", " << posM.y() << ", " << posM.z()
+                  << "] meters\n";
     }
 
 


### PR DESCRIPTION
### Some Context

Satellites have a component named UCompType to determine if they're a Planet, Vehicle, ActiveArea, etc. Types needed to be registered at the start of the program, assigned a sequential TypeSatIndex. They are used by Activate functions to create a physical representation of a Satellite in the ActiveScene.

### Problem

The Type is only a hint at what components a Satellite contains, and is a remnant of when the Universe was inheritance-based. Problems arise in how Activate functions are tied to type, instead of specific components. This means that the Activate functions must know about all the components that is contained in a type, and cannot be extended.

For example, if Atmospheres were added, then the Planet Activate function would need to know about Atmospheres specifically. If a Star type was added too, that also have Atmospheres, then both the Planet and the Star activate functions would need to separately implement Atmospheres.

### Changes

The current system is misusing ECS, and a better solution would be to have an Activate function for each component instead of each type.

This PR removes Satellite Types entirely:

* Removed lots of code related to Satellite Ttypes
* ACompAreaLink now stores a single set of "entered, exited, and already inside" queues and maps, instead of a separate one for each Satellite Type (ActivationTracker struct). This was quite complicated before, and should be easier to understand now. 
* Activate functions would now have to check if an entered/exited Satellite contain the right component. See `SatPlanet::update_activate` and `SysVehicle::update_activate`
* Modified `list_uni` debug CLI command to list components instead of showing type



