### PR TITLE
Update test universes and DebugCameraController for distant vehicles

### DIFF
--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -37,8 +37,11 @@ UCompPlanet& SatPlanet::add_planet(
         osp::universe::Universe& rUni, Satellite sat, double radius, float mass,
         float resolutionSurfaceMax, float resolutionScreenMax)
 {
+
+    float activateRadius = float(radius) * 256.0f;
+
     rUni.get_reg().emplace<UCompActivatable>(sat);
-    rUni.get_reg().emplace<UCompActivationRadius>(sat, float(radius));
+    rUni.get_reg().emplace<UCompActivationRadius>(sat, activateRadius);
 
     return rUni.get_reg().emplace<UCompPlanet>(
                 sat, radius, resolutionSurfaceMax, resolutionScreenMax, mass);

--- a/src/test_application/DebugObject.h
+++ b/src/test_application/DebugObject.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include <osp/Active/activetypes.h>
+#include <osp/Universe.h>
 #include <osp/UserInputHandler.h>
 #include <osp/types.h>
 
@@ -82,10 +83,14 @@ public:
     void update_vehicle_mod_pre();
     void update_physics_pre();
     void update_physics_post();
-    void view_orbit(osp::active::ActiveEnt ent);
+
+    bool try_switch_vehicle();
+    osp::active::ActiveEnt try_get_vehicle_ent();
+
 private:
 
-    osp::active::ActiveEnt m_orbiting;
+    //osp::active::ActiveEnt m_orbiting;
+    osp::universe::Satellite m_selected;
     osp::Vector3 m_orbitPos;
     float m_orbitDistance;
 

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -62,57 +62,45 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
     auto &stationary = rUni.trajectory_create<TrajStationary>(
                                         rUni, rUni.sat_root());
 
-    // Create 10 random vehicles
-    for (int i = 0; i < 10; i ++)
+    // Create 4 part vehicles
+    for (int i = 0; i < 4; i ++)
     {
-        // Creates a random mess of spamcans as a vehicle
-        Satellite sat = debug_add_random_vehicle(rUni, rPkg, "TestyMcTestFace Mk"
-                                                 + std::to_string(i));
+        Satellite sat = testapp::debug_add_part_vehicle(rUni, rPkg, "Placeholder Mk. I " + std::to_string(i));
 
         auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
 
-        posTraj.m_position = osp::Vector3s(i * 1024l * 5l, 0l, 0l);
+        posTraj.m_position = osp::Vector3s(i * 1024l * 4l, 0l, 0l);
         posTraj.m_dirty = true;
 
         stationary.add(sat);
     }
 
-    Satellite sat = debug_add_deterministic_vehicle(rUni, rPkg, "Stomper Mk. I");
+    /*Satellite sat = debug_add_deterministic_vehicle(rUni, rPkg, "Stomper Mk. I");
     auto& posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_position = osp::Vector3s(22 * 1024l * 5l, 0l, 0l);
     posTraj.m_dirty = true;
-    stationary.add(sat);
+    stationary.add(sat);*/
 
 
-    // Add Grid of planets too
+    // Add Moon
 
-    for (int x = -0; x < 1; x ++)
-    {
-        for (int z = -0; z < 1; z ++)
-        {
-            Satellite sat = rUni.sat_create();
+    Satellite moonSat = rUni.sat_create();
 
-            // Create the real world moon
-            float radius = 1.737E+6;
-            float mass = 7.347673E+22;
+    // Create the real world moon
+    float radius = 1.737E+6;
+    float mass = 7.347673E+22;
 
-            float resolutionScreenMax = 0.056f;
-            float resolutionSurfaceMax = 12.0f;
+    float resolutionScreenMax = 0.056f;
+    float resolutionSurfaceMax = 12.0f;
 
-            // assign sat as a planet
-            UCompPlanet &planet = SatPlanet::add_planet(
-                        rUni, sat, radius, mass, resolutionSurfaceMax,
-                        resolutionScreenMax);
+    // assign sat as a planet
+    SatPlanet::add_planet(rUni, moonSat, radius, mass, resolutionSurfaceMax,
+                          resolutionScreenMax);
 
-            auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
+    auto &moonPosTraj = rUni.get_reg().get<UCompTransformTraj>(moonSat);
 
-            // space planets 400m apart from each other
-            // 1024 units = 1 meter
-            posTraj.m_position = {x * 1024l * 400l,
-                                  -1024l * osp::SpaceInt(1.74E+6),
-                                  z * 1024l * 400l};
-        }
-    }
+    // 1024 units = 1 meter
+    moonPosTraj.m_position = {0 * 1024l, 1024l * osp::SpaceInt(1.74E+6), 0 * 1024l};
 
     std::cout << "Created Large Planet umm... moon!\n";
 }

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -54,7 +54,7 @@ using planeta::universe::UCompPlanet;
 void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
 {
     Universe &rUni = ospApp.get_universe();
-    Package &pkg = ospApp.debug_find_package("lzdb");
+    Package &rPkg = ospApp.debug_find_package("lzdb");
 
     // Create trajectory that will make things added to the universe stationary
     auto &stationary = rUni.trajectory_create<TrajStationary>(
@@ -64,7 +64,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
     for (int i = 0; i < 1; i ++)
     {
         // Creates a random mess of spamcans as a vehicle
-        Satellite sat = debug_add_random_vehicle(rUni, pkg, "TestyMcTestFace Mk"
+        Satellite sat = debug_add_random_vehicle(rUni, rPkg, "TestyMcTestFace Mk"
                                                  + std::to_string(i));
 
         auto &posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
@@ -76,7 +76,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
     }
 
     //Satellite sat = debug_add_deterministic_vehicle(uni, pkg, "Stomper Mk. I");
-    Satellite sat = testapp::debug_add_part_vehicle(rUni, pkg, "Placeholder Mk. I");
+    Satellite sat = testapp::debug_add_part_vehicle(rUni, rPkg, "Placeholder Mk. I");
     auto& posTraj = rUni.get_reg().get<UCompTransformTraj>(sat);
     posTraj.m_position = osp::Vector3s(22 * 1024l * 5l, 0l, 0l);
     posTraj.m_dirty = true;
@@ -109,7 +109,7 @@ void testapp::create_simple_solar_system(osp::OSPApplication& ospApp)
             // 1024 units = 1 meter
             posTraj.m_position = {x * 1024l * 400l,
                                   1024l * -300l,
-                                  z * 1024l * 400l};
+                                  z * 1024l * 6000l};
         }
     }
 


### PR DESCRIPTION
* Increased default activation radius of planets to 256x their radius. This stops the planet from disappearing at a short distance.
* DebugCameraController was modified to switch between vehicle satellites instead of only already-activated vehicles. This allows switching between very distant vehicles.
* Increased distance between planets in simple test universe
* Replaced moon test vehicles with 4 part vehicles instead of spamcans
* Added roll control to part vehicles by adding RCS "blocks" consisting of two RCS thrusters
* A few other minor cleanups