### PR TITLE
Remove IDynamicSystem and make all systems static

### DIFF
--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -37,13 +37,11 @@ struct ACompExhaustPlume
     DependRes<PlumeEffectData> m_effect;
 };
 
-class SysExhaustPlume : public IDynamicSystem
+class SysExhaustPlume
 {
 public:
-    static inline std::string smc_name = "ExhaustPlume";
 
-    SysExhaustPlume(ActiveScene& rScene);
-    ~SysExhaustPlume() = default;
+    static void add_functions(ActiveScene& rScene);
 
     /**
      * Initialize plume graphics
@@ -52,15 +50,9 @@ public:
      * this function takes such entities, retrieves the appropriate graphics
      * resources, and configures the graphical components
      */
-    void initialize_plume(ActiveEnt e);
+    static void initialize_plume(ActiveScene& rScene, ActiveEnt e);
 
-    void update_plumes(ActiveScene& rScene);
-
-private:
-    ActiveScene& m_scene;
-    float m_time;
-
-    UpdateOrderHandle_t m_updatePlume;
+    static void update_plumes(ActiveScene& rScene);
 };
 
 } // namespace osp::active

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -60,8 +60,6 @@ ActiveScene::ActiveScene(UserInputHandler &userInput, OSPApplication &app, Packa
 
 ActiveScene::~ActiveScene()
 {
-    // destruct dynamic systems before registry
-    m_dynamicSys.clear();
     m_registry.clear();
 }
 
@@ -236,7 +234,7 @@ void ActiveScene::draw(ActiveEnt camera)
     //cameraProject = cameraComp.m_projection;
     cameraComp.m_inverse = cameraTransform.m_transformWorld.inverted();
 
-    m_renderOrder.call(cameraComp);
+    m_renderOrder.call(*this, cameraComp);
 }
 
 MapSysMachine_t::iterator ActiveScene::system_machine_add(std::string_view name,
@@ -268,17 +266,5 @@ MapSysMachine_t::iterator ActiveScene::system_machine_find(std::string_view name
 bool ActiveScene::system_machine_it_valid(MapSysMachine_t::iterator it)
 {
     return it != m_sysMachines.end();
-}
-
-
-
-MapDynamicSys_t::iterator ActiveScene::dynamic_system_find(std::string_view name)
-{
-    return m_dynamicSys.find(name);
-}
-
-bool ActiveScene::dynamic_system_it_valid(MapDynamicSys_t::iterator it)
-{
-    return it != m_dynamicSys.end();
 }
 

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -37,13 +37,10 @@ using osp::universe::UCompActivatable;
 using osp::universe::UCompActivationRadius;
 using osp::universe::UCompActiveArea;
 
-const std::string SysAreaAssociate::smc_name = "AreaAssociate";
-
-SysAreaAssociate::SysAreaAssociate(ActiveScene &rScene)
- : m_updateScan(rScene.get_update_order(), "areascan", "physics", "",
-                &SysAreaAssociate::update_scan)
+void SysAreaAssociate::add_functions(ActiveScene &rScene)
 {
-
+    rScene.debug_update_add(rScene.get_update_order(), "areascan", "physics", "",
+                            &SysAreaAssociate::update_scan);
 }
 
 void SysAreaAssociate::update_scan(ActiveScene& rScene)

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -69,14 +69,11 @@ struct ACompActivatedSat
 /**
  * System used to associate an ActiveScene to a UCompActiveArea in the Universe
  */
-class SysAreaAssociate : public IDynamicSystem
+class SysAreaAssociate
 {
 public:
 
-    static const std::string smc_name;
-
-    SysAreaAssociate(ActiveScene &rScene);
-    ~SysAreaAssociate() = default;
+    static void add_functions(ActiveScene& rScene);
 
     /**
      * Scans the universe for Satellites to activate or deactivate, tracking
@@ -130,7 +127,6 @@ public:
 
 private:
 
-    UpdateOrderHandle_t m_updateScan;
 
     /**
      * Translate all entities in an ActiveScene that contain an

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -54,38 +54,32 @@ struct CompVisibleDebug
     bool m_state = true;
 };
 
-class SysDebugRender : public IDynamicSystem
+class SysDebugRender
 {
 public:
 
-    static const std::string smc_name;
+    static void add_functions(ActiveScene& rScene);
 
-    SysDebugRender(ActiveScene &rScene);
-    ~SysDebugRender() = default;
-
-    void draw(ACompCamera const& camera);
+    static void draw(ActiveScene& rScene, ACompCamera const& camera);
 
 private:
     template <typename T>
-    void draw_group(T& rCollection, ACompCamera const& camera);
+    static void draw_group(ActiveScene& rScene, T& rCollection, ACompCamera const& camera);
 
-    ActiveScene &m_scene;
-
-    RenderOrderHandle_t m_renderDebugDraw;
 };
 
 template<typename T>
-inline void SysDebugRender::draw_group(T& rCollection, ACompCamera const& camera)
+inline void SysDebugRender::draw_group(ActiveScene& rScene, T& rCollection, ACompCamera const& camera)
 {
     for (auto entity : rCollection)
     {
         auto& drawable = rCollection.template get<CompDrawableDebug>(entity);
         auto const& transform = rCollection.template get<ACompTransform>(entity);
-        auto const* visible = m_scene.get_registry().try_get<CompVisibleDebug>(entity);
+        auto const* visible = rScene.get_registry().try_get<CompVisibleDebug>(entity);
 
         if (visible && !visible->m_state) { continue; }
 
-        drawable.m_shader_draw(entity, m_scene, *drawable.m_mesh, camera, transform);
+        drawable.m_shader_draw(entity, rScene, *drawable.m_mesh, camera, transform);
     }
 }
 

--- a/src/osp/Active/SysForceFields.cpp
+++ b/src/osp/Active/SysForceFields.cpp
@@ -28,21 +28,19 @@
 
 using namespace osp::active;
 
-const std::string SysFFGravity::smc_name = "FFGravity";
-
-SysFFGravity::SysFFGravity(ActiveScene &scene)
- : m_scene(scene)
- , m_updateForce(scene.get_update_order(), "ff_gravity", "", "physics",
-                 [this] (ActiveScene& rScene) { this->update_force(rScene); })
-{ }
+void SysFFGravity::add_functions(ActiveScene &rScene)
+{
+    rScene.debug_update_add(rScene.get_update_order(), "ff_gravity", "", "physics",
+                            &SysFFGravity::update_force);
+}
 
 void SysFFGravity::update_force(ActiveScene& rScene)
 {
 
-    auto viewFields = m_scene.get_registry()
+    auto viewFields = rScene.get_registry()
             .view<ACompFFGravity, ACompTransform>();
 
-    auto viewMasses = m_scene.get_registry()
+    auto viewMasses = rScene.get_registry()
             .view<ACompRigidBody_t, ACompTransform>();
 
     for (ActiveEnt fieldEnt : viewFields)

--- a/src/osp/Active/SysForceFields.h
+++ b/src/osp/Active/SysForceFields.h
@@ -44,7 +44,7 @@ namespace osp::active
 //    FORCEFIELD_T m_field;
 //};
 
-class SysForceField : public IDynamicSystem
+class SysForceField
 {
 };
 
@@ -63,19 +63,9 @@ class SysFFGravity : public SysForceField
 {
 public:
 
-    static const std::string smc_name;
+    static void add_functions(ActiveScene& rScene);
 
-    SysFFGravity(ActiveScene &scene);
-    ~SysFFGravity() = default;
-
-    void update_force(ActiveScene& rScene);
-
-private:
-
-
-    ActiveScene &m_scene;
-
-    UpdateOrderHandle_t m_updateForce;
+    static void update_force(ActiveScene& rScene);
 };
 
 

--- a/src/osp/Active/SysNewton.cpp
+++ b/src/osp/Active/SysNewton.cpp
@@ -98,32 +98,25 @@ ACompNwtBody& ACompNwtBody::operator=(ACompNwtBody&& move) noexcept
     return *this;
 }
 
-SysNewton::SysNewton(ActiveScene &scene)
- : m_scene(scene)
- , m_updatePhysicsWorld(scene.get_update_order(), "physics", "wire", "",
-                [this] (ActiveScene& rScene) { this->update_world(rScene); })
+void SysNewton::add_functions(ActiveScene &rScene)
 {
+    rScene.debug_update_add(rScene.get_update_order(), "physics", "wire", "",
+                            &SysNewton::update_world);
+
     //std::cout << "sysnewtoninit\n";
     //NewtonWorldSetUserData(m_nwtWorld, this);
 
     // Connect signal handlers to destruct Newton objects when components are
     // deleted.
 
-    scene.get_registry().on_destroy<ACompNwtBody>()
+    rScene.get_registry().on_destroy<ACompNwtBody>()
                     .connect<&SysNewton::on_body_destruct>();
 
-    scene.get_registry().on_destroy<ACompCollider>()
+    rScene.get_registry().on_destroy<ACompCollider>()
                     .connect<&SysNewton::on_shape_destruct>();
 
-    scene.get_registry().on_destroy<ACompNwtWorld>()
+    rScene.get_registry().on_destroy<ACompNwtWorld>()
                     .connect<&SysNewton::on_world_destruct>();
-}
-
-SysNewton::~SysNewton()
-{
-    // Clean up newton dynamics stuff
-    m_scene.get_registry().clear<ACompNwtBody>();
-    m_scene.get_registry().clear<ACompCollider>();
 }
 
 void SysNewton::update_world(ActiveScene& rScene)
@@ -609,7 +602,7 @@ std::pair<Matrix3, Vector4> SysNewton::compute_hier_inertia(ActiveScene& rScene,
 void SysNewton::on_body_destruct(ActiveReg_t& reg, ActiveEnt ent)
 {
     NewtonBody const *body = reg.get<ACompNwtBody>(ent).m_body;
-    if (body)
+    if (body != nullptr)
     {
         NewtonDestroyBody(body); // make sure the Newton body is destroyed
     }
@@ -626,10 +619,33 @@ void SysNewton::on_shape_destruct(ActiveReg_t& reg, ActiveEnt ent)
 
 void SysNewton::on_world_destruct(ActiveReg_t& reg, ActiveEnt ent)
 {
+
+
     NewtonWorld const *world = reg.get<ACompNwtWorld>(ent).m_nwtWorld;
     if (world != nullptr)
     {
-        NewtonDestroyAllBodies(world);
+        // delete all collision shapes first to prevent crash
+        auto collisionView = reg.view<ACompCollider>();
+        for (ActiveEnt ent : collisionView)
+        {
+            auto &collider = collisionView.get<ACompCollider>(ent);
+            if (collider.m_collision != nullptr)
+            {
+                NewtonDestroyCollision(std::exchange(collider.m_collision, nullptr));
+            }
+        }
+
+        // delete all rigid bodies too
+        auto bodyView = reg.view<ACompNwtBody>();
+        for (ActiveEnt ent : bodyView)
+        {
+            auto &body = bodyView.get<ACompNwtBody>(ent);
+            if (body.m_body != nullptr)
+            {
+                NewtonDestroyBody(std::exchange(body.m_body, nullptr));
+            }
+        }
+
         NewtonDestroy(world); // make sure the world is destroyed
     }
 }

--- a/src/osp/Active/SysNewton.h
+++ b/src/osp/Active/SysNewton.h
@@ -91,20 +91,14 @@ using ACompRigidBody_t = ACompNwtBody;
 
 using ACompPhysicsWorld_t = ACompNwtWorld;
 
-class SysNewton : public IDynamicSystem
+class SysNewton
 {
 
 public:
 
-    static inline std::string smc_name = "NewtonPhysics";
-
-    SysNewton(ActiveScene &scene);
-    SysNewton(SysNewton const& copy) = delete;
-    SysNewton(SysNewton&& move) = delete;
-
-    ~SysNewton();
+    static void add_functions(ActiveScene &scene);
     
-    void update_world(ActiveScene& rScene);
+    static void update_world(ActiveScene& rScene);
 
     static ACompNwtWorld* try_get_physics_world(ActiveScene &rScene);
 
@@ -170,10 +164,9 @@ public:
      * @param end
      */
     template<class TRIANGLE_IT_T>
-    void shape_create_tri_mesh_static(ACompShape &rShape,
-                                      ACompCollider &rCollider,
-                                      TRIANGLE_IT_T const& start,
-                                      TRIANGLE_IT_T const& end);
+    static void shape_create_tri_mesh_static(
+            ActiveScene& rScene,ACompShape &rShape, ACompCollider &rCollider,
+            TRIANGLE_IT_T const& start, TRIANGLE_IT_T const& end);
 
 private:
     /**
@@ -266,14 +259,10 @@ private:
             const NewtonCollision* treeCollision);
     static void newton_tree_collision_end_build(
             const NewtonCollision* treeCollision,  int optimize);
-
-    ActiveScene& m_scene;
-
-    UpdateOrderHandle_t m_updatePhysicsWorld;
 };
 
 template<class TRIANGLE_IT_T>
-void SysNewton::shape_create_tri_mesh_static(ACompShape& rShape,
+void SysNewton::shape_create_tri_mesh_static(ActiveScene& rScene, ACompShape& rShape,
     ACompCollider& rCollider, TRIANGLE_IT_T const& start, TRIANGLE_IT_T const& end)
 {
     // TODO: this is actually horrendously slow and WILL cause issues later on.
@@ -281,7 +270,7 @@ void SysNewton::shape_create_tri_mesh_static(ACompShape& rShape,
     //       manually hacking up serialized data instead of add face, or use
     //       Newton's dgAABBPolygonSoup stuff directly
 
-    ACompNwtWorld* nwtWorldComp = try_get_physics_world(m_scene);
+    ACompNwtWorld* nwtWorldComp = try_get_physics_world(rScene);
     NewtonCollision* tree = newton_create_tree_collision(nwtWorldComp->m_nwtWorld, 0);
 
     newton_tree_collision_begin_build(tree);

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -49,21 +49,20 @@ using osp::universe::UCompVehicle;
 // for the 0xrrggbb_rgbf literalsm
 using namespace Magnum::Math::Literals;
 
-const std::string SysVehicle::smc_name = "Vehicle";
+void SysVehicle::add_functions(ActiveScene &rScene)
+{
+    rScene.debug_update_add(rScene.get_update_order(), "vehicle_activate", "", "vehicle_modification",
+                            &SysVehicle::update_activate);
 
-SysVehicle::SysVehicle(ActiveScene &scene)
- : m_updateActivation(
-       scene.get_update_order(), "vehicle_activate", "", "vehicle_modification",
-       &SysVehicle::update_activate)
- , m_updateVehicleModification(
-       scene.get_update_order(), "vehicle_modification", "", "physics",
-       &SysVehicle::update_vehicle_modification)
-{ }
+    rScene.debug_update_add(rScene.get_update_order(), "vehicle_modification", "", "physics",
+                            &SysVehicle::update_vehicle_modification);
+
+}
 
 
 ActiveEnt SysVehicle::activate(ActiveScene &rScene, universe::Universe &rUni,
                           universe::Satellite areaSat,
-                          universe::Satellite tgtSat)
+                             universe::Satellite tgtSat)
 {
 
     std::cout << "loadin a vehicle!\n";
@@ -169,8 +168,6 @@ ActiveEnt SysVehicle::activate(ActiveScene &rScene, universe::Universe &rUni,
 
     // Wire the thing up
 
-    SysWire& sysWire = rScene.dynamic_system_find<SysWire>();
-
     // Loop through wire connections
     for (BlueprintWire& blueprintWire : vehicleData.get_wires())
     {
@@ -202,7 +199,7 @@ ActiveEnt SysVehicle::activate(ActiveScene &rScene, universe::Universe &rUni,
 
         // make the connection
 
-        sysWire.connect(*fromWire, *toWire);
+        SysWire::connect(*fromWire, *toWire);
     }
 
     // temporary: make the whole thing a single rigid body

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -79,16 +79,11 @@ struct ACompPart
     unsigned m_separationIsland{0};
 };
 
-class SysVehicle : public IDynamicSystem
+class SysVehicle
 {
 public:
 
-    static const std::string smc_name;
-
-    SysVehicle(ActiveScene &scene);
-    SysVehicle(SysNewton const& copy) = delete;
-    SysVehicle(SysNewton&& move) = delete;
-    ~SysVehicle() = default;
+    static void add_functions(ActiveScene &rScene);
 
     static ActiveEnt activate(ActiveScene &rScene, universe::Universe &rUni,
                               universe::Satellite areaSat,
@@ -202,11 +197,6 @@ private:
         std::vector<MachineDef> const& machineMapping,
         PrototypePart const& part, BlueprintPart const& partBP);
 
-    //ActiveScene& m_scene;
-    //AppPackages& m_packages;
-
-    UpdateOrderHandle_t m_updateActivation;
-    UpdateOrderHandle_t m_updateVehicleModification;
 };
 
 

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -30,9 +30,6 @@
 using namespace osp;
 using namespace osp::active;
 
-
-const std::string SysWire::smc_name = "Wire";
-
 WireData* WireInput::connected_value()
 {
     WireOutput* woConnected = list();
@@ -51,21 +48,6 @@ void WireInput::doErase()
      list()->cut(this);
 };
 
-SysWire::SysWire(ActiveScene &scene)
- : m_updateWire(scene.get_update_order(), "wire", "", "",
-                [this] (ActiveScene& rScene) { this->update_propagate(rScene); })
-{
-
-}
-
-
-void SysWire::update_propagate(ActiveScene& rScene)
-{
-    for (DependentOutput &output : m_dependentOutputs)
-    {
-        output.m_element->propagate_output(output.m_output);
-    }
-}
 
 void SysWire::connect(WireOutput &wireFrom, WireInput &wireTo)
 {

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -287,11 +287,11 @@ private:
 //-----------------------------------------------------------------------------
 
 
-class SysWire : public IDynamicSystem
+class SysWire
 {
 public:
 
-    static const std::string smc_name;
+    static inline std::string smc_name = "Wire";
 
     struct DependentOutput
     {
@@ -300,12 +300,7 @@ public:
         unsigned depth;
     };
 
-    SysWire(ActiveScene &scene);
-    SysWire(SysWire const& copy) = delete;
-    SysWire(SysWire&& move) = delete;
-
-    void update_propagate(ActiveScene& rScene);
-    void connect(WireOutput &wireFrom, WireInput &wireTo);
+    static void connect(WireOutput &wireFrom, WireInput &wireTo);
 
 private:
     std::vector<DependentOutput> m_dependentOutputs;

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -55,22 +55,12 @@ using ActiveReg_t = entt::basic_registry<ActiveEnt>;
 using UpdateOrder_t = FunctionOrder<void(ActiveScene&)>;
 using UpdateOrderHandle_t = FunctionOrderHandle<void(ActiveScene&)>;
 
-using RenderOrder_t = FunctionOrder<void(ACompCamera const&)>;
-using RenderOrderHandle_t = FunctionOrderHandle<void(ACompCamera const&)>;
+using RenderOrder_t = FunctionOrder<void(ActiveScene&, ACompCamera const&)>;
+using RenderOrderHandle_t = FunctionOrderHandle<void(ActiveScene&, ACompCamera const&)>;
 
 struct ACompFloatingOrigin
 {
     //bool m_dummy;
 };
-
-// not really sure what else to put in here
-class IDynamicSystem
-{
-public:
-    virtual ~IDynamicSystem() = default;
-};
-
-using MapDynamicSys_t = std::map<std::string, std::unique_ptr<IDynamicSystem>,
-                                 std::less<> >;
 
 }

--- a/src/osp/FunctonOrder.h
+++ b/src/osp/FunctonOrder.h
@@ -172,7 +172,7 @@ FunctionOrderHandle<FUNC_T>::FunctionOrderHandle(
         std::string const& before,
         ARGS_T&& ... args)
 {
-    to.add(*this, name, after, before, args...);
+    to.add(*this, name, after, before, std::forward<ARGS_T>(args)...);
 }
 
 template<typename FUNC_T>
@@ -228,7 +228,9 @@ void FunctionOrder<FUNC_T>::add(
     // new FunctionOrderCall call can be emplaces somewhere between
     // minPos or maxPos
 
-    handle.m_to = m_calls.insert(maxPos, {name, after, before, args...});
+    handle.m_to = m_calls.insert(
+            maxPos, FunctionOrderCall<FUNC_T>(name, after, before,
+                     std::function<FUNC_T>(std::forward<ARGS_T>(args)...) ));
 
 }
 

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -54,46 +54,34 @@ struct ACompPlanet
 };
 
 
-class SysPlanetA : public osp::active::IDynamicSystem
+class SysPlanetA
 {
 public:
 
-    static const std::string smc_name;
-
-    SysPlanetA(osp::active::ActiveScene &scene,
-               osp::UserInputHandler &userInput);
-    ~SysPlanetA() = default;
+    static void add_functions(osp::active::ActiveScene& rScene);
 
     static osp::active::ActiveEnt activate(
             osp::active::ActiveScene &rScene, osp::universe::Universe &rUni,
             osp::universe::Satellite areaSat, osp::universe::Satellite tgtSat);
 
-    void draw(osp::active::ACompCamera const& camera);
+    static void draw(osp::active::ActiveScene& rScene,
+              osp::active::ACompCamera const& camera);
 
-    void debug_create_chunk_collider(osp::active::ActiveEnt ent,
-                                     ACompPlanet &planet,
-                                     chindex_t chunk);
+    static void debug_create_chunk_collider(
+            osp::active::ActiveScene& rScene,
+            osp::active::ActiveEnt ent,
+            ACompPlanet &planet,
+            chindex_t chunk);
 
-    static void planet_update_geometry(osp::active::ActiveEnt planetEnt,
-                                osp::active::ActiveScene& rScene);
+    static void planet_update_geometry(
+            osp::active::ActiveEnt planetEnt,
+            osp::active::ActiveScene& rScene);
 
     static void update_activate(osp::active::ActiveScene& rScene);
 
-    void update_geometry(osp::active::ActiveScene& rScene);
+    static void update_geometry(osp::active::ActiveScene& rScene);
 
-    void update_physics(osp::active::ActiveScene& rScene);
-
-private:
-
-    osp::active::ActiveScene &m_scene;
-
-    osp::active::UpdateOrderHandle_t m_updateActivate;
-    osp::active::UpdateOrderHandle_t m_updateGeometry;
-    osp::active::UpdateOrderHandle_t m_updatePhysics;
-
-    osp::active::RenderOrderHandle_t m_renderPlanetDraw;
-
-    osp::ButtonControlHandle m_debugUpdate;
+    static void update_physics(osp::active::ActiveScene& rScene);
 };
 
 }

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -89,24 +89,23 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     config_controls(*pMagnumApp);
 
     // Create an ActiveScene
-    osp::active::ActiveScene& scene = pMagnumApp->scene_create("Area 1");
+    osp::active::ActiveScene& rScene = pMagnumApp->scene_create("Area 1");
 
-    // Register dynamic systems needed for flight scene
-
-    scene.dynamic_system_create<osp::active::SysPhysics_t>();
-    scene.dynamic_system_create<osp::active::SysWire>();
-    scene.dynamic_system_create<osp::active::SysDebugRender>();
-    scene.dynamic_system_create<osp::active::SysAreaAssociate>();
-    scene.dynamic_system_create<osp::active::SysVehicle>();
-    scene.dynamic_system_create<osp::active::SysExhaustPlume>();
-    scene.dynamic_system_create<planeta::active::SysPlanetA>(pMagnumApp->get_input_handler());
-    scene.dynamic_system_create<osp::active::SysFFGravity>();
+    // Add system functions needed for flight scene
+    osp::active::SysPhysics_t::add_functions(rScene);
+    //osp::active::SysWire::add_functions(rScene);
+    osp::active::SysDebugRender::add_functions(rScene);
+    osp::active::SysAreaAssociate::add_functions(rScene);
+    osp::active::SysVehicle::add_functions(rScene);
+    osp::active::SysExhaustPlume::add_functions(rScene);
+    planeta::active::SysPlanetA::add_functions(rScene);
+    osp::active::SysFFGravity::add_functions(rScene);
 
     // Register machines for that scene
-    scene.system_machine_create<SysMachineUserControl>(pMagnumApp->get_input_handler());
-    scene.system_machine_create<SysMachineRocket>();
-    scene.system_machine_create<SysMachineRCSController>();
-    scene.system_machine_create<SysMachineContainer>();
+    rScene.system_machine_create<SysMachineUserControl>(pMagnumApp->get_input_handler());
+    rScene.system_machine_create<SysMachineRocket>();
+    rScene.system_machine_create<SysMachineRCSController>();
+    rScene.system_machine_create<SysMachineContainer>();
 
     // Make active areas load vehicles and planets
     //sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);
@@ -119,21 +118,21 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     UCompActiveArea &area = SatActiveArea::add_active_area(rUni, areaSat);
 
     // Link ActiveArea to scene using the AreaAssociate
-    osp::active::SysAreaAssociate::connect(scene, rUni, areaSat);
+    osp::active::SysAreaAssociate::connect(rScene, rUni, areaSat);
 
     // Add default-constructed physics world to scene
-    scene.get_registry().emplace<osp::active::ACompPhysicsWorld_t>(scene.hier_get_root());
+    rScene.get_registry().emplace<osp::active::ACompPhysicsWorld_t>(rScene.hier_get_root());
 
     // Add a camera to the scene
 
     // Create the camera entity
-    ActiveEnt camera = scene.hier_create_child(scene.hier_get_root(),
+    ActiveEnt camera = rScene.hier_create_child(rScene.hier_get_root(),
                                                        "Camera");
-    auto &cameraTransform = scene.reg_emplace<ACompTransform>(camera);
-    auto &cameraComp = scene.get_registry().emplace<ACompCamera>(camera);
+    auto &cameraTransform = rScene.reg_emplace<ACompTransform>(camera);
+    auto &cameraComp = rScene.get_registry().emplace<ACompCamera>(camera);
 
     cameraTransform.m_transform = Matrix4::translation(Vector3(0, 0, 25));
-    scene.reg_emplace<ACompFloatingOrigin>(camera);
+    rScene.reg_emplace<ACompFloatingOrigin>(camera);
 
     cameraComp.m_viewport
             = Vector2(Magnum::GL::defaultFramebuffer.viewport().size());
@@ -144,10 +143,10 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     cameraComp.calculate_projection();
 
     // Add the debug camera controller to the scene. This adds controls
-    auto camObj = std::make_unique<DebugCameraController>(scene, camera);
+    auto camObj = std::make_unique<DebugCameraController>(rScene, camera);
 
     // Add a ACompDebugObject to camera to manage camObj's lifetime
-    scene.reg_emplace<ACompDebugObject>(camera, std::move(camObj));
+    rScene.reg_emplace<ACompDebugObject>(camera, std::move(camObj));
 
     // Starts the game loop. This function is blocking, and will only return
     // when the window is  closed. See OSPMagnum::drawEvent
@@ -158,7 +157,7 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     std::cout << "Magnum Application closed\n";
 
     // Disconnect ActiveArea
-    osp::active::SysAreaAssociate::disconnect(scene);
+    osp::active::SysAreaAssociate::disconnect(rScene);
 
     // destruct the application, this closes the window
     pMagnumApp.reset();


### PR DESCRIPTION
Might as well clear the spaghetti now rather than later so we can stop building new changes on top of it.

Systems are suppose to be just static functions, but for some reason I decided to use classes at the start of the project. This led to the `IDynamicSystem` interface (just a virtual destructor) that allows the lifetime of these system classes to be managed by `ActiveScene`. They are also stored in a map so they can be accessed with strings.

This is a rather messy and horrible system, and we've been taking steps towards fully static systems (see #46). Since only static functions are used, there is no longer a purpose in initializing system classes. The only purpose left for system classes is to manage the lifetime of `FunctionOrderHandles`, which are pointlessly ref-counted handles to a function in a `FunctionOrder`.

This PR removes `IDynamicSystem` entirely, and makes all affected system classes static.
* Removed `IDynamicSystem`-related functions in `ActiveScene`, replaced with debug_update_add and debug_render_add to create `FunctionOrderHandle`s. These are denoted with "debug" as `FunctionOrder` would likely be replaced soon (see #2, #92)
* All the constructors were replaced with an add_functions static function instead
* Fix dangling pointer issue in `SysNewton`
* A few other minor cleanups

This issue progresses on #46, but doesn't fix it entirely. Machines follow a similar scheme for their systems, but that will be handled in a different PR. 

This also conflicts with #92 with many systems being changed to static. 
