### PR TITLE
Add reserved Resources to Package and Add list_pkg CLI command

### DIFF
--- a/src/osp/Resource/Package.h
+++ b/src/osp/Resource/Package.h
@@ -82,6 +82,9 @@ class Package
 
 public:
 
+    template<class TYPE_T>
+    using group_t =  std::map<std::string, osp::Resource<TYPE_T>, std::less<>>;
+
     Package(std::string prefix, std::string packageName);
     Package(Package&& move) = default;
     Package(const Package& copy) = delete;
@@ -111,6 +114,21 @@ public:
     template<class TYPE_T>
     DependRes<TYPE_T> get(std::string_view path) noexcept;
 
+    /**
+     * Get a resource by path identifier. If it isn't found, then reserve the
+     * path to be loaded later.
+     *
+     * @tparam TYPE_T Type of resource to get
+     *
+     * @param path [in] String used to identify the target resource
+     * @return Reference counted dependency to the found or unloaded resource
+     */
+    template<class TYPE_T>
+    DependRes<TYPE_T> get_or_reserve(std::string_view path) noexcept;
+
+    template<class TYPE_T>
+    group_t<TYPE_T> const& group_get();
+
     // TODO: function for removing specific resources
 
     /**
@@ -133,7 +151,7 @@ public:
         // entt experimental branch allows move-only types.
         GroupType(GroupType const& copy) { assert(0); };
 
-        std::map<std::string, Resource<TYPE_T>, std::less<>> m_resources;
+        group_t<TYPE_T> m_resources;
     };
 
     constexpr ResPrefix_t const& get_prefix() const { return m_prefix; }
@@ -175,17 +193,30 @@ DependRes<TYPE_T> Package::add(std::string_view path,
 
     GroupType<TYPE_T> &group = entt::any_cast< GroupType<TYPE_T>& >(groupAny);
 
+    // Check if resource already exists
+    auto resIt = group.m_resources.find(path); // Find resource by path
+
+    if (resIt != group.m_resources.end())
+    {
+        // Resource already exists, replace if not loaded
+        if (!resIt->second.m_data.has_value())
+        {
+            resIt->second.m_data.emplace(std::forward<ARGS_T>(args)...);
+        }
+        return {};
+    }
+
     // Emplace without needing copy constructor
-    auto final = group.m_resources
-        .try_emplace(std::string{path}, false, std::forward<ARGS_T>(args)...);
+    auto newIt = group.m_resources
+        .try_emplace(std::string{path}, construct_tag(), std::forward<ARGS_T>(args)...);
 
     // check if emplace fails, Resource already exists
-    if (!final.second)
+    if (!newIt.second)
     {
         return {}; // return empty if so
     }
 
-    return DependRes<TYPE_T>(final.first);
+    return DependRes<TYPE_T>(newIt.first);
 }
 
 template<class TYPE_T>
@@ -211,12 +242,72 @@ DependRes<TYPE_T> Package::get(std::string_view path) noexcept
 
     if (resIt == group.m_resources.end())
     {
-        // resource not found
-        return DependRes<TYPE_T>();
+        return {}; // resource not found
     }
 
     // found
     return DependRes<TYPE_T>(resIt);
+}
+
+template<class TYPE_T>
+DependRes<TYPE_T> Package::get_or_reserve(std::string_view path) noexcept
+{
+    const uint32_t resTypeId = resource_id::type<TYPE_T>;
+
+    // Resize m_groups to ensure that resTypeId a valid index
+    if (m_groups.size() <= resTypeId)
+    {
+        m_groups.resize(resTypeId + 1);
+    }
+
+    entt::any &groupAny = m_groups[resTypeId];
+
+    // Initialize GroupType if blank. This only happens for the first TYPE_T
+    // added.
+    if(!groupAny)
+    {
+        groupAny = GroupType<TYPE_T>();
+    }
+
+    GroupType<TYPE_T> &group = entt::any_cast<GroupType<TYPE_T>&>(groupAny);
+
+    auto resIt = group.m_resources.find(path); // Find resource by path
+
+    if (resIt == group.m_resources.end())
+    {
+        // Not found, reserve with m_data as empty optional
+        auto newIt = group.m_resources.try_emplace(std::string{path},
+                                                   reserve_tag());
+        return DependRes<TYPE_T>(newIt.first);
+    }
+
+    // found
+    return DependRes<TYPE_T>(resIt);
+}
+
+template<class TYPE_T>
+Package::group_t<TYPE_T> const& Package::group_get()
+{
+    const uint32_t resTypeId = resource_id::type<TYPE_T>;
+
+    // Resize m_groups to ensure that resTypeId a valid index
+    if (m_groups.size() <= resTypeId)
+    {
+        m_groups.resize(resTypeId + 1);
+    }
+
+    entt::any &groupAny = m_groups[resTypeId];
+
+    // Initialize GroupType if blank. This only happens for the first TYPE_T
+    // added.
+    if(!groupAny)
+    {
+        groupAny = GroupType<TYPE_T>();
+    }
+
+    GroupType<TYPE_T> &group = entt::any_cast<GroupType<TYPE_T>&>(groupAny);
+
+    return group.m_resources;
 }
 
 template<class TYPE_T>

--- a/src/osp/Resource/Resource.h
+++ b/src/osp/Resource/Resource.h
@@ -24,29 +24,37 @@
  */
 #pragma once
 
