### PR TITLE
Fix Resource type ID bounds check on get<>()

### DIFF
--- a/src/osp/Resource/Package.h
+++ b/src/osp/Resource/Package.h
@@ -193,7 +193,7 @@ DependRes<TYPE_T> Package::get(std::string_view path) noexcept
 {
     const uint32_t resTypeId = resource_id::type<TYPE_T>;
 
-    if (m_groups.size() < resTypeId)
+    if (m_groups.size() <= resTypeId)
     {
         return {}; // Return if resTypeId is not a valid index to m_groups
     }


### PR DESCRIPTION
The bounds check on `Package::get<T>` was missing the `=` (see `Package::add<T>`) which caused a crash when the type being retrieved did not yet exist in the Package