### PR TITLE
Offscreen rendering, renderer restructure

### DIFF
--- a/bin/OSPData/adera/Shaders/RenderTexture.frag
+++ b/bin/OSPData/adera/Shaders/RenderTexture.frag
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#version 430 core
+//#version 430 core
 
 layout(location = 0, index = 0) out vec3 color;
 
@@ -33,5 +33,5 @@ in vec2 uv;
 
 void main()
 {
-    color = vec3(uv.x, uv.y, 1.0);
+    color = texture(framebuffer, uv).rgb;
 }

--- a/bin/OSPData/adera/Shaders/RenderTexture.frag
+++ b/bin/OSPData/adera/Shaders/RenderTexture.frag
@@ -1,0 +1,37 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#version 430 core
+
+layout(location = 0, index = 0) out vec3 color;
+
+layout(location = 0) uniform sampler2D framebuffer;
+
+in vec2 uv;
+
+void main()
+{
+    color = vec3(uv.x, uv.y, 1.0);
+}

--- a/bin/OSPData/adera/Shaders/RenderTexture.vert
+++ b/bin/OSPData/adera/Shaders/RenderTexture.vert
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#version 430 core
+//#version 430 core
 
 layout(location = 0) in vec2 vertPosition;
 layout(location = 1) in vec2 vertTexCoords;

