### PR TITLE
Remove unsigneds

### DIFF
--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -219,14 +219,14 @@ void SysVehicle::add_machines_to_object(ActiveScene& rScene,
     ActiveEnt partEnt, ActiveEnt objEnt,
     std::vector<PrototypeMachine> const& protoMachines,
     std::vector<BlueprintMachine> const& blueprintMachines,
-    std::vector<unsigned> const& machineIndices)
+    std::vector<uint32_t> const& machineIndices)
 {
     if (machineIndices.empty()) { return; }
 
     auto &compMachines =
         rScene.get_registry().get_or_emplace<ACompMachines>(partEnt);
 
-    for (unsigned i : machineIndices)
+    for (uint32_t i : machineIndices)
     {
         BlueprintMachine const& bpMachine = blueprintMachines[i];
         PrototypeMachine const& protoMachine = protoMachines[i];
@@ -355,9 +355,9 @@ std::pair<ActiveEnt, std::vector<SysVehicle::MachineDef>> SysVehicle::part_insta
 
             std::vector<DependRes<Texture2D>> textureResources;
             textureResources.reserve(drawable.m_textures.size());
-            for (unsigned i = 0; i < drawable.m_textures.size(); i++)
+            for (size_t i = 0; i < drawable.m_textures.size(); i++)
             {
-                unsigned texID = drawable.m_textures[i];
+                uint32_t texID = drawable.m_textures[i];
                 std::string const& texName = part.get_strings()[texID];
                 DependRes<Texture2D> texRes = glResources.get<Texture2D>(texName);
 
@@ -524,7 +524,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
 
             // NOTE: vehicleVehicle and vehicleTransform become invalid
             //       when emplacing new ones.
-            for (unsigned i = 1; i < islands.size(); i ++)
+            for (size_t i = 1; i < islands.size(); i ++)
             {
                 ActiveEnt islandEnt = rScene.hier_create_child(
                             rScene.hier_get_root());

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -124,9 +124,9 @@ private:
     struct MachineDef
     {
         ActiveEnt m_machineOwner;
-        std::vector<unsigned> const& m_machineIndices;
+        std::vector<uint32_t> const& m_machineIndices;
 
-        MachineDef(ActiveEnt owner, std::vector<unsigned> const& indexArray)
+        MachineDef(ActiveEnt owner, std::vector<uint32_t> const& indexArray)
             : m_machineOwner(owner)
             , m_machineIndices(indexArray)
         {}

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -79,7 +79,7 @@ void osp::AssetImporter::load_sturdy_file(std::string_view filepath, Package& pk
     gltfImporter.close();
 }
 
-std::vector<unsigned> AssetImporter::load_machines(tinygltf::Value const& extras,
+std::vector<uint32_t> AssetImporter::load_machines(tinygltf::Value const& extras,
     std::vector<PrototypeMachine>& machineArray)
 {
     if (!extras.Has("machines"))
@@ -91,7 +91,7 @@ std::vector<unsigned> AssetImporter::load_machines(tinygltf::Value const& extras
     std::cout << "JSON machines!\n";
     auto const& machArray = machines.Get<tinygltf::Value::Array>();
 
-    std::vector<unsigned> machineIndices;
+    std::vector<uint32_t> machineIndices;
     machineIndices.reserve(machArray.size());
     // Loop through machine configs
     // machArray looks like:
@@ -191,7 +191,7 @@ void osp::AssetImporter::load_plume(TinyGltfImporter& gltfImporter,
 
     // Get mesh data
     Pointer<ObjectData3D> rootNode = gltfImporter.object3D(id);
-    unsigned meshID = gltfImporter.object3D(rootNode->children()[0])->instance();
+    Magnum::Int meshID = gltfImporter.object3D(rootNode->children()[0])->instance();
     std::string meshName = string_concat(resPrefix, gltfImporter.meshName(meshID));
 
     // Get shader params from extras
@@ -457,7 +457,7 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
         // list of strings, and the object's mesh is set to the index to that
         // string.
         obj.m_objectData = DrawableData{
-            static_cast<unsigned>(part.get_strings().size())};
+            static_cast<uint32_t>(part.get_strings().size())};
         part.get_strings().push_back(meshName);
 
         MeshObjectData3D& mesh = static_cast<MeshObjectData3D&>(*childData);
@@ -471,7 +471,7 @@ void AssetImporter::proto_add_obj_recurse(TinyGltfImporter& gltfImporter,
             std::string const& imgName = gltfImporter.image2DName(imgID);
             std::cout << "Base Tex: " << imgName << "\n";
             std::get<DrawableData>(obj.m_objectData).m_textures.push_back(
-                static_cast<unsigned>(part.get_strings().size()));
+                static_cast<uint32_t>(part.get_strings().size()));
             part.get_strings().push_back(imgName);
 
             if (pbr.hasNoneRoughnessMetallicTexture())

--- a/src/osp/Resource/PrototypePart.h
+++ b/src/osp/Resource/PrototypePart.h
@@ -52,8 +52,8 @@ struct DrawableData
 {
 
     // index to a PrototypePart.m_meshDataUsed
-    unsigned m_mesh;
-    std::vector<unsigned> m_textures;
+    uint32_t m_mesh;
+    std::vector<uint32_t> m_textures;
     //std::string m_mesh;
     //unsigned m_material;
 };

--- a/src/osp/Resource/blueprints.cpp
+++ b/src/osp/Resource/blueprints.cpp
@@ -33,10 +33,10 @@ BlueprintPart& BlueprintVehicle::add_part(
         const Quaternion& rotation,
         const Vector3& scale)
 {
-    unsigned partIndex = m_prototypes.size();
+    size_t partIndex = m_prototypes.size();
 
     // check if the part is added already.
-    for (unsigned i = 0; i < partIndex; i ++)
+    for (size_t i = 0; i < partIndex; i ++)
     {
         const DependRes<PrototypePart>& dep = m_prototypes[i];
 
@@ -63,7 +63,7 @@ BlueprintPart& BlueprintVehicle::add_part(
 
     BlueprintPart blueprint
     {
-        partIndex,
+        static_cast<uint32_t>(partIndex),
         translation,
         rotation,
         scale,
@@ -76,8 +76,8 @@ BlueprintPart& BlueprintVehicle::add_part(
 }
 
 void BlueprintVehicle::add_wire(
-        unsigned fromPart, unsigned fromMachine, WireOutPort fromPort,
-        unsigned toPart, unsigned toMachine, WireInPort toPort)
+        uint32_t fromPart, uint32_t fromMachine, WireOutPort fromPort,
+        uint32_t toPart, uint32_t toMachine, WireInPort toPort)
 {
     m_wires.emplace_back(fromPart, fromMachine, fromPort,
                          toPart, toMachine, toPort);

--- a/src/osp/Resource/blueprints.h
+++ b/src/osp/Resource/blueprints.h
@@ -50,7 +50,7 @@ struct BlueprintMachine
 struct BlueprintPart
 { 
 
-    unsigned m_partIndex; // index to BlueprintVehicle's m_partsUsed
+    uint32_t m_partIndex; // index to BlueprintVehicle's m_partsUsed
 
     Vector3 m_translation;
     Quaternion m_rotation;

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -373,7 +373,7 @@ void SysPlanetA::planet_update_geometry(osp::active::ActiveEnt planetEnt,
 
     // update GPU index buffer
 
-    std::vector<unsigned> const &indxData = rPlanetGeo.get_index_buffer();
+    std::vector<buindex_t> const &indxData = rPlanetGeo.get_index_buffer();
 
     for (UpdateRangeSub updRange : rPlanetGeo.updates_get_index_changes())
     {

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -112,7 +112,7 @@ void DebugCameraController::update_vehicle_mod_pre()
         //tgtVehicle.m_separationCount = 1;
 
         // separate all parts into their own separation islands
-        for (unsigned i = 0; i < tgtVehicle.m_parts.size(); i ++)
+        for (size_t i = 0; i < tgtVehicle.m_parts.size(); i ++)
         {
             m_scene.reg_get<ACompPart>(tgtVehicle.m_parts[i])
                     .m_separationIsland = i;

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -353,7 +353,7 @@ void debug_print_hier()
     {
         // print some info about the entitysize() != 0
         auto const &hier = scene.reg_get<ACompHierarchy>(currentEnt);
-        for (unsigned i = 0; i < hier.m_level; i ++)
+        for (uint8_t i = 0; i < hier.m_level; i ++)
         {
             // print arrows to indicate level
             std::cout << "  ->";


### PR DESCRIPTION
This is the first sweep, but this removes all `unsigned` and `unsigned int`s. 

Mentioned in #63 