+#include <assert.h>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace osp
 {
 
+struct construct_tag {};
+struct reserve_tag {};
+
 template <class TYPE_T>
 struct Resource
 {
-    Resource(bool loaded)
+    Resource(reserve_tag)
      : m_data()
-     , m_loaded(loaded)
     { }
-    Resource(bool loaded, TYPE_T&& data)
+    Resource(construct_tag)
+     : m_data(TYPE_T())
+    { }
+    Resource(construct_tag, TYPE_T&& data)
      : m_data(std::move(data))
-     , m_loaded(loaded)
     { }
     Resource(Resource&& move) = default;
     Resource(const Resource& copy) = delete;
+    ~Resource()
+    {
+        assert(m_refCount == 0);
+    }
 
-    TYPE_T m_data;
-
-    bool m_loaded;
+    std::optional<TYPE_T> m_data;
 
     int m_refCount{0};
 };
@@ -102,11 +110,11 @@ public:
 
     std::string name() const { return m_it->first; }
 
-    constexpr TYPE_T const& operator*() const noexcept { return m_it->second.m_data; }
-    constexpr TYPE_T& operator*() noexcept { return m_it->second.m_data; }
+    constexpr TYPE_T const& operator*() const noexcept { return m_it->second.m_data.value(); }
+    constexpr TYPE_T& operator*() noexcept { return m_it->second.m_data.value(); }
 
-    constexpr TYPE_T const* operator->() const noexcept { return &m_it->second.m_data; }
-    constexpr TYPE_T* operator->() noexcept { return &m_it->second.m_data; }
+    constexpr TYPE_T const* operator->() const noexcept { return &m_it->second.m_data.value(); }
+    constexpr TYPE_T* operator->() noexcept { return &m_it->second.m_data.value(); }
 private:
     bool m_empty;
     typename std::map<std::string, Resource<TYPE_T>>::iterator m_it;

--- a/src/osp/Resource/Resource.h
+++ b/src/osp/Resource/Resource.h
@@ -32,20 +32,15 @@
 namespace osp
 {
 
-struct construct_tag {};
-struct reserve_tag {};
-
 template <class TYPE_T>
 struct Resource
 {
-    Resource(reserve_tag)
-     : m_data()
+    Resource(std::nullopt_t)
+     : m_data(std::nullopt)
     { }
-    Resource(construct_tag)
-     : m_data(TYPE_T())
-    { }
-    Resource(construct_tag, TYPE_T&& data)
-     : m_data(std::move(data))
+    template<typename ... ARGS_T>
+    Resource(std::in_place_t, ARGS_T&& ... args)
+     : m_data(std::in_place, std::forward<ARGS_T>(args)...)
     { }
     Resource(Resource&& move) = default;
     Resource(const Resource& copy) = delete;

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -74,6 +74,8 @@ public:
     constexpr osp::UserInputHandler& get_input_handler() { return m_userInput; }
     constexpr MapActiveScene_t& get_scenes() { return m_scenes; }
 
+    constexpr osp::Package& get_context_resources() { return m_glResources; }
+
 private:
 
     void drawEvent() override;


### PR DESCRIPTION
This PR adds support for reserving placeholders in an `osp::Package` for resources that aren't loaded yet (see issue #42).

`osp::Package` maps any type (referred to as a resource) to a string path identifier, by creating an `std::map` for each unique type. These maps store the resource as a member of `osp::Resource<T>` to handle reference counting.

`osp::Resource<T>` had an unused `m_loaded` member intended to handle placeholders, but it isn't adequate as the resource type must still be constructed. Some resources like `Magnum::Trade::ImageData2D` are not default-constructable. Instead of storing the type as a member directly, this PR changes it to an `std::optional` so placeholders can be created without constructing the resource.

If a config refers to a resource that isn't loaded yet, then it can now use `Package::get_or_reserve(path)` to create a non-initialized placeholder with the path, where it can be loaded in a later step.

These changes are cherry-picked from a branch where I'm doing some major changes to how vehicles are loaded.

There is also the `list_pkg` command and a few other minor changes added to main.cpp.