--- a/bin/OSPData/adera/Shaders/RenderTexture.vert
+++ b/bin/OSPData/adera/Shaders/RenderTexture.vert
@@ -1,0 +1,37 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#version 430 core
+
+layout(location = 0) in vec2 vertPosition;
+layout(location = 1) in vec2 vertTexCoords;
+
+out vec2 uv;
+
+void main()
+{
+    gl_Position = vec4(vertPosition, 0.0, 1.0);
+    uv = vertTexCoords;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,20 @@ file (GLOB_RECURSE CPP_FILES *.cpp)
 file (GLOB_RECURSE H_FILES *.h)
 set (SOURCE_FILES ${CPP_FILES} ${H_FILES})
 
-add_executable(osp-magnum ${CPP_FILES})
+if(MSVC)
+	# For some reason, source_group() requires all files to be added to the
+	# executable. I did this conditionally in case it messes up other platforms
+	set(SHADERS_DIR "../bin/OSPData/adera/Shaders")
+  	file (GLOB_RECURSE SHADER_FILES
+  		"${SHADERS_DIR}/*.vert"
+  		"${SHADERS_DIR}/*.frag"
+  		"${SHADERS_DIR}/*.comp"
+  		)
+  	list(APPEND SOURCE_FILES ${SHADER_FILES})
+	add_executable(osp-magnum ${SOURCE_FILES})
+else()
+	add_executable(osp-magnum ${CPP_FILES})
+endif()
 
 target_include_directories(osp-magnum PRIVATE .)
 
@@ -84,10 +97,17 @@ elseif(MINGW)
 
 endif()
 
-# Set the MSVC debug working directory, enforce conformance mode for osp-magnum
+# MSVC quality of life improvements for Visual Studio
 if(MSVC)
-  set_property(TARGET osp-magnum PROPERTY VS_DEBUGGER_WORKING_DIRECTORY ../../bin)
-  target_compile_options(osp-magnum PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+	# Set the MSVC debug working directory
+  	set_property(TARGET osp-magnum PROPERTY VS_DEBUGGER_WORKING_DIRECTORY ../../bin)
+
+  	# Enforce conformance mode for osp-magnum
+  	target_compile_options(osp-magnum PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
+
+  	# Segregate headers, shaders into filters
+  	source_group("Shader Files" FILES ${SHADER_FILES})
+  	source_group("Header Files" FILES ${H_FILES})
 endif()
 
 # Include ENTT (header only lib)

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -26,6 +26,9 @@
 
 #include "ActiveScene.h"
 
+#include <Magnum/GL/Framebuffer.h>
+#include <Magnum/GL/DefaultFramebuffer.h>
+
 using namespace osp;
 using namespace osp::active;
 
@@ -234,7 +237,12 @@ void ActiveScene::draw(ActiveEnt camera)
     //cameraProject = cameraComp.m_projection;
     cameraComp.m_inverse = cameraTransform.m_transformWorld.inverted();
 
-    m_renderOrder.call(*this, cameraComp);
+    for (auto& pass : m_renderQueue)
+    {
+        pass(*this, cameraComp);
+    }
+
+    //m_renderOrder.call(*this, cameraComp);
 }
 
 MapSysMachine_t::iterator ActiveScene::system_machine_add(std::string_view name,

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -237,12 +237,7 @@ void ActiveScene::draw(ActiveEnt camera)
     //cameraProject = cameraComp.m_projection;
     cameraComp.m_inverse = cameraTransform.m_transformWorld.inverted();
 
-    for (auto& pass : m_renderQueue)
-    {
-        pass(*this, cameraComp);
-    }
-
-    //m_renderOrder.call(*this, cameraComp);
+    m_renderOrder.call(*this, cameraComp);
 }
 
 MapSysMachine_t::iterator ActiveScene::system_machine_add(std::string_view name,

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -42,6 +42,8 @@
 #include "SysWire.h"
 #include "adera/SysExhaustPlume.h"
 
+#include <Magnum/GL/Framebuffer.h>
+
 namespace osp::active
 {
 
@@ -168,7 +170,9 @@ public:
 
     constexpr UpdateOrder_t& get_update_order() { return m_updateOrder; }
 
-    constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
+    //constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
+    using RenderPass_t = std::function<void(ActiveScene& rScene, ACompCamera& rCamera)>;
+    constexpr std::vector<RenderPass_t>& get_render_queue() { return m_renderQueue; }
 
     // TODO
     constexpr float get_time_delta_fixed() const { return 1.0f / 60.0f; }
@@ -229,7 +233,8 @@ private:
     UserInputHandler &m_userInput;
 
     UpdateOrder_t m_updateOrder;
-    RenderOrder_t m_renderOrder;
+    //RenderOrder_t m_renderOrder;
+    std::vector<RenderPass_t> m_renderQueue;
 
     std::vector<UpdateOrderHandle_t> m_updateHandles;
     std::vector<RenderOrderHandle_t> m_renderHandles;

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -170,9 +170,7 @@ public:
 
     constexpr UpdateOrder_t& get_update_order() { return m_updateOrder; }
 
-    //constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
-    using RenderPass_t = std::function<void(ActiveScene& rScene, ACompCamera& rCamera)>;
-    constexpr std::vector<RenderPass_t>& get_render_queue() { return m_renderQueue; }
+    constexpr RenderOrder_t& get_render_order() { return m_renderOrder; }
 
     // TODO
     constexpr float get_time_delta_fixed() const { return 1.0f / 60.0f; }
@@ -233,14 +231,12 @@ private:
     UserInputHandler &m_userInput;
 
     UpdateOrder_t m_updateOrder;
-    //RenderOrder_t m_renderOrder;
-    std::vector<RenderPass_t> m_renderQueue;
+    RenderOrder_t m_renderOrder;
 
     std::vector<UpdateOrderHandle_t> m_updateHandles;
     std::vector<RenderOrderHandle_t> m_renderHandles;
 
     MapSysMachine_t m_sysMachines; // TODO: Put this in SysVehicle
-
 };
 
 // move these to another file eventually

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -128,7 +128,6 @@ public:
     template<class T>
     decltype(auto) reg_get(ActiveEnt ent) const { return m_registry.get<T>(ent); }
 
-
     /**
      * Shorthand for get_registry().try_get<T>()
      * @tparam T Component to get
@@ -211,6 +210,7 @@ public:
     { m_renderHandles.emplace_back(std::forward<ARGS_T>(args)...); }
 
     Package& get_context_resources() { return m_context; }
+
 private:
 
     void on_hierarchy_construct(ActiveReg_t& reg, ActiveEnt ent);
@@ -305,6 +305,9 @@ struct ACompCamera
 
     Matrix4 m_projection;
     Matrix4 m_inverse;
+
+    // If empty, GL::DefaultFramebuffer is used
+    DependRes<Magnum::GL::Framebuffer> m_renderTarget;
 
     void calculate_projection();
 };

--- a/src/osp/Active/SysDebugRender.cpp
+++ b/src/osp/Active/SysDebugRender.cpp
@@ -30,6 +30,7 @@
 #include <Magnum/GL/Renderer.h>
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/Mesh.h>
+#include <Magnum/Shaders/MeshVisualizer.h>
 #include <Magnum/Mesh.h>
 #include <Corrade/Containers/ArrayViewStl.h>
 
@@ -56,28 +57,39 @@ void SysDebugRender::add_functions(ActiveScene &rScene)
     Package& glResources = rScene.get_context_resources();
 
     using namespace adera::shader;
+    using Magnum::Shaders::MeshVisualizer3D;
+
+    glResources.add<MeshVisualizer3D>("mesh_vis_shader",
+        MeshVisualizer3D{MeshVisualizer3D::Flag::Wireframe | MeshVisualizer3D::Flag::NormalDirection});
 
     glResources.add<Phong>("phong_shader",
         Phong{Magnum::Shaders::Phong::Flag::DiffuseTexture});
 
     glResources.add<PlumeShader>("plume_shader");
 
+    glResources.add<RenderTexture>("render_texture");
+
     // Generate fullscreen tri for texture rendering
     using namespace Magnum; 
     if (glResources.get<GL::Mesh>("fullscreen_tri").empty())
     {
+        Vector2 screenSize = Vector2{GL::defaultFramebuffer.viewport().size()};
+
+        float aspectRatio = screenSize.x() / screenSize.y();
+
         std::array<float, 12> surfData
         {
             // Vert position    // UV coordinate
             -1.0f,  1.0f,       0.0f,  1.0f,
-            -1.0f, -2.0f,       0.0f, -1.0f,
-             2.0f,  1.0f,       2.0f,  1.0f
+            -1.0f, -3.0f,       0.0f, -1.0f,
+             3.0f,  1.0f,       2.0f,  1.0f
         };
 
         GL::Buffer surface(std::move(surfData), GL::BufferUsage::StaticDraw);
         GL::Mesh surfaceMesh;
         surfaceMesh
             .setPrimitive(Magnum::MeshPrimitive::Triangles)
+            .setCount(3)
             .addVertexBuffer(std::move(surface), 0,
                 RenderTexture::Position{}, RenderTexture::TextureCoordinates{});
         glResources.add<GL::Mesh>("fullscreen_tri", std::move(surfaceMesh));
@@ -85,7 +97,7 @@ void SysDebugRender::add_functions(ActiveScene &rScene)
 
 }
 
-void SysDebugRender::draw(ACompCamera& camera)
+/*void SysDebugRender::draw(ACompCamera& camera)
 {
     GL::AbstractFramebuffer* framebuffer = (camera.m_renderTarget.empty()) ?
         reinterpret_cast<GL::AbstractFramebuffer*>(&GL::defaultFramebuffer)
@@ -102,7 +114,7 @@ void SysDebugRender::draw(ACompCamera& camera)
     {
         pass(m_scene, camera);
     }
-}
+}*/
 
 void SysDebugRender::render_framebuffer(ActiveScene& rScene, Magnum::GL::Texture2D& rTexture)
 {

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -61,18 +61,11 @@ public:
 
     static void add_functions(ActiveScene& rScene);
 
-    static void draw(ActiveScene& rScene, ACompCamera& camera);
-
-    // TODO staticify
-    void add_pass(std::function<void(ActiveScene&, ACompCamera&)> passDef)
-    { m_renderPasses.push_back(std::move(passDef)); }
+    //static void draw(ActiveScene& rScene, ACompCamera& camera);
 
     template <typename T>
-    static void draw_group(ActiveScene& rScene, T& rCollection, ACompCamera const& camera);
+    static void draw_group(ActiveScene& rScene, T& rCollection, ACompCamera& camera);
     static void render_framebuffer(ActiveScene& rScene, Magnum::GL::Texture2D& rTexture);
-    // TODO
-    std::vector<std::function<void(ActiveScene&, ACompCamera&)>> m_renderPasses;
-
 };
 
 template<typename T>

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -27,6 +27,7 @@
 #include <variant>
 #include <Magnum/Math/Color.h>
 #include <Magnum/GL/Mesh.h>
+#include <Magnum/GL/Texture.h>
 
 #include "osp/Resource/Resource.h"
 #include "osp/Active/Shader.h"
@@ -60,16 +61,22 @@ public:
 
     static void add_functions(ActiveScene& rScene);
 
-    static void draw(ActiveScene& rScene, ACompCamera const& camera);
+    static void draw(ActiveScene& rScene, ACompCamera& camera);
 
-private:
+    // TODO staticify
+    void add_pass(std::function<void(ActiveScene&, ACompCamera&)> passDef)
+    { m_renderPasses.push_back(std::move(passDef)); }
+
     template <typename T>
     static void draw_group(ActiveScene& rScene, T& rCollection, ACompCamera const& camera);
+    static void render_framebuffer(ActiveScene& rScene, Magnum::GL::Texture2D& rTexture);
+    // TODO
+    std::vector<std::function<void(ActiveScene&, ACompCamera&)>> m_renderPasses;
 
 };
 
 template<typename T>
-inline void SysDebugRender::draw_group(ActiveScene& rScene, T& rCollection, ACompCamera const& camera)
+inline void SysDebugRender::draw_group(ActiveScene& rScene, T& rCollection, ACompCamera& camera)
 {
     for (auto entity : rCollection)
     {

--- a/src/osp/Active/SysDebugRender.h
+++ b/src/osp/Active/SysDebugRender.h
@@ -61,11 +61,13 @@ public:
 
     static void add_functions(ActiveScene& rScene);
 
-    //static void draw(ActiveScene& rScene, ACompCamera& camera);
-
     template <typename T>
     static void draw_group(ActiveScene& rScene, T& rCollection, ACompCamera& camera);
-    static void render_framebuffer(ActiveScene& rScene, Magnum::GL::Texture2D& rTexture);
+    static void display_framebuffer(ActiveScene& rScene, Magnum::GL::Texture2D& rTexture);
+
+private:
+    static void initialize_context_resources(ActiveScene& rScene);
+    static void configure_render_passes(ActiveScene& rScene);
 };
 
 template<typename T>

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -55,8 +55,8 @@ using ActiveReg_t = entt::basic_registry<ActiveEnt>;
 using UpdateOrder_t = FunctionOrder<void(ActiveScene&)>;
 using UpdateOrderHandle_t = FunctionOrderHandle<void(ActiveScene&)>;
 
-using RenderOrder_t = FunctionOrder<void(ActiveScene&, ACompCamera const&)>;
-using RenderOrderHandle_t = FunctionOrderHandle<void(ActiveScene&, ACompCamera const&)>;
+using RenderOrder_t = FunctionOrder<void(ActiveScene&, ACompCamera&)>;
+using RenderOrderHandle_t = FunctionOrderHandle<void(ActiveScene&, ACompCamera&)>;
 
 struct ACompFloatingOrigin
 {

--- a/src/osp/Shaders/RenderTexture.cpp
+++ b/src/osp/Shaders/RenderTexture.cpp
@@ -1,0 +1,60 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <osp/Shaders/RenderTexture.h>
+#include <Magnum/GL/Version.h>
+#include <Magnum/GL/Shader.h>
+#include <Magnum/GL/Texture.h>
+#include <Corrade/Containers/Reference.h>
+
+using namespace osp::active;
+using namespace Magnum;
+
+RenderTexture::RenderTexture()
+{
+    GL::Shader vert{GL::Version::GL430, GL::Shader::Type::Vertex};
+    GL::Shader frag{GL::Version::GL430, GL::Shader::Type::Fragment};
+    vert.addFile("OSPData/adera/Shaders/RenderTexture.vert");
+    frag.addFile("OSPData/adera/Shaders/RenderTexture.frag");
+
+    CORRADE_INTERNAL_ASSERT_OUTPUT(GL::Shader::compile({vert, frag}));
+    attachShaders({vert, frag});
+    CORRADE_INTERNAL_ASSERT_OUTPUT(link());
+
+    setUniform(static_cast<Int>(UniformPos::FramebufferSampler),
+        static_cast<Int>(TextureSlot::FramebufferSlot));
+}
+
+void RenderTexture::render_texure(GL::Mesh& surface, GL::Texture2D& texture)
+{
+    set_framebuffer(texture);
+    draw(surface);
+}
+
+RenderTexture& RenderTexture::set_framebuffer(GL::Texture2D& rTex)
+{
+    rTex.bind(static_cast<Int>(TextureSlot::FramebufferSlot));
+    return *this;
+}

--- a/src/osp/Shaders/RenderTexture.h
+++ b/src/osp/Shaders/RenderTexture.h
@@ -1,0 +1,68 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <Magnum/GL/AbstractShaderProgram.h>
+#include <Magnum/GL/Attribute.h>
+
+namespace osp::active
+{
+
+class RenderTexture : public Magnum::GL::AbstractShaderProgram
+{
+public:
+    // Vertex attribs
+    typedef Magnum::GL::Attribute<0, Magnum::Vector2> Position;
+    typedef Magnum::GL::Attribute<0, Magnum::Vector2> TextureCoordinates;
+
+    // Outputs
+    enum : Magnum::UnsignedInt
+    {
+        ColorOutput = 0
+    };
+
+    RenderTexture();
+
+    void render_texure(Magnum::GL::Mesh& surface, Magnum::GL::Texture2D& texture);
+private:
+    // Uniforms
+    enum class UniformPos : Magnum::Int
+    {
+        FramebufferSampler = 0
+    };
+
+    // Texture2D slots
+    enum class TextureSlot : Magnum::Int
+    {
+        FramebufferSlot = 0
+    };
+
+    // Hide irrelevant calls
+    using Magnum::GL::AbstractShaderProgram::drawTransformFeedback;
+    using Magnum::GL::AbstractShaderProgram::dispatchCompute;
+
+    RenderTexture& set_framebuffer(Magnum::GL::Texture2D& rTex);
+};
+
+}  // namespace osp::active

--- a/src/osp/Shaders/RenderTexture.h
+++ b/src/osp/Shaders/RenderTexture.h
@@ -34,7 +34,7 @@ class RenderTexture : public Magnum::GL::AbstractShaderProgram
 public:
     // Vertex attribs
     typedef Magnum::GL::Attribute<0, Magnum::Vector2> Position;
-    typedef Magnum::GL::Attribute<0, Magnum::Vector2> TextureCoordinates;
+    typedef Magnum::GL::Attribute<1, Magnum::Vector2> TextureCoordinates;
 
     // Outputs
     enum : Magnum::UnsignedInt

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -44,10 +44,7 @@ struct ACompPlanet
 {
     std::shared_ptr<IcoSphereTree> m_icoTree;
     std::shared_ptr<PlanetGeometryA> m_planet;
-    Magnum::GL::Mesh m_mesh{};
-    Magnum::Shaders::MeshVisualizer3D m_shader{
-            Magnum::Shaders::MeshVisualizer3D::Flag::Wireframe
-            | Magnum::Shaders::MeshVisualizer3D::Flag::NormalDirection};
+    osp::DependRes<Magnum::GL::Mesh> m_mesh;
     Magnum::GL::Buffer m_vrtxBufGL{};
     Magnum::GL::Buffer m_indxBufGL{};
     double m_radius;
@@ -63,9 +60,6 @@ public:
     static osp::active::ActiveEnt activate(
             osp::active::ActiveScene &rScene, osp::universe::Universe &rUni,
             osp::universe::Satellite areaSat, osp::universe::Satellite tgtSat);
-
-    static void draw(osp::active::ActiveScene& rScene,
-              osp::active::ACompCamera const& camera);
 
     static void debug_create_chunk_collider(
             osp::active::ActiveScene& rScene,

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -57,10 +57,6 @@ OSPMagnum::~OSPMagnum()
 
 void OSPMagnum::drawEvent()
 {
-
-    Magnum::GL::defaultFramebuffer.clear(Magnum::GL::FramebufferClear::Color
-                                         | Magnum::GL::FramebufferClear::Depth);
-
 //    if (m_area)
 //    {
 //        //Scene3D& scene = m_area->get_scene();

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -37,7 +37,7 @@
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/Math/Color.h>
-#include <Magnum/Platform/Sdl2Application.h>
+#include <Magnum/Platform/GlfwApplication.h>
 #include <Magnum/Shaders/VertexColor.h>
 
 #include <memory>

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -37,7 +37,7 @@
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/Math/Color.h>
-#include <Magnum/Platform/GlfwApplication.h>
+#include <Magnum/Platform/Sdl2Application.h>
 #include <Magnum/Shaders/VertexColor.h>
 
 #include <memory>

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -43,13 +43,7 @@
 #include <planet-a/Active/SysPlanetA.h>
 #include <planet-a/Satellites/SatPlanet.h>
 
-#include <Magnum/GL/Renderer.h>
 #include <Magnum/GL/Framebuffer.h>
-#include <Magnum/Math/Range.h>
-#include <Magnum/GL/Renderbuffer.h>
-#include <Magnum/GL/RenderbufferFormat.h>
-#include <Magnum/GL/Texture.h>
-#include <Magnum/GL/TextureFormat.h>
 
 using namespace testapp;
 
@@ -115,91 +109,6 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     rScene.system_machine_create<SysMachineRCSController>();
     rScene.system_machine_create<SysMachineContainer>();
 
-    // Define render passes
-
-    // Opaque pass
-    rScene.get_render_queue().push_back(
-        [](osp::active::ActiveScene& rScene, ACompCamera& camera)
-        {
-            using namespace Magnum;
-            using Magnum::GL::Renderer;
-            using namespace osp::active;
-
-            auto& reg = rScene.get_registry();
-
-            camera.m_renderTarget->bind();
-
-            camera.m_renderTarget->clear(
-                GL::FramebufferClear::Color
-                | GL::FramebufferClear::Depth
-                | GL::FramebufferClear::Stencil);
-
-            Renderer::enable(Renderer::Feature::DepthTest);
-            Renderer::enable(Renderer::Feature::FaceCulling);
-            Renderer::disable(Renderer::Feature::Blending);
-
-            // Fetch opaque objects
-            auto opaqueView = reg.view<CompDrawableDebug, ACompTransform>(
-                entt::exclude<CompTransparentDebug>);
-
-            SysDebugRender::draw_group(rScene, opaqueView, camera);
-        }
-    );
-
-    // Transparent pass
-    rScene.get_render_queue().push_back(
-        [](osp::active::ActiveScene& rScene, ACompCamera& camera)
-        {
-            using Magnum::GL::Renderer;
-            using namespace osp::active;
-
-            auto& reg = rScene.get_registry();
-
-            Renderer::enable(Renderer::Feature::DepthTest);
-            Renderer::enable(Renderer::Feature::FaceCulling);
-            Renderer::enable(Renderer::Feature::Blending);
-            Renderer::setBlendFunction(
-                Renderer::BlendFunction::SourceAlpha,
-                Renderer::BlendFunction::OneMinusSourceAlpha);
-
-            auto transparentView = reg.view<CompDrawableDebug, CompVisibleDebug,
-                CompTransparentDebug, ACompTransform>();
-
-            // Draw backfaces
-            Renderer::setFaceCullingMode(Renderer::PolygonFacing::Front);
-            SysDebugRender::draw_group(rScene, transparentView, camera);
-
-            // Draw frontfaces
-            Renderer::setFaceCullingMode(Renderer::PolygonFacing::Back);
-            SysDebugRender::draw_group(rScene, transparentView, camera);
-        }
-    );
-
-    // Render offscreen buffer
-    rScene.get_render_queue().push_back(
-        [](osp::active::ActiveScene& rScene, ACompCamera& camera)
-        {
-            using namespace Magnum;
-            using Magnum::GL::Renderer;
-            using namespace osp::active;
-            using namespace osp;
-
-            GL::defaultFramebuffer.bind();
-            GL::defaultFramebuffer.clear(
-                GL::FramebufferClear::Color
-                | GL::FramebufferClear::Depth
-                | GL::FramebufferClear::Stencil);
-
-            Renderer::disable(Renderer::Feature::DepthTest);
-            Renderer::disable(Renderer::Feature::FaceCulling);
-            Renderer::disable(Renderer::Feature::Blending);
-
-            DependRes<GL::Texture2D> colorTex =
-                rScene.get_context_resources().get<GL::Texture2D>("offscreen_fbo_color");
-            SysDebugRender::render_framebuffer(rScene, *colorTex);
-        }
-    );
-
     // Make active areas load vehicles and planets
     //sysArea.activator_add(rUni.sat_type_find_index<SatVehicle>(), sysVehicle);
     //sysArea.activator_add(rUni.sat_type_find_index<SatPlanet>(), sysPlanet);
@@ -228,35 +137,19 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     rScene.reg_emplace<ACompFloatingOrigin>(camera);
 
     {
-        // Add an offscreen framebuffer
-        using namespace Magnum;
+        auto& resources = rScene.get_context_resources();
+        Magnum::Vector2i viewSize = Magnum::GL::defaultFramebuffer.viewport().size();
 
-        auto& glResources = rScene.get_context_resources();
-
-        Vector2i viewSize = GL::defaultFramebuffer.viewport().size();
-
-        GL::Texture2D color;
-        color.setStorage(1, GL::TextureFormat::RGB8, viewSize);
-        osp::DependRes<GL::Texture2D> colorRes = glResources.add<GL::Texture2D>("offscreen_fbo_color", std::move(color));
-
-        GL::Renderbuffer depthStencil;
-        depthStencil.setStorage(GL::RenderbufferFormat::Depth24Stencil8, viewSize);
-        osp::DependRes<GL::Renderbuffer> depthStencilRes =
-            glResources.add<GL::Renderbuffer>("offscreen_fbo_depthStencil", std::move(depthStencil));
-
-        GL::Framebuffer fbo(Range2Di{{0, 0}, viewSize});
-        fbo.attachTexture(GL::Framebuffer::ColorAttachment{0}, *colorRes, 0);
-        fbo.attachRenderbuffer(GL::Framebuffer::BufferAttachment::DepthStencil, *depthStencilRes);
-
-        osp::DependRes<GL::Framebuffer> fboRes =
-            rScene.get_context_resources().add<GL::Framebuffer>("offscreen_fbo", std::move(fbo));
+        // Fetch primary render target (an offscreen FBO)
+        osp::DependRes<Magnum::GL::Framebuffer> fbo =
+            resources.get<Magnum::GL::Framebuffer>("offscreen_fbo");
 
         // Set up camera
         cameraComp.m_viewport = Vector2(viewSize);
         cameraComp.m_far = 1u << 24;
         cameraComp.m_near = 1.0f;
         cameraComp.m_fov = 45.0_degf;
-        cameraComp.m_renderTarget = std::move(fboRes);
+        cameraComp.m_renderTarget = std::move(fbo);
 
         cameraComp.calculate_projection();
     }

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -257,7 +257,7 @@ void load_a_bunch_of_stuff()
         "ph_rcs.sturdy.gltf",
         "ph_rcs_plume.sturdy.gltf"
     };
-    for (auto meshName : meshes)
+    for (std::string_view meshName : meshes)
     {
         osp::AssetImporter::load_sturdy_file(
             osp::string_concat(datapath, meshName), lazyDebugPack);


### PR DESCRIPTION
Restructures the renderer to facilitate more advanced rendering schemes, including multipass and offscreen rendering.

Major changes:
* SysDebugRender's original draw function is defunct. It now has a function which assembles the rendering pipeline out of a series of passes.
* `ACompCamera` now stores a `DependRes<Magnum::GL::Framebuffer> m_renderTarget` which specifies the render target for that camera. By convention, if this member is empty, the camera renders to the default framebuffer.
* Because of the need to bind the camera's target framebuffer, the camera argument for render functions can no longer be `const`.
* SysPlanetA's draw function has been removed, and is now drawn by the centralized rendering scheme; its meshes are now provided a temporary lambda draw function which wraps Magnum's mesh visualizer shader, until a proper planet shader is added.
* A shader was added to draw textures to the screen via a fullscreen triangle
* The renderer now draws to an offscreen framebuffer and uses the aforementioned mechanism to display it on the screen (this is not necessary now but will be soon, and demonstrates the changes made in this PR).

I also added a small QoL improvement to the CMake build process for MSVC: header and shader source files are now collected into filter groups when the VS solution is generated.