### PR TITLE
Node Wiring System(s)

### DIFF
--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -130,13 +130,13 @@ void SysMachineContainer::update_construct(ActiveScene &rScene)
         for (BlueprintMachine &mach : rVehConstr.m_blueprint->m_machines[id])
         {
             // Get part
-            ActiveEnt partEnt = rVeh.m_parts[mach.m_blueprintIndex];
+            ActiveEnt partEnt = rVeh.m_parts[mach.m_partIndex];
 
             // Get machine entity previously reserved by SysVehicle
             auto& machines = rScene.reg_get<ACompMachines>(partEnt);
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
-            BlueprintPart const& partBp = vehBp.m_blueprints[mach.m_blueprintIndex];
+            BlueprintPart const& partBp = vehBp.m_blueprints[mach.m_partIndex];
             instantiate(rScene, machEnt,
                         vehBp.m_prototypes[partBp.m_protoIndex]
                                 ->m_protoMachines[mach.m_protoMachineIndex],

--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -141,7 +141,6 @@ void SysMachineContainer::update_construct(ActiveScene &rScene)
                         vehBp.m_prototypes[partBp.m_protoIndex]
                                 ->m_protoMachines[mach.m_protoMachineIndex],
                         mach);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }

--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -35,31 +35,6 @@ using namespace adera::active::machines;
 
 /* MachineContainer */
 
-void MachineContainer::propagate_output(WireOutput* output)
-{
-
-}
-
-WireInput* MachineContainer::request_input(WireInPort port)
-{
-    return nullptr;
-}
-
-WireOutput* MachineContainer::request_output(WireOutPort port)
-{
-    return &m_outputs;
-}
-
-std::vector<WireInput*> MachineContainer::existing_inputs()
-{
-    return {};
-}
-
-std::vector<WireOutput*> MachineContainer::existing_outputs()
-{
-    return {&m_outputs};
-}
-
 uint64_t MachineContainer::request_contents(uint64_t quantity)
 {
     if (quantity > m_contents.m_quantity)
@@ -166,11 +141,7 @@ void SysMachineContainer::update_construct(ActiveScene &rScene)
                         vehBp.m_prototypes[partBp.m_protoIndex]
                                 ->m_protoMachines[mach.m_protoMachineIndex],
                         mach);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id,
-                    [] (ActiveScene &rScene, ActiveEnt ent) -> Machine&
-                    {
-                        return rScene.reg_get<MachineContainer>(ent);
-                    });
+            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }

--- a/src/adera/Machines/Container.h
+++ b/src/adera/Machines/Container.h
@@ -26,6 +26,8 @@
 
 #include "../ShipResources.h"
 
+#include <osp/Resource/blueprints.h>
+
 namespace adera::active::machines
 {
 

--- a/src/adera/Machines/Container.h
+++ b/src/adera/Machines/Container.h
@@ -56,7 +56,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-class MachineContainer : public osp::active::Machine
+class MachineContainer
 {
     friend SysMachineContainer;
 
@@ -65,17 +65,6 @@ public:
     static inline std::string smc_mach_name = "Container";
 
     MachineContainer(osp::active::ActiveEnt ownID, float capacity, ShipResource resource);
-    MachineContainer(MachineContainer&& move) noexcept;
-    MachineContainer& operator=(MachineContainer&& move) noexcept;
-    ~MachineContainer() = default;
-
-    void propagate_output(osp::active::WireOutput *output) override;
-
-    osp::active::WireInput* request_input(osp::WireInPort port) override;
-    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
-
-    std::vector<osp::active::WireInput*> existing_inputs() override;
-    std::vector<osp::active::WireOutput*> existing_outputs() override;
 
     constexpr const ShipResource& check_contents() const
     { return m_contents; }
@@ -100,39 +89,17 @@ public:
      */
     float compute_mass() const noexcept;
 private:
-    //osp::active::WireInput m_inputs;
-    osp::active::WireOutput m_outputs;
 
     float m_capacity;
     ShipResource m_contents;
 }; // class MachineContainer
 
-/* MachineContainer */
 inline MachineContainer::MachineContainer(osp::active::ActiveEnt ownID,
     float capacity, ShipResource resource)
-    : Machine(true)
-    , m_capacity(capacity)
-    , m_contents(resource)
-    , m_outputs(this, "output")
+ : m_capacity(capacity)
+ , m_contents(resource)
 {
-    m_outputs.value() = osp::active::wiretype::Pipe{ownID};
-}
-
-inline MachineContainer::MachineContainer(MachineContainer&& move) noexcept
-    : Machine(std::move(move))
-    , m_capacity(std::move(move.m_capacity))
-    , m_contents(std::move(move.m_contents))
-    , m_outputs(this, std::move(move.m_outputs))
-{}
-
-inline MachineContainer& MachineContainer::operator=(MachineContainer&& move) noexcept
-{
-    m_enable = std::exchange(move.m_enable, false);
-    m_capacity = std::exchange(move.m_capacity, 0.0f);
-    m_contents = std::move(move.m_contents);
-    m_outputs = {this, std::move(move.m_outputs)};
-
-    return *this;
+    //m_outputs.value() = osp::active::wiretype::Pipe{ownID};
 }
 
 } // namespace adera::active::machines

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -40,30 +40,6 @@ using namespace osp;
 using Magnum::Vector3;
 using Magnum::Matrix4;
 
-void MachineRCSController::propagate_output(WireOutput* output)
-{
-
-}
-
-WireInput* MachineRCSController::request_input(osp::WireInPort port)
-{
-    return existing_inputs()[port];
-}
-
-WireOutput* MachineRCSController::request_output(osp::WireOutPort port)
-{
-    return existing_outputs()[port];
-}
-
-std::vector<WireInput*> MachineRCSController::existing_inputs()
-{
-    return {&m_wiCommandOrient};
-}
-
-std::vector<WireOutput*> MachineRCSController::existing_outputs()
-{
-    return {&m_woThrottle};
-}
 
 void SysMachineRCSController::add_functions(ActiveScene& rScene)
 {
@@ -141,11 +117,7 @@ void SysMachineRCSController::update_construct(ActiveScene &rScene)
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
             rScene.reg_emplace<MachineRCSController>(machEnt);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id,
-                    [] (ActiveScene &rScene, ActiveEnt ent) -> Machine&
-                    {
-                        return rScene.reg_get<MachineRCSController>(ent);
-                    });
+            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }
@@ -154,6 +126,7 @@ void SysMachineRCSController::update_controls(ActiveScene& rScene)
 {
     auto view = rScene.get_registry().view<MachineRCSController>();
 
+#if 0
     for (ActiveEnt ent : view)
     {
         auto& machine = view.get<MachineRCSController>(ent);
@@ -192,4 +165,5 @@ void SysMachineRCSController::update_controls(ActiveScene& rScene)
             std::get<wiretype::Percent>(machine.m_woThrottle.value()).m_value = influence;
         }
     }
+#endif
 }

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -43,8 +43,8 @@ using Magnum::Matrix4;
 
 void SysMachineRCSController::add_functions(ActiveScene& rScene)
 {
-    rScene.debug_update_add(rScene.get_update_order(), "mach_rcs", "wire", "controls",
-                            &SysMachineRCSController::update_controls);
+    //rScene.debug_update_add(rScene.get_update_order(), "mach_rcs", "wire", "controls",
+    //                        &SysMachineRCSController::update_controls);
     rScene.debug_update_add(rScene.get_update_order(), "mach_rcs_construct", "vehicle_activate", "vehicle_modification",
                             &SysMachineRCSController::update_construct);
 }
@@ -110,7 +110,7 @@ void SysMachineRCSController::update_construct(ActiveScene &rScene)
         for (BlueprintMachine &mach : rVehConstr.m_blueprint->m_machines[id])
         {
             // Get part
-            ActiveEnt partEnt = rVeh.m_parts[mach.m_blueprintIndex];
+            ActiveEnt partEnt = rVeh.m_parts[mach.m_partIndex];
 
             // Get machine entity previously reserved by SysVehicle
             auto& machines = rScene.reg_get<ACompMachines>(partEnt);
@@ -122,11 +122,12 @@ void SysMachineRCSController::update_construct(ActiveScene &rScene)
     }
 }
 
+#if 0
 void SysMachineRCSController::update_controls(ActiveScene& rScene)
 {
     auto view = rScene.get_registry().view<MachineRCSController>();
 
-#if 0
+
     for (ActiveEnt ent : view)
     {
         auto& machine = view.get<MachineRCSController>(ent);
@@ -165,5 +166,6 @@ void SysMachineRCSController::update_controls(ActiveScene& rScene)
             std::get<wiretype::Percent>(machine.m_woThrottle.value()).m_value = influence;
         }
     }
-#endif
+
 }
+#endif

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -117,7 +117,6 @@ void SysMachineRCSController::update_construct(ActiveScene &rScene)
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
             rScene.reg_emplace<MachineRCSController>(machEnt);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -34,14 +34,38 @@
 #include <Magnum/Math/Vector.h>
 #include <functional>
 
-using namespace adera::active::machines;
-using namespace osp::active;
-using namespace osp;
-using Magnum::Vector3;
-using Magnum::Matrix4;
+using adera::active::machines::SysMachineRCSController;
+using adera::active::machines::MachineRCSController;
+using adera::wire::Percent;
+using adera::wire::AttitudeControl;
 
-using osp::active::wiretype::AttitudeControl;
-using osp::active::wiretype::Percent;
+using osp::active::ActiveScene;
+using osp::active::ActiveEnt;
+using osp::active::ACompMachines;
+using osp::active::ACompRigidBody_t;
+using osp::active::ACompTransform;
+using osp::active::SysPhysics_t;
+
+using osp::active::ACompWirePanel;
+using osp::active::ACompWireNodes;
+using osp::active::ACompWire;
+using osp::active::SysWire;
+using osp::active::SysSignal;
+using osp::active::WireNode;
+using osp::active::WirePort;
+using osp::active::UpdNodes_t;
+using osp::nodeindex_t;
+
+using osp::BlueprintMachine;
+
+using osp::Package;
+using osp::DependRes;
+using osp::Path;
+
+using osp::machine_id_t;
+using osp::NodeMap_t;
+using osp::Matrix4;
+using osp::Vector3;
 
 void SysMachineRCSController::add_functions(ActiveScene& rScene)
 {
@@ -96,7 +120,7 @@ void SysMachineRCSController::update_construct(ActiveScene &rScene)
             .view<osp::active::ACompVehicle,
                   osp::active::ACompVehicleInConstruction>();
 
-    machine_id_t const id = mach_id<MachineRCSController>();
+    machine_id_t const id = osp::mach_id<MachineRCSController>();
 
     for (auto [vehEnt, rVeh, rVehConstr] : view.each())
     {
@@ -128,7 +152,7 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
     std::vector<ActiveEnt>& rToUpdate
             = SysWire::to_update<MachineRCSController>(rScene);
 
-    std::vector< nodeindex_t<wiretype::Percent> > updPercent;
+    UpdNodes_t<Percent> updPercent;
 
     auto view = rScene.get_registry().view<MachineRCSController>();
 
@@ -137,44 +161,45 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
 
         float influence = 0.0f;
 
-        auto const *panelAtCtrl = rScene.get_registry()
+        auto const *pPanelAtCtrl = rScene.get_registry()
                 .try_get< ACompWirePanel<AttitudeControl> >(ent);
 
-        if (panelAtCtrl != nullptr)
+        if (pPanelAtCtrl != nullptr)
         {
-            WirePort<AttitudeControl> const *portCommand
-                    = panelAtCtrl->port(MachineRCSController::smc_wiCommandOrient);
+            WirePort<AttitudeControl> const *pPortCommand
+                    = pPanelAtCtrl->port(MachineRCSController::smc_wiCommandOrient);
 
             // Read AttitudeControl Command Input
-            if (portCommand != nullptr)
+            if (pPortCommand != nullptr)
             {
                 auto const &nodesAttCtrl
                         = rScene.reg_get< ACompWireNodes<AttitudeControl> >(
                             rScene.hier_get_root());
                 WireNode<AttitudeControl> const &nodeCommand
-                        = nodesAttCtrl.get_node(portCommand->m_nodeIndex);
+                        = nodesAttCtrl.get_node(pPortCommand->m_nodeIndex);
 
                 // Get rigidbody ancestor and its transformation component
-                auto const *rbAncestor
+                auto const *pRbAncestor
                         = SysPhysics_t::try_get_or_find_rigidbody_ancestor(
                             rScene, ent);
                 auto const &compRb = rScene.reg_get<ACompRigidBody_t>(
-                            rbAncestor->m_ancestor);
+                            pRbAncestor->m_ancestor);
                 auto const &compTf = rScene.reg_get<ACompTransform>(
-                            rbAncestor->m_ancestor);
+                            pRbAncestor->m_ancestor);
 
-                Matrix4 transform = rbAncestor->m_relTransform;
+                Matrix4 transform = pRbAncestor->m_relTransform;
 
                 // TODO: RCS translation is not currently implemented, only
                 // rotation
                 Vector3 commandTransl = Vector3{0.0f};
-                Vector3 commandRot = nodeCommand.m_state.m_value.m_attitude;
+                Vector3 commandRot = nodeCommand.m_state.m_attitude;
                 Vector3 thrusterPos = transform.translation()
                                     - compRb.m_centerOfMassOffset;
                 Vector3 thrusterDir = transform.rotation()
                                     * Vector3{0.0f, 0.0f, 1.0f};
 
-                if (commandRot.length() > 0.0f || commandTransl.length() > 0.0f)
+                if ((commandRot.length() > 0.0f)
+                        || (commandTransl.length() > 0.0f))
                 {
                     influence = thruster_influence(thrusterPos, thrusterDir,
                                                    commandTransl, commandRot);
@@ -182,24 +207,24 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
             }
         }
 
-        auto const *panelPercent = rScene.get_registry()
+        auto const *pPanelPercent = rScene.get_registry()
                 .try_get< ACompWirePanel<Percent> >(ent);
 
-        if (panelPercent != nullptr)
+        if (pPanelPercent != nullptr)
         {
-            WirePort<Percent> const *portThrottle
-                    = panelPercent->port(MachineRCSController::m_woThrottle);
+            WirePort<Percent> const *pPortThrottle
+                    = pPanelPercent->port(MachineRCSController::m_woThrottle);
 
             // Write to throttle output
-            if (portThrottle != nullptr)
+            if (pPortThrottle != nullptr)
             {
-                WireNode<Percent> &nodeThrottle
-                        = rNodesPercent.get_node(portThrottle->m_nodeIndex);
+                WireNode<Percent> const &nodeThrottle
+                        = rNodesPercent.get_node(pPortThrottle->m_nodeIndex);
 
                 // Write possibly new throttle value to node
                 SysSignal<Percent>::signal_assign(
                         rScene, {influence}, nodeThrottle,
-                        portThrottle->m_nodeIndex, updPercent);
+                        pPortThrottle->m_nodeIndex, updPercent);
             }
         }
     }
@@ -207,7 +232,8 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
     // Request to update any wire nodes if they were modified
     if (!updPercent.empty())
     {
-        rNodesPercent.update_request(std::move(updPercent));
+        std::sort(std::begin(updPercent), std::end(updPercent));
+        rNodesPercent.update_write(updPercent);
         rScene.reg_get<ACompWire>(rScene.hier_get_root()).request_update();
     }
 }

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -45,8 +45,6 @@ using osp::active::wiretype::Percent;
 
 void SysMachineRCSController::add_functions(ActiveScene& rScene)
 {
-    //rScene.debug_update_add(rScene.get_update_order(), "mach_rcs", "wire", "controls",
-    //                        &SysMachineRCSController::update_controls);
     rScene.debug_update_add(rScene.get_update_order(), "mach_rcs_construct", "vehicle_activate", "vehicle_modification",
                             &SysMachineRCSController::update_construct);
 }
@@ -130,13 +128,12 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
     std::vector<ActiveEnt>& rToUpdate
             = SysWire::to_update<MachineRCSController>(rScene);
 
-    std::vector< nodeindex_t<wiretype::Percent> > propagatePercent;
+    std::vector< nodeindex_t<wiretype::Percent> > updPercent;
 
     auto view = rScene.get_registry().view<MachineRCSController>();
 
     for (ActiveEnt ent : rToUpdate)
     {
-        auto& machine = view.get<MachineRCSController>(ent);
 
         float influence = 0.0f;
 
@@ -202,15 +199,15 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
                 // Write possibly new throttle value to node
                 SysSignal<Percent>::signal_assign(
                         rScene, {influence}, nodeThrottle,
-                        portThrottle->m_nodeIndex, propagatePercent);
+                        portThrottle->m_nodeIndex, updPercent);
             }
         }
     }
 
-    // Request propagation if wire nodes were modified
-    if (!propagatePercent.empty())
+    // Request to update any wire nodes if they were modified
+    if (!updPercent.empty())
     {
-        rNodesPercent.propagate_request(std::move(propagatePercent));
+        rNodesPercent.update_request(std::move(updPercent));
         rScene.reg_get<ACompWire>(rScene.hier_get_root()).request_update();
     }
 }

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright Â© 2019-2020 Open Space Program Project
  *
  * MIT License
  *
@@ -22,10 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 #pragma once
 
-#include <osp/Active/SysMachine.h>
 #include <osp/Resource/blueprints.h>
+
+#include <osp/Active/SysWire.h>
 
 namespace adera::active::machines
 {
@@ -65,8 +67,6 @@ public:
 
     static void update_calculate(osp::active::ActiveScene &rScene);
 
-    static void update_propagate(osp::active::ActiveScene &rScene);
-
 private:
     /**
      * Command-thrust influence calculator
@@ -94,14 +94,18 @@ class MachineRCSController
 {
     friend SysMachineRCSController;
 
+    using Percent = osp::active::wiretype::Percent;
+    using AttitudeControl = osp::active::wiretype::AttitudeControl;
+
 public:
 
     static inline std::string smc_mach_name = "RCSController";
 
+    static constexpr osp::portindex_t<AttitudeControl> smc_wiCommandOrient{0};
+
+    static constexpr osp::portindex_t<Percent> m_woThrottle{0};
 
 private:
-    //osp::active::WireInput m_wiCommandOrient{this, "Orient"};
-    //osp::active::WireOutput m_woThrottle{this, "Throttle"};
 
     osp::active::ActiveEnt m_rigidBody{entt::null};
 }; // MachineRCSController

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <osp/Active/SysMachine.h>
-#include <Magnum/Math/Vector3.h>
 #include <osp/Resource/blueprints.h>
 
 namespace adera::active::machines
@@ -62,7 +61,11 @@ public:
      *
      * @param rScene [ref] Scene with MachineRCSControllers to update
      */
-    static void update_controls(osp::active::ActiveScene &rScene);
+    //static void update_controls(osp::active::ActiveScene &rScene);
+
+    static void update_calculate(osp::active::ActiveScene &rScene);
+
+    static void update_propagate(osp::active::ActiveScene &rScene);
 
 private:
     /**
@@ -80,8 +83,8 @@ private:
      * @param cmdRot    [in] Commanded axis of rotation
      */
     static float thruster_influence(
-        Magnum::Vector3 posOset, Magnum::Vector3 direction,
-        Magnum::Vector3 cmdTransl, Magnum::Vector3 cmdRot);
+        osp::Vector3 posOset, osp::Vector3 direction,
+        osp::Vector3 cmdTransl, osp::Vector3 cmdRot);
 
 }; // SysMachineRCSController
 

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -105,9 +105,6 @@ public:
 
     static constexpr osp::portindex_t<Percent> m_woThrottle{0};
 
-private:
-
-    osp::active::ActiveEnt m_rigidBody{entt::null};
 }; // MachineRCSController
 
 

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -87,7 +87,7 @@ private:
 
 //-----------------------------------------------------------------------------
 
-class MachineRCSController : public osp::active::Machine
+class MachineRCSController
 {
     friend SysMachineRCSController;
 
@@ -95,47 +95,13 @@ public:
 
     static inline std::string smc_mach_name = "RCSController";
 
-    MachineRCSController();
-    MachineRCSController(MachineRCSController&& move) noexcept;
-    MachineRCSController& operator=(MachineRCSController&& move) noexcept;
-    ~MachineRCSController() = default;
-
-    void propagate_output(osp::active::WireOutput *output) override;
-
-    osp::active::WireInput* request_input(osp::WireInPort port) override;
-    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
-
-    std::vector<osp::active::WireInput*> existing_inputs() override;
-    std::vector<osp::active::WireOutput*> existing_outputs() override;
 
 private:
-    osp::active::WireInput m_wiCommandOrient{this, "Orient"};
-    osp::active::WireOutput m_woThrottle{this, "Throttle"};
+    //osp::active::WireInput m_wiCommandOrient{this, "Orient"};
+    //osp::active::WireOutput m_woThrottle{this, "Throttle"};
 
     osp::active::ActiveEnt m_rigidBody{entt::null};
 }; // MachineRCSController
 
-inline MachineRCSController::MachineRCSController()
-    : Machine(true)
-{
-    m_woThrottle.value() = osp::active::wiretype::Percent{0.0f};
-}
-
-
-inline MachineRCSController::MachineRCSController(MachineRCSController&& move) noexcept
-    : Machine(std::move(move))
-    , m_wiCommandOrient{this, std::move(move.m_wiCommandOrient)}
-    , m_woThrottle{this, std::move(move.m_woThrottle)}
-    , m_rigidBody(std::move(move.m_rigidBody))
-{}
-
-inline MachineRCSController& MachineRCSController::operator=(MachineRCSController&& move) noexcept
-{
-    Machine::operator=(std::move(move));
-    m_wiCommandOrient = {this, std::move(move.m_wiCommandOrient)};
-    m_woThrottle = {this, std::move(move.m_woThrottle)};
-    m_rigidBody = std::exchange(move.m_rigidBody, entt::null);
-    return *this;
-}
 
 } // adera::active::machines

--- a/src/adera/Machines/RCSController.h
+++ b/src/adera/Machines/RCSController.h
@@ -27,7 +27,7 @@
 
 #include <osp/Resource/blueprints.h>
 
-#include <osp/Active/SysWire.h>
+#include "../wiretypes.h"
 
 namespace adera::active::machines
 {
@@ -94,8 +94,8 @@ class MachineRCSController
 {
     friend SysMachineRCSController;
 
-    using Percent = osp::active::wiretype::Percent;
-    using AttitudeControl = osp::active::wiretype::AttitudeControl;
+    using Percent = wire::Percent;
+    using AttitudeControl = wire::AttitudeControl;
 
 public:
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -71,19 +71,18 @@ void SysMachineRocket::update_construct(ActiveScene& rScene)
         for (BlueprintMachine const &mach : vehBp.m_machines[id])
         {
             // Get part
-            ActiveEnt partEnt = rVeh.m_parts[mach.m_blueprintIndex];
+            ActiveEnt partEnt = rVeh.m_parts[mach.m_partIndex];
 
             // Get machine entity previously reserved by SysVehicle
             auto& machines = rScene.reg_get<ACompMachines>(partEnt);
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
-            BlueprintPart const& partBp = vehBp.m_blueprints[mach.m_blueprintIndex];
+            BlueprintPart const& partBp = vehBp.m_blueprints[mach.m_partIndex];
             instantiate(rScene, machEnt,
                         vehBp.m_prototypes[partBp.m_protoIndex]
                                 ->m_protoMachines[mach.m_protoMachineIndex],
                         mach);
             rScene.reg_emplace<ACompMachineType>(machEnt, id);
-            rScene.reg_emplace<ACompWirePanel<wiretype::Percent>>(machEnt, 1);
         }
     }
 }
@@ -98,15 +97,15 @@ void SysMachineRocket::update_calculate(ActiveScene& rScene)
 
         // Get the Percent Panel which contains the Throttle Port
         auto &panelPercent = rScene.reg_get< ACompWirePanel<wiretype::Percent> >(ent);
-        WirePort<wiretype::Percent> &portThrottle = panelPercent.get_port(MachineRocket::smc_wiThrottle);
+        WirePort<wiretype::Percent> const *portThrottle = panelPercent.connection(MachineRocket::smc_wiThrottle);
 
         machine.m_powerOutput = 0;
 
-        if (portThrottle.connected())
+        if (portThrottle != nullptr)
         {
             // Get the connected node and its value
             auto &nodesPercent = rScene.reg_get< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
-            WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle.m_nodeIndex);
+            WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle->m_nodeIndex);
             float throttle = nodeThrottle.m_value.m_value;
             machine.m_powerOutput = throttle;
         }

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -97,7 +97,7 @@ void SysMachineRocket::update_calculate(ActiveScene& rScene)
 
         // Get the Percent Panel which contains the Throttle Port
         auto &panelPercent = rScene.reg_get< ACompWirePanel<wiretype::Percent> >(ent);
-        WirePort<wiretype::Percent> const *portThrottle = panelPercent.connection(MachineRocket::smc_wiThrottle);
+        WirePort<wiretype::Percent> const *portThrottle = panelPercent.port(MachineRocket::smc_wiThrottle);
 
         machine.m_powerOutput = 0;
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -82,7 +82,6 @@ void SysMachineRocket::update_construct(ActiveScene& rScene)
                         vehBp.m_prototypes[partBp.m_protoIndex]
                                 ->m_protoMachines[mach.m_protoMachineIndex],
                         mach);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -88,9 +88,10 @@ void SysMachineRocket::update_construct(ActiveScene& rScene)
 
 void SysMachineRocket::update_calculate(ActiveScene& rScene)
 {
-    auto view = rScene.get_registry().view<MachineRocket, ACompWireNeedUpdate>();
+    auto view = rScene.get_registry().view<MachineRocket>();
+    std::vector<ActiveEnt>& rToUpdate = rScene.reg_get<ACompWire>(rScene.hier_get_root()).m_entToCalculate[mach_id<MachineRocket>()];
 
-    for (ActiveEnt ent : view)
+    for (ActiveEnt ent : rToUpdate)
     {
         auto &machine = view.get<MachineRocket>(ent);
 
@@ -105,11 +106,12 @@ void SysMachineRocket::update_calculate(ActiveScene& rScene)
             // Get the connected node and its value
             auto &nodesPercent = rScene.reg_get< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
             WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle->m_nodeIndex);
-            float throttle = nodeThrottle.m_value.m_value;
+            float throttle = nodeThrottle.m_state.m_value.m_percent;
             machine.m_powerOutput = throttle;
         }
-
     }
+
+    rToUpdate.clear();
 
 }
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -89,25 +89,31 @@ void SysMachineRocket::update_construct(ActiveScene& rScene)
 void SysMachineRocket::update_calculate(ActiveScene& rScene)
 {
     auto view = rScene.get_registry().view<MachineRocket>();
-    std::vector<ActiveEnt>& rToUpdate = rScene.reg_get<ACompWire>(rScene.hier_get_root()).m_entToCalculate[mach_id<MachineRocket>()];
+    std::vector<ActiveEnt>& rToUpdate = SysWire::to_update<MachineRocket>(rScene);
 
     for (ActiveEnt ent : rToUpdate)
     {
         auto &machine = view.get<MachineRocket>(ent);
 
-        // Get the Percent Panel which contains the Throttle Port
-        auto &panelPercent = rScene.reg_get< ACompWirePanel<wiretype::Percent> >(ent);
-        WirePort<wiretype::Percent> const *portThrottle = panelPercent.port(MachineRocket::smc_wiThrottle);
-
         machine.m_powerOutput = 0;
 
-        if (portThrottle != nullptr)
+        // Get the Percent Panel which contains the Throttle Port
+        auto const *panelPercent = rScene.get_registry()
+                .try_get< ACompWirePanel<wiretype::Percent> >(ent);
+
+        if (panelPercent != nullptr)
         {
-            // Get the connected node and its value
-            auto &nodesPercent = rScene.reg_get< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
-            WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle->m_nodeIndex);
-            float throttle = nodeThrottle.m_state.m_value.m_percent;
-            machine.m_powerOutput = throttle;
+            WirePort<wiretype::Percent> const *portThrottle
+                    = panelPercent->port(MachineRocket::smc_wiThrottle);
+
+            if (portThrottle != nullptr)
+            {
+                // Get the connected node and its value
+                auto &nodesPercent = rScene.reg_get< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
+                WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle->m_nodeIndex);
+                float throttle = nodeThrottle.m_state.m_value.m_percent;
+                machine.m_powerOutput = throttle;
+            }
         }
     }
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -37,9 +37,37 @@
 
 #include <iostream>
 
-using namespace adera::active::machines;
-using namespace osp::active;
-using namespace osp;
+using adera::active::machines::SysMachineRocket;
+using adera::wire::Percent;
+using adera::active::machines::MachineRocket;
+
+using osp::active::ActiveScene;
+using osp::active::ActiveEnt;
+using osp::active::ACompHierarchy;
+using osp::active::EHierarchyTraverseStatus;
+using osp::active::ACompMachines;
+using osp::active::ACompRigidBody_t;
+using osp::active::ACompTransform;
+using osp::active::SysPhysics_t;
+
+using osp::active::ACompWirePanel;
+using osp::active::ACompWireNodes;
+using osp::active::SysWire;
+using osp::active::WireNode;
+using osp::active::WirePort;
+
+using osp::BlueprintMachine;
+using osp::BlueprintPart;
+using osp::BlueprintVehicle;
+
+using osp::Package;
+using osp::DependRes;
+using osp::Path;
+
+using osp::machine_id_t;
+using osp::NodeMap_t;
+using osp::Matrix4;
+using osp::Vector3;
 
 void SysMachineRocket::add_functions(ActiveScene &rScene)
 {
@@ -55,7 +83,7 @@ void SysMachineRocket::update_construct(ActiveScene& rScene)
             .view<osp::active::ACompVehicle,
                   osp::active::ACompVehicleInConstruction>();
 
-    machine_id_t const id = mach_id<MachineRocket>();
+    machine_id_t const id = osp::mach_id<MachineRocket>();
 
     for (auto [vehEnt, rVeh, rVehConstr] : view.each())
     {
@@ -98,20 +126,23 @@ void SysMachineRocket::update_calculate(ActiveScene& rScene)
         machine.m_powerOutput = 0;
 
         // Get the Percent Panel which contains the Throttle Port
-        auto const *panelPercent = rScene.get_registry()
-                .try_get< ACompWirePanel<wiretype::Percent> >(ent);
+        auto const *pPanelPercent = rScene.get_registry()
+                .try_get< ACompWirePanel<Percent> >(ent);
 
-        if (panelPercent != nullptr)
+        if (pPanelPercent != nullptr)
         {
-            WirePort<wiretype::Percent> const *portThrottle
-                    = panelPercent->port(MachineRocket::smc_wiThrottle);
+            WirePort<Percent> const *pPortThrottle
+                    = pPanelPercent->port(MachineRocket::smc_wiThrottle);
 
-            if (portThrottle != nullptr)
+            if (pPortThrottle != nullptr)
             {
                 // Get the connected node and its value
-                auto &nodesPercent = rScene.reg_get< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
-                WireNode<wiretype::Percent> &nodeThrottle = nodesPercent.get_node(portThrottle->m_nodeIndex);
-                float throttle = nodeThrottle.m_state.m_value.m_percent;
+                auto const &nodesPercent
+                        = rScene.reg_get< ACompWireNodes<Percent> >(
+                            rScene.hier_get_root());
+                WireNode<Percent> const &nodeThrottle
+                        = nodesPercent.get_node(pPortThrottle->m_nodeIndex);
+                float throttle = nodeThrottle.m_state.m_percent;
                 machine.m_powerOutput = throttle;
             }
         }
@@ -296,7 +327,7 @@ MachineRocket& SysMachineRocket::instantiate(
     rocket.m_params.m_specImpulse = config_get_if<double>(config.m_config, "Isp", 42.0);
 
     std::string const& fuelIdent = config_get_if<std::string>(config.m_config, "fueltype", "");
-    Path resPath = decompose_path(fuelIdent);
+    Path resPath = osp::decompose_path(fuelIdent);
     Package& pkg = rScene.get_application().debug_find_package(resPath.prefix);
     DependRes<ShipResourceType> fuel = pkg.get<ShipResourceType>(resPath.identifier);
 

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -102,12 +102,6 @@ public:
     static void update_calculate(osp::active::ActiveScene& rScene);
 
     /**
-     * Request fuel...
-     * @param rScene
-     */
-    static void update_propagate(osp::active::ActiveScene& rScene);
-
-    /**
      * Updates all MachineRockets in the scene
      *
      * This function handles draining fuel and applying thrust.

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -35,24 +35,9 @@ namespace adera::active::machines
 /**
  *
  */
-class MachineRocket : public osp::active::Machine
+class MachineRocket
 {
     friend class SysMachineRocket;
-
-    using input_t = std::pair<osp::DependRes<ShipResourceType>, float>;
-    struct ResourceInput
-    {
-        ResourceInput(osp::DependRes<ShipResourceType> type,
-            float massRateFraction, osp::active::WireInput source)
-            : m_type(std::move(type))
-            , m_massRateFraction(massRateFraction)
-            , m_source(std::move(source))
-        {}
-
-        osp::DependRes<ShipResourceType> m_type;
-        float m_massRateFraction;
-        osp::active::WireInput m_source;
-    };
 
     struct Parameters
     {
@@ -63,21 +48,6 @@ class MachineRocket : public osp::active::Machine
 public:
 
     static inline std::string smc_mach_name = "Rocket";
-
-    MachineRocket(Parameters params, std::vector<input_t> resources);
-    MachineRocket(MachineRocket &&move) noexcept;
-    MachineRocket& operator=(MachineRocket&& move) noexcept;
-
-    MachineRocket(MachineRocket const& copy) = delete;
-    MachineRocket& operator=(MachineRocket const& move) = delete;
-
-    void propagate_output(osp::active::WireOutput *output) override;
-
-    osp::active::WireInput* request_input(osp::WireInPort port) override;
-    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
-
-    std::vector<osp::active::WireInput*> existing_inputs() override;
-    std::vector<osp::active::WireOutput*> existing_outputs() override;
 
     /**
      * Return normalized power output level of the rocket this frame
@@ -96,10 +66,10 @@ public:
     }
 
 private:
-    osp::active::WireInput m_wiGimbal{this, "Gimbal"};
-    osp::active::WireInput m_wiIgnition{this, "Ignition"};
-    osp::active::WireInput m_wiThrottle{this, "Throttle"};
-    std::vector<ResourceInput> m_resourceLines;
+//    osp::active::WireInput m_wiGimbal{this, "Gimbal"};
+//    osp::active::WireInput m_wiIgnition{this, "Ignition"};
+//    osp::active::WireInput m_wiThrottle{this, "Throttle"};
+//    std::vector<ResourceInput> m_resourceLines;
 
     osp::active::ActiveEnt m_rigidBody{entt::null};
     Parameters m_params;
@@ -155,53 +125,8 @@ public:
             osp::BlueprintMachine const& settings);
 
 private:
-    static uint64_t resource_units_required(
-        osp::active::ActiveScene const& scene,
-        MachineRocket const& machine, float throttle,
-        MachineRocket::ResourceInput const& resource);
 
-    constexpr static float resource_mass_flow_rate(MachineRocket const& machine,
-        float throttle, MachineRocket::ResourceInput const& resource);
-
-    osp::active::UpdateOrderHandle_t m_updatePhysics;
 }; // SysMachineRocket
 
-inline MachineRocket::MachineRocket(Parameters params, std::vector<input_t> resources)
-    : Machine(true)
-    , m_params(params)
-{
-    for (input_t& input : std::move(resources))
-    {
-        std::string resName = input.first->m_identifier;
-        m_resourceLines.emplace_back(
-            std::move(input.first),
-            input.second,
-            osp::active::WireInput{this, resName});
-    }
-}
-
-inline MachineRocket::MachineRocket(MachineRocket&& move) noexcept
-   : Machine(std::move(move))
-   , m_wiGimbal(this, std::move(move.m_wiGimbal))
-   , m_wiIgnition(this, std::move(move.m_wiIgnition))
-   , m_wiThrottle(this, std::move(move.m_wiThrottle))
-   , m_rigidBody(std::move(move.m_rigidBody))
-   , m_params(std::move(move.m_params))
-   , m_resourceLines(std::move(move.m_resourceLines))
-   , m_powerOutput(std::exchange(move.m_powerOutput, 0.0f))
-{ }
-
-inline MachineRocket& MachineRocket::operator=(MachineRocket&& move) noexcept
-{
-    Machine::operator=(std::move(move));
-    m_wiGimbal   = { this, std::move(move.m_wiGimbal)   };
-    m_wiIgnition = { this, std::move(move.m_wiIgnition) };
-    m_wiThrottle = { this, std::move(move.m_wiThrottle) };
-    m_rigidBody  = std::move(move.m_rigidBody);
-    m_params = std::move(move.m_params);
-    m_resourceLines = std::move(move.m_resourceLines);
-    m_powerOutput = std::exchange(move.m_powerOutput, 0.0f);
-    return *this;
-}
 
 } // namespace adera::active::machines

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -52,7 +52,7 @@ public:
 
     static inline std::string smc_mach_name = "Rocket";
 
-    static constexpr osp::wire_port_t<Percent> smc_wiThrottle{0};
+    static constexpr osp::portindex_t<Percent> smc_wiThrottle{0};
 
     /**
      * Return normalized power output level of the rocket this frame

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -25,7 +25,7 @@
 #pragma once
 #include <utility>
 #include <osp/Active/SysMachine.h>
-
+#include <osp/Active/SysWire.h>
 #include <osp/Active/physics.h>
 #include <osp/Resource/blueprints.h>
 #include "adera/ShipResources.h"
@@ -71,10 +71,7 @@ public:
     }
 
 private:
-//    osp::active::WireInput m_wiGimbal{this, "Gimbal"};
-//    osp::active::WireInput m_wiIgnition{this, "Ignition"};
-//    osp::active::WireInput m_wiThrottle{this, "Throttle"};
-//    std::vector<ResourceInput> m_resourceLines;
+
 
     osp::active::ActiveEnt m_rigidBody{entt::null};
     Parameters m_params;
@@ -97,6 +94,18 @@ public:
      * @param rScene [ref] Scene supporting vehicles
      */
     static void update_construct(osp::active::ActiveScene &rScene);
+
+    /**
+     * Read wire inputs and calculate required fuel
+     * @param rScene
+     */
+    static void update_calculate(osp::active::ActiveScene& rScene);
+
+    /**
+     * Request fuel...
+     * @param rScene
+     */
+    static void update_propagate(osp::active::ActiveScene& rScene);
 
     /**
      * Updates all MachineRockets in the scene

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -25,6 +25,7 @@
 #pragma once
 #include <utility>
 #include <osp/Active/SysMachine.h>
+
 #include <osp/Active/physics.h>
 #include <osp/Resource/blueprints.h>
 #include "adera/ShipResources.h"
@@ -39,6 +40,8 @@ class MachineRocket
 {
     friend class SysMachineRocket;
 
+    using Percent = osp::active::wiretype::Percent;
+
     struct Parameters
     {
         float m_maxThrust;
@@ -48,6 +51,8 @@ class MachineRocket
 public:
 
     static inline std::string smc_mach_name = "Rocket";
+
+    static constexpr osp::wire_port_t<Percent> smc_wiThrottle{0};
 
     /**
      * Return normalized power output level of the rocket this frame

--- a/src/adera/Machines/Rocket.h
+++ b/src/adera/Machines/Rocket.h
@@ -23,12 +23,13 @@
  * SOFTWARE.
  */
 #pragma once
-#include <utility>
+
+#include "../wiretypes.h"
+
 #include <osp/Active/SysMachine.h>
 #include <osp/Active/SysWire.h>
 #include <osp/Active/physics.h>
 #include <osp/Resource/blueprints.h>
-#include "adera/ShipResources.h"
 
 namespace adera::active::machines
 {
@@ -40,7 +41,7 @@ class MachineRocket
 {
     friend class SysMachineRocket;
 
-    using Percent = osp::active::wiretype::Percent;
+    using Percent = wire::Percent;
 
     struct Parameters
     {

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -87,8 +87,8 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
     ACompWireNodes<Percent> &rNodesPercent = SysWire::nodes<Percent>(rScene);
     ACompWireNodes<AttitudeControl> &rNodesAttCtrl = SysWire::nodes<AttitudeControl>(rScene);
 
-    std::vector< nodeindex_t<wiretype::Percent> > propagatePercent;
-    std::vector< nodeindex_t<wiretype::AttitudeControl> > propagateAttCtrl;
+    std::vector< nodeindex_t<wiretype::Percent> > updPercent;
+    std::vector< nodeindex_t<wiretype::AttitudeControl> > updAttCtrl;
 
     if (usrCtrl.m_selfDestruct.triggered())
     {
@@ -152,7 +152,7 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
                 // Write possibly new throttle value to node
                 SysSignal<Percent>::signal_assign(
                         rScene, {throttlePos}, nodeThrottle,
-                        portThrottle->m_nodeIndex, propagatePercent);
+                        portThrottle->m_nodeIndex, updPercent);
             }
         }
 
@@ -167,19 +167,19 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
 
             SysSignal<AttitudeControl>::signal_assign(
                     rScene, {attitudeIn}, nodeAttCtrl,
-                    portAttitude->m_nodeIndex, propagateAttCtrl);
+                    portAttitude->m_nodeIndex, updAttCtrl);
         }
     }
 
-    // Request propagation if wire nodes were modified
-    if (!propagatePercent.empty())
+    // Request to update any wire nodes if they were modified
+    if (!updPercent.empty())
     {
-        rNodesPercent.propagate_request(std::move(propagatePercent));
+        rNodesPercent.update_request(std::move(updPercent));
         rScene.reg_get<ACompWire>(rScene.hier_get_root()).request_update();
     }
-    if (!propagateAttCtrl.empty())
+    if (!updAttCtrl.empty())
     {
-        rNodesAttCtrl.propagate_request(std::move(propagateAttCtrl));
+        rNodesAttCtrl.update_request(std::move(updAttCtrl));
         rScene.reg_get<ACompWire>(rScene.hier_get_root()).request_update();
     }
 }

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -70,6 +70,9 @@ void SysMachineUserControl::update_construct(ActiveScene &rScene)
 
             rScene.reg_emplace<MachineUserControl>(machEnt);
             rScene.reg_emplace<ACompMachineType>(machEnt, id);
+            auto &panelAttCtrl = rScene.reg_emplace<ACompWirePanel<wiretype::AttitudeControl>>(machEnt);
+            auto &panelPercent = rScene.reg_emplace<ACompWirePanel<wiretype::Percent>>(machEnt);
+
         }
     }
 }

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -69,7 +69,6 @@ void SysMachineUserControl::update_construct(ActiveScene &rScene)
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
             rScene.reg_emplace<MachineUserControl>(machEnt);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }

--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -42,31 +42,6 @@ void SysMachineUserControl::add_functions(ActiveScene &rScene)
                             &SysMachineUserControl::update_construct);
 }
 
-void MachineUserControl::propagate_output(WireOutput* output)
-{
-    SPDLOG_LOGGER_INFO(spdlog::get("application"), "Propagate test: {}", output->get_name());
-}
-
-WireInput* MachineUserControl::request_input(WireInPort port)
-{
-    return existing_inputs()[port];
-}
-
-WireOutput* MachineUserControl::request_output(WireOutPort port)
-{
-    return existing_outputs()[port];
-}
-
-std::vector<WireInput*> MachineUserControl::existing_inputs()
-{
-    return {&m_wiTest};
-}
-
-std::vector<WireOutput*> MachineUserControl::existing_outputs()
-{
-    return {&m_woAttitude, &m_woThrottle, &m_woTestPropagate};
-}
-
 void SysMachineUserControl::update_construct(ActiveScene &rScene)
 {
     auto view = rScene.get_registry()
@@ -94,11 +69,7 @@ void SysMachineUserControl::update_construct(ActiveScene &rScene)
             ActiveEnt machEnt = machines.m_machines[mach.m_protoMachineIndex];
 
             rScene.reg_emplace<MachineUserControl>(machEnt);
-            rScene.reg_emplace<ACompMachineType>(machEnt, id,
-                    [] (ActiveScene &rScene, ActiveEnt ent) -> Machine&
-                    {
-                        return rScene.reg_get<MachineUserControl>(ent);
-                    });
+            rScene.reg_emplace<ACompMachineType>(machEnt, id);
         }
     }
 }
@@ -126,6 +97,8 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
 
     auto view = rScene.get_registry().view<MachineUserControl>();
 
+
+#if 0
     for (ActiveEnt ent : view)
     {
         MachineUserControl &machine = view.get<MachineUserControl>(ent);
@@ -167,4 +140,6 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
         SPDLOG_LOGGER_TRACE(rScene.get_application().get_logger(),
                             "Updating control");
     }
+
+#endif
 }

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -26,6 +26,7 @@
 
 #include <osp/UserInputHandler.h>
 #include <osp/Active/SysMachine.h>
+#include <osp/Active/SysWire.h>
 
 namespace adera::active::machines
 {
@@ -98,11 +99,13 @@ class MachineUserControl
 {
     friend SysMachineUserControl;
 
+    using Percent = osp::active::wiretype::Percent;
+
 public:
 
     static constexpr std::string_view smc_mach_name = "UserControl";
 
-
+    static constexpr osp::wire_port_t<Percent> smc_woThrottle{0};
 
 
 private:

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include "../wiretypes.h"
+
 #include <osp/UserInputHandler.h>
 #include <osp/Active/SysMachine.h>
 #include <osp/Active/SysWire.h>
@@ -95,24 +97,20 @@ public:
 /**
  * Interfaces user input into WireOutputs designed for controlling spacecraft.
  */
-class MachineUserControl
+struct MachineUserControl
 {
-    friend SysMachineUserControl;
-
-    using Percent = osp::active::wiretype::Percent;
-    using AttitudeControl = osp::active::wiretype::AttitudeControl;
-
-public:
+    using Percent = adera::wire::Percent;
+    using AttitudeControl = adera::wire::AttitudeControl;
 
     static constexpr std::string_view smc_mach_name = "UserControl";
 
     static constexpr osp::portindex_t<Percent> smc_woThrottle{0};
-
     static constexpr osp::portindex_t<AttitudeControl> smc_woAttitude{0};
 
-
-private:
-    int dummy;
+    // TODO: Eventually restructure MachineUserControl to instead have controls
+    //       as members that can be written to instead of listening directly
+    //       to a UserInputHandler
+    bool m_enable{false};
 };
 
 //-----------------------------------------------------------------------------

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -90,6 +90,12 @@ public:
      * @param rScene [ref] Scene with MachineUserControls to update
      */
     static void update_sensor(osp::active::ActiveScene &rScene);
+
+    /**
+     *
+     * @param rScene
+     */
+    static void update_propagate(osp::active::ActiveScene &rScene);
 };
 
 /**

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -94,7 +94,7 @@ public:
 /**
  * Interfaces user input into WireOutputs designed for controlling spacecraft.
  */
-class MachineUserControl : public osp::active::Machine
+class MachineUserControl
 {
     friend SysMachineUserControl;
 
@@ -102,50 +102,18 @@ public:
 
     static constexpr std::string_view smc_mach_name = "UserControl";
 
-    MachineUserControl();
-    MachineUserControl(MachineUserControl&& move);
 
-    MachineUserControl& operator=(MachineUserControl&& move);
 
-    void propagate_output(osp::active::WireOutput* output) override;
-
-    osp::active::WireInput* request_input(osp::WireInPort port) override;
-    osp::active::WireOutput* request_output(osp::WireOutPort port) override;
-
-    std::vector<osp::active::WireInput*> existing_inputs() override;
-    std::vector<osp::active::WireOutput*> existing_outputs() override;
 
 private:
-    osp::active::WireInput  m_wiTest          { this, "Test"              };
-    osp::active::WireOutput m_woAttitude      { this, "AttitudeControl"   };
-    osp::active::WireOutput m_woTestPropagate { this, "TestOut", m_wiTest };
-    osp::active::WireOutput m_woThrottle      { this, "Throttle"          };
+    int dummy;
+//    osp::active::WireInput  m_wiTest          { this, "Test"              };
+//    osp::active::WireOutput m_woAttitude      { this, "AttitudeControl"   };
+//    osp::active::WireOutput m_woTestPropagate { this, "TestOut", m_wiTest };
+//    osp::active::WireOutput m_woThrottle      { this, "Throttle"          };
 };
 
 //-----------------------------------------------------------------------------
 
-inline MachineUserControl::MachineUserControl()
-{
-    m_woAttitude.value() = osp::active::wiretype::AttitudeControl{};
-    m_woThrottle.value() = osp::active::wiretype::Percent{0.0f};
-}
-
-inline MachineUserControl::MachineUserControl(MachineUserControl&& move)
- : Machine(std::move(move))
- , m_wiTest(this, std::move(move.m_wiTest))
- , m_woAttitude(this, std::move(move.m_woAttitude))
- , m_woTestPropagate(this, std::move(move.m_woTestPropagate)) // TODO: Why not reference m_wiTest here?
- , m_woThrottle(this, std::move(move.m_woThrottle))
-{ }
-
-inline MachineUserControl& MachineUserControl::operator=(MachineUserControl&& move)
-{
-    Machine::operator=(std::move(move));
-    m_wiTest          = { this, std::move(move.m_wiTest)          };
-    m_woAttitude      = { this, std::move(move.m_woAttitude)      };
-    m_woTestPropagate = { this, std::move(move.m_woTestPropagate) }; // TODO: Why not reference m_wiTest here?
-    m_woThrottle      = { this, std::move(move.m_woThrottle)      };
-    return *this;
-}
 
 } // namespace adera::active::machines

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -113,10 +113,6 @@ public:
 
 private:
     int dummy;
-//    osp::active::WireInput  m_wiTest          { this, "Test"              };
-//    osp::active::WireOutput m_woAttitude      { this, "AttitudeControl"   };
-//    osp::active::WireOutput m_woTestPropagate { this, "TestOut", m_wiTest };
-//    osp::active::WireOutput m_woThrottle      { this, "Throttle"          };
 };
 
 //-----------------------------------------------------------------------------

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -90,12 +90,6 @@ public:
      * @param rScene [ref] Scene with MachineUserControls to update
      */
     static void update_sensor(osp::active::ActiveScene &rScene);
-
-    /**
-     *
-     * @param rScene
-     */
-    static void update_propagate(osp::active::ActiveScene &rScene);
 };
 
 /**
@@ -112,9 +106,9 @@ public:
 
     static constexpr std::string_view smc_mach_name = "UserControl";
 
-    static constexpr osp::wire_port_t<Percent> smc_woThrottle{0};
+    static constexpr osp::portindex_t<Percent> smc_woThrottle{0};
 
-    static constexpr osp::wire_port_t<AttitudeControl> m_woAttitude{0};
+    static constexpr osp::portindex_t<AttitudeControl> m_woAttitude{0};
 
 
 private:

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -108,7 +108,7 @@ public:
 
     static constexpr osp::portindex_t<Percent> smc_woThrottle{0};
 
-    static constexpr osp::portindex_t<AttitudeControl> m_woAttitude{0};
+    static constexpr osp::portindex_t<AttitudeControl> smc_woAttitude{0};
 
 
 private:

--- a/src/adera/Machines/UserControl.h
+++ b/src/adera/Machines/UserControl.h
@@ -106,12 +106,15 @@ class MachineUserControl
     friend SysMachineUserControl;
 
     using Percent = osp::active::wiretype::Percent;
+    using AttitudeControl = osp::active::wiretype::AttitudeControl;
 
 public:
 
     static constexpr std::string_view smc_mach_name = "UserControl";
 
     static constexpr osp::wire_port_t<Percent> smc_woThrottle{0};
+
+    static constexpr osp::wire_port_t<AttitudeControl> m_woAttitude{0};
 
 
 private:

--- a/src/adera/ShipResources.h
+++ b/src/adera/ShipResources.h
@@ -145,6 +145,4 @@ struct ShipResource
     uint64_t m_quantity;
 };
 
-
-
 } // namespace adera::active::machines

--- a/src/adera/wiretypes.h
+++ b/src/adera/wiretypes.h
@@ -1,0 +1,89 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <osp/Active/SysSignal.h>
+
+namespace adera::wire
+{
+    /**
+     * Rotation command with pitch, yaw and roll components
+     */
+    struct AttitudeControl : public osp::active::Signal<AttitudeControl>
+    {
+        static inline std::string smc_wire_name = "AttitudeControl";
+
+        AttitudeControl() = default;
+        constexpr AttitudeControl(osp::Vector3 value) noexcept : m_attitude(value) { }
+
+        //  each (-1.0 .. 1.0)
+        // pitch, yaw, roll
+        osp::Vector3 m_attitude;
+
+        bool operator==(AttitudeControl const& rhs) const
+        {
+            return m_attitude == rhs.m_attitude;
+        }
+
+        bool operator!=(AttitudeControl const& rhs) const
+        {
+            return m_attitude != rhs.m_attitude;
+        }
+    };
+
+    /**
+     * A percentage for something like throttle
+     */
+    struct Percent : public osp::active::Signal<Percent>
+    {
+        static inline std::string smc_wire_name = "Percent";
+
+        Percent() = default;
+        constexpr Percent(float value) noexcept : m_percent(value) { }
+
+        float m_percent;
+
+        constexpr bool operator==(Percent const& rhs) const
+        {
+            return m_percent == rhs.m_percent;
+        }
+
+        constexpr bool operator!=(Percent const& rhs) const
+        {
+            return m_percent != rhs.m_percent;
+        }
+    };
+
+    /**
+     * Boolean signal for logic gates
+     */
+    struct Logic : public osp::active::Signal<Logic>
+    {
+        bool m_value;
+    };
+
+} // namespace wiretype
+
+

--- a/src/osp/Active/SysMachine.h
+++ b/src/osp/Active/SysMachine.h
@@ -24,7 +24,8 @@
  */
 #pragma once
 
-#include "SysWire.h"
+#include "ActiveScene.h"
+#include "../Resource/machines.h"
 
 #include <cstdint>
 #include <iostream>

--- a/src/osp/Active/SysMachine.h
+++ b/src/osp/Active/SysMachine.h
@@ -33,8 +33,6 @@
 namespace osp::active
 {
 
-using Corrade::Containers::LinkedList;
-using Corrade::Containers::LinkedListItem;
 
 class ISysMachine;
 class Machine;
@@ -56,61 +54,18 @@ struct ACompMachines
 
 struct ACompMachineType
 {
-    // TODO: Temporary, remove when new wiring system is added. A well made ECS
-    //       means that all publicly accessible properties of machines are in
-    //       separate components
-    using get_machine_component_t = Machine& (*)(ActiveScene&, ActiveEnt);
-
-    ACompMachineType(machine_id_t type, get_machine_component_t get)
+    ACompMachineType(machine_id_t type)
      : m_type(type)
-     , m_get_machine{get}
     { }
     machine_id_t m_type;
-    get_machine_component_t m_get_machine;
 };
 
 //-----------------------------------------------------------------------------
 
-/**
- * Machine Base class. This should tecnically be an AComp Virtual functions are
- * only for wiring; this will probably change soon.
- *
- * Calling updates are handled by SysMachines
- */
-class Machine : public IWireElement
-{
 
-public:
-    constexpr Machine() noexcept = default;
-    constexpr Machine(bool enable) noexcept;
-    constexpr Machine(Machine&& move) noexcept = default;
-    constexpr Machine& operator=(Machine&& move) noexcept = default;
-
-    Machine(Machine const& copy) = delete;
-    Machine& operator=(Machine const& move) = delete;
-
-    constexpr void enable(void) noexcept;
-    constexpr void disable(void) noexcept;
-
-protected:
-    bool m_enable = false;
-};
 
 //-----------------------------------------------------------------------------
 
-constexpr Machine::Machine(bool enable) noexcept
- : m_enable(enable)
-{ }
-
-constexpr void Machine::enable(void) noexcept
-{
-    m_enable = true;
-}
-
-constexpr void Machine::disable(void) noexcept
-{
-    m_enable = false;
-}
 
 
 } // namespace osp::active

--- a/src/osp/Active/SysSignal.h
+++ b/src/osp/Active/SysSignal.h
@@ -1,0 +1,239 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "SysWire.h"
+
+namespace osp::active
+{
+
+/**
+ * Template for Signal types
+ *
+ * Signals have Single writers and multiple readers. They are analogous to
+ * voltage levels in digital logic. Values are copied and reassigned without
+ * describing any sort of mass-conserving flow.
+ *
+ * The first Link in a Node writes new values to the node (Machine's Output)
+ * The remaining Links only read values (Connected Machine Inputs)
+ */
+template<typename WIRETYPE_T>
+struct Signal
+{
+    // New values to write to the node, same data as wire type
+    struct WriteValue : public WIRETYPE_T { };
+
+    // State stored in each node, same data as wire type
+    struct NodeState : public WIRETYPE_T { };
+
+    // No link state needed
+    struct LinkState { };
+};
+
+//-----------------------------------------------------------------------------
+
+template<typename WIRETYPE_T>
+class SysSignal
+{
+public:
+
+    /**
+     * Assign a new value to a signal Node
+     *
+     * If the value has changed, then changes will be pushed to the updNodes
+     * vector. Changes will be applied after the node update
+     *
+     * @param rScene        [ref] Scene the Node is part of
+     * @param newValue      [in] New value to assign to Node
+     * @param rNode         [out] Node to assign value of
+     * @param nodeIndex     [in] Index of Node
+     * @param updNodes      [out] Vector of nodes to update
+     */
+    static void signal_assign(
+            ActiveScene& rScene,
+            WIRETYPE_T&& newValue,
+            WireNode<WIRETYPE_T> const& rNode,
+            nodeindex_t<WIRETYPE_T> nodeIndex,
+            UpdNodes_t<WIRETYPE_T>& updNodes);
+
+    /**
+     * Read the blueprint of a Vehicle and construct needed Nodes and Links.
+     *
+     * The vehicle must already have fully initialized Panels
+     *
+     * @param rScene     [ref] Scene supporting Vehicles and the right Node type
+     * @param vehicleEnt [in] Vehicle entity
+     * @param vehicle    [in] Vehicle component used to locate parts
+     * @param vehicleBp  [in] Blueprint of vehicle
+     */
+    static void signal_construct_nodes(
+            ActiveScene& rScene, ActiveEnt vehicleEnt,
+            ACompVehicle const& vehicle,
+            BlueprintVehicle const& vehicleBp);
+
+    /**
+     * Scan the scene for vehicles in construction, and construct Nodes and
+     * Panels if their Blueprint specifies it.
+     *
+     * @param rScene [ref] Scene supporting Vehicles and the right Node type
+     */
+    static void signal_update_construct(ActiveScene& rScene);
+
+    /**
+     * Update all signal Nodes in the scene.
+     *
+     * This applies changes to Nodes by processing all write requests, and also
+     * marks connected machine inputs for update.
+     *
+     * @param rScene [ref] Scene supporting the right Node type
+     */
+    static void signal_update_nodes(ActiveScene& rScene);
+
+}; // class SysSignal
+
+template<typename WIRETYPE_T>
+void SysSignal<WIRETYPE_T>::signal_assign(
+        ActiveScene& rScene,
+        WIRETYPE_T&& newValue,
+        WireNode<WIRETYPE_T> const& rNode,
+        nodeindex_t<WIRETYPE_T> nodeIndex,
+        UpdNodes_t<WIRETYPE_T>& updNodes)
+{
+    if (static_cast<WIRETYPE_T const&>(rNode.m_state) != newValue)
+    {
+        updNodes.emplace_back(
+                nodeIndex, typename WIRETYPE_T::WriteValue{
+                        std::forward<WIRETYPE_T>(newValue)});
+    }
+}
+
+template<typename WIRETYPE_T>
+void SysSignal<WIRETYPE_T>::signal_construct_nodes(
+        ActiveScene& rScene, ActiveEnt vehicleEnt,
+        ACompVehicle const& vehicle, BlueprintVehicle const& vehicleBp)
+{
+    wire_id_t const id = wiretype_id<WIRETYPE_T>();
+
+    // Check if the vehicle blueprint stores the right wire node type
+    if (vehicleBp.m_wireNodes.size() <= id)
+    {
+        return;
+    }
+
+    // Initialize all nodes in the vehicle
+    for (BlueprintWireNode const &bpNode : vehicleBp.m_wireNodes[id])
+    {
+        // Create the node
+        auto &rNodes = rScene.reg_get< ACompWireNodes<WIRETYPE_T> >(
+                    rScene.hier_get_root());
+        auto const &[node, nodeIndex] = rNodes.create_node();
+
+        // Create Links
+        for (BlueprintWireLink const &bpLink : bpNode.m_links)
+        {
+            // Get part entity from vehicle
+            ActiveEnt partEnt = vehicle.m_parts[bpLink.m_partIndex];
+
+            // Get machine entity from vehicle
+            auto &machines = rScene.reg_get<ACompMachines>(partEnt);
+            ActiveEnt machEnt = machines.m_machines[bpLink.m_protoMachineIndex];
+
+            // Get panel to connect to
+            auto& panel = rScene.reg_get< ACompWirePanel<WIRETYPE_T> >(machEnt);
+
+            // Link them
+            SysWire::connect<WIRETYPE_T>(node, nodeIndex, panel, machEnt,
+                                         portindex_t<WIRETYPE_T>(bpLink.m_port),
+                                         typename WIRETYPE_T::LinkState{});
+        }
+    }
+}
+
+template<typename WIRETYPE_T>
+void SysSignal<WIRETYPE_T>::signal_update_construct(ActiveScene& rScene)
+{
+    auto view = rScene.get_registry()
+            .view<osp::active::ACompVehicle,
+                  osp::active::ACompVehicleInConstruction>();
+
+    wire_id_t const id = wiretype_id<WIRETYPE_T>();
+
+    for (auto [vehEnt, rVeh, rVehConstr] : view.each())
+    {
+        SysWire::construct_panels<WIRETYPE_T>(
+                    rScene, vehEnt, rVeh, *(rVehConstr.m_blueprint));
+
+        signal_construct_nodes(rScene, vehEnt, rVeh, *(rVehConstr.m_blueprint));
+    }
+}
+
+template<typename WIRETYPE_T>
+void SysSignal<WIRETYPE_T>::signal_update_nodes(ActiveScene& rScene)
+{
+    auto &rNodes = rScene.reg_get< ACompWireNodes<WIRETYPE_T> >(
+                rScene.hier_get_root());
+    auto &rWire = rScene.reg_get<ACompWire>(rScene.hier_get_root());
+
+    // Machines to update accumulated throughout updating nodes
+    std::vector<std::vector<ActiveEnt>> machToUpdate(rWire.m_entToCalculate.size());
+
+    // Loop through all nodes that need to be updated
+    for (UpdNode<WIRETYPE_T> const& updNode : rNodes.m_writeRequests)
+    {
+        WireNode<WIRETYPE_T> &rNode = rNodes.get_node(
+                nodeindex_t<WIRETYPE_T>(updNode.m_node));
+
+        // Overwrite value with value to write
+        static_cast<WIRETYPE_T&>(rNode.m_state)
+                = static_cast<WIRETYPE_T const&>(updNode.m_write);
+
+        // Add connected machine inputs to machToUpdate vectors, as they now
+        // require a calculation update
+        for (auto it = std::next(std::begin(rNode.m_links));
+             it != std::end(rNode.m_links); std::advance(it, 1))
+        {
+            ActiveEnt ent = it->m_entity;
+            auto const& type = rScene.reg_get<ACompMachineType>(ent);
+            machToUpdate[size_t(type.m_type)].push_back(ent);
+        }
+    }
+
+    // Clear write requests, as they've all been written
+    rNodes.m_writeRequests.clear();
+
+    // Commit machines to update to the scene-wide vectors
+    for (int i = 0; i < machToUpdate.size(); i ++)
+    {
+        std::vector<ActiveEnt> &rVec = machToUpdate[i];
+        if (!rVec.empty())
+        {
+            std::lock_guard<std::mutex> guard(rWire.m_entToCalculateMutex[i]);
+            vecset_merge(rWire.m_entToCalculate[i], rVec);
+            rWire.request_update();
+        }
+    }
+}
+
+}

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -192,8 +192,8 @@ ActiveEnt SysVehicle::part_instantiate(
     ActiveEnt& rootEntity = newEntities[0];
 
     // reserve space for new entities and ACompTransforms to be created
-    rScene.get_registry().reserve(
-                rScene.get_registry().capacity() + part.m_entityCount);
+    //rScene.get_registry().reserve(
+    //            rScene.get_registry().capacity() + part.m_entityCount);
     rScene.get_registry().reserve<ACompTransform>(
                 rScene.get_registry().capacity<ACompTransform>() + part.m_entityCount);
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -338,9 +338,10 @@ ActiveEnt SysVehicle::part_instantiate(
 
     for (PCompMachine const& pcompMachine : part.m_protoMachines)
     {
-        ActiveEnt machEnt = newEntities[pcompMachine.m_entity];
-        machines.m_machines.push_back(
-                    rScene.hier_create_child(machEnt, "Machine"));
+        ActiveEnt parent = newEntities[pcompMachine.m_entity];
+        ActiveEnt machEnt = machines.m_machines.emplace_back(
+                    rScene.hier_create_child(parent, "Machine"));
+        rScene.reg_emplace<ACompMachineType>(machEnt, pcompMachine.m_type);
     }
 
     return rootEntity;

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -352,39 +352,7 @@ void debug_wire_vehicles(ActiveScene &rScene)
             .view<osp::active::ACompVehicle,
                   osp::active::ACompVehicleInConstruction>();
 
-    for (auto [vehEnt, rVeh, rVehConstr] : view.each())
-    {
-        // Loop through wire connections
-        for (BlueprintWire& blueprintWire : rVehConstr.m_blueprint->m_wires)
-        {
-            // TODO: check if the connections are valid
 
-            // get wire from
-
-            ACompMachines& fromMachines = rScene.reg_get<ACompMachines>(
-                    rVeh.m_parts[blueprintWire.m_fromPart]);
-
-            ActiveEnt fromEnt = fromMachines.m_machines[blueprintWire.m_fromMachine];
-            Machine &fromMachine = rScene.reg_get<ACompMachineType>(fromEnt)
-                                         .m_get_machine(rScene, fromEnt);
-            WireOutput* fromWire =
-                    fromMachine.request_output(blueprintWire.m_fromPort);
-
-            // get wire to
-
-            ACompMachines& toMachines = rScene.reg_get<ACompMachines>(
-                   rVeh.m_parts[blueprintWire.m_toPart]);
-
-            ActiveEnt toEnt = toMachines.m_machines[blueprintWire.m_toMachine];
-            Machine &toMachine = rScene.reg_get<ACompMachineType>(toEnt)
-                                       .m_get_machine(rScene, toEnt);
-            WireInput* toWire = toMachine.request_input(blueprintWire.m_toPort);
-
-            // make the connection
-
-            SysWire::connect(*fromWire, *toWire);
-        }
-    }
 }
 
 void SysVehicle::update_activate(ActiveScene &rScene)

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -36,17 +36,6 @@
 namespace osp::active
 {
 
-struct WireMachineConnection
-{
-    ActiveEnt m_fromPartEnt;
-    unsigned m_fromMachine;
-    WireOutPort m_fromPort;
-
-    ActiveEnt m_toPartEnt;
-    unsigned m_toMachine;
-    WireInPort m_toPort;
-};
-
 struct ACompVehicle
 {
     std::vector<ActiveEnt> m_parts;

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -39,12 +39,12 @@ void SysWire::setup_default(
         ActiveScene& rScene,
         uint32_t machineTypeCount,
         std::vector<ACompWire::updfunc_t> updCalculate,
-        std::vector<ACompWire::updfunc_t> updPropagate)
+        std::vector<ACompWire::updfunc_t> updNodes)
 {
     rScene.reg_emplace<ACompWire>(
             rScene.hier_get_root(),
             ACompWire{std::move(updCalculate),
-                      std::move(updPropagate),
+                      std::move(updNodes),
                       std::vector<std::vector<ActiveEnt>>(machineTypeCount),
                       std::vector<std::mutex>(machineTypeCount)});
 }
@@ -59,8 +59,8 @@ void SysWire::update_wire(ActiveScene &rScene)
     {
         wire.m_updateRequest = false;
 
-        // Perform Propagation update for all Nodes
-        for (ACompWire::updfunc_t update : wire.m_updPropagate)
+        // Update all Nodes
+        for (ACompWire::updfunc_t update : wire.m_updNodes)
         {
             update(rScene);
         }

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -26,3 +26,51 @@
 
 #include "SysWire.h"
 #include "ActiveScene.h"
+
+using osp::active::SysWire;
+
+void SysWire::add_functions(ActiveScene& rScene)
+{
+    rScene.debug_update_add(rScene.get_update_order(), "wire", "vehicle_modification", "physics",
+                            &SysWire::update_wire);
+}
+
+void SysWire::setup_default(
+        ActiveScene& rScene,
+        std::vector<ACompWire::update_func_t> updCalculate,
+        std::vector<ACompWire::update_func_t> updPropagate)
+{
+    rScene.reg_emplace<ACompWire>(rScene.hier_get_root(),
+                                  ACompWire{std::move(updCalculate),
+                                            std::move(updPropagate)});
+}
+
+void SysWire::update_wire(ActiveScene &rScene)
+{
+    auto view = rScene.get_registry().view<ACompWireNeedUpdate>();
+
+    auto const& wire = rScene.reg_get<ACompWire>(rScene.hier_get_root());
+
+    int updateLimit = 16;
+
+    while (!view.empty())
+    {
+        for (ACompWire::update_func_t update : wire.m_updCalculate)
+        {
+            update(rScene);
+        }
+
+        for (ACompWire::update_func_t update : wire.m_updPropagate)
+        {
+            update(rScene);
+        }
+
+        updateLimit --;
+        if (0 == updateLimit)
+        {
+            SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
+                               "Wire update limit reached");
+            break;
+        }
+    }
+}

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -26,33 +26,3 @@
 
 #include "SysWire.h"
 #include "ActiveScene.h"
-
-using namespace osp;
-using namespace osp::active;
-
-WireData* WireInput::connected_value()
-{
-    WireOutput* woConnected = list();
-    if (woConnected)
-    {
-        return &(woConnected->value());
-    }
-    else
-    {
-        return nullptr;
-    }
-}
-
-void WireInput::doErase()
-{
-     list()->cut(this);
-};
-
-
-void SysWire::connect(WireOutput &wireFrom, WireInput &wireTo)
-{
-  SPDLOG_LOGGER_INFO(spdlog::get("application"), "Connected {} to {}", wireFrom.get_name(),
-                      wireTo.get_name());
-    wireFrom.insert(&wireTo);
-    // TODO: check for dependent outputs and add to list and sort
-}

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -49,6 +49,9 @@ void SysWire::update_wire(ActiveScene &rScene)
 {
     auto view = rScene.get_registry().view<ACompWireNeedUpdate>();
 
+    ActiveReg_t::poly_storage t = rScene.get_registry().storage(entt::type_id<ACompWireNeedUpdate>());
+
+
     auto const& wire = rScene.reg_get<ACompWire>(rScene.hier_get_root());
 
     int updateLimit = 16;

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -41,7 +41,7 @@ void SysWire::setup_default(
         std::vector<ACompWire::updfunc_t> updCalculate,
         std::vector<ACompWire::updfunc_t> updPropagate)
 {
-    auto& wire = rScene.reg_emplace<ACompWire>(
+    rScene.reg_emplace<ACompWire>(
             rScene.hier_get_root(),
             ACompWire{std::move(updCalculate),
                       std::move(updPropagate),
@@ -51,8 +51,6 @@ void SysWire::setup_default(
 
 void SysWire::update_wire(ActiveScene &rScene)
 {
-    //auto view = rScene.get_registry().view<ACompWireNeedUpdate>();
-
     auto &wire = rScene.reg_get<ACompWire>(rScene.hier_get_root());
 
     int updateLimit = 16;
@@ -60,21 +58,6 @@ void SysWire::update_wire(ActiveScene &rScene)
     while (wire.m_updateRequest)
     {
         wire.m_updateRequest = false;
-        // Check if any updates are needed
-//        bool needUpdate = false;
-//        for (std::vector<ActiveEnt> const& toUpdate : wire.m_entToCalculate)
-//        {
-//            if (!toUpdate.empty())
-//            {
-//                needUpdate = true;
-//                break;
-//            }
-//        }
-
-//        if (!needUpdate)
-//        {
-//            break; // Break if no updates needed
-//        }
 
         // Perform Calculation update for all Machines
         for (ACompWire::updfunc_t update : wire.m_updCalculate)

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -59,16 +59,22 @@ void SysWire::update_wire(ActiveScene &rScene)
     {
         wire.m_updateRequest = false;
 
+        // Perform Propagation update for all Nodes
+        for (ACompWire::updfunc_t update : wire.m_updPropagate)
+        {
+            update(rScene);
+        }
+
         // Perform Calculation update for all Machines
         for (ACompWire::updfunc_t update : wire.m_updCalculate)
         {
             update(rScene);
         }
 
-        // Perform Propagation update for all Nodes
-        for (ACompWire::updfunc_t update : wire.m_updPropagate)
+        // Clear update queues
+        for (std::vector<ActiveEnt> &toUpdate : wire.m_entToCalculate)
         {
-            update(rScene);
+            toUpdate.clear();
         }
 
         // Stop updating if limit is reached

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include "SysVehicle.h"
+
 #include "activetypes.h"
 #include "../types.h"
 #include "../Resource/blueprints.h"
@@ -33,14 +35,14 @@
 namespace osp::active
 {
 
-
-
 namespace wiretype
 {
 
     struct Signal
     {
-        enum class LinkType : uint8_t { Input, Output };
+        //enum class LinkType : uint8_t { Input, Output };
+
+        struct LinkState { };
     };
 
     /**
@@ -118,38 +120,54 @@ namespace wiretype
 
 //-----------------------------------------------------------------------------
 
+template<typename WIRETYPE_T>
+struct WireLink
+{
+    ActiveEnt m_entity;
+    wire_port_t<WIRETYPE_T> m_port;
+    typename WIRETYPE_T::LinkState m_linktype;
+};
+
 /**
  * Stores the wire value, and connects to machine's ACompWirePanel
  */
-template<typename VALUE_T>
+template<typename WIRETYPE_T>
 struct WireNode
 {
-    struct ConnectToPanel
+    std::vector< WireLink<WIRETYPE_T> > m_links;
+
+    WIRETYPE_T m_value;
+};
+
+template<typename WIRETYPE_T>
+struct WirePort
+{
+    wire_node_t<WIRETYPE_T> m_nodeIndex{nullvalue< wire_node_t<WIRETYPE_T> >()};
+    //typename WIRETYPE_T::LinkState m_linktype;
+    constexpr bool connected() noexcept
     {
-        ActiveEnt m_entity; // ACompWirePanel<VALUE_T>
-        uint32_t m_index;
-        typename VALUE_T::LinkType m_linktype;
+        return m_nodeIndex != nullvalue< wire_node_t<WIRETYPE_T> >();
     };
-
-    std::vector<ConnectToPanel> m_connections;
-
-    VALUE_T m_value;
 };
 
 /**
  * Connects machines to WireNodes
  */
-template<typename VALUE_T>
+template<typename WIRETYPE_T>
 struct ACompWirePanel
 {
-    struct ConnectToNode
-    {
-        uint32_t m_index;
-        typename VALUE_T::LinkType m_linktype;
-    };
+
+    ACompWirePanel(uint16_t portCount)
+     : m_ports(portCount)
+    { }
 
     // Connect to nodes
-    std::vector<ConnectToNode> m_connections;
+    std::vector< WirePort<WIRETYPE_T> > m_ports;
+
+    WirePort<WIRETYPE_T>& get_port(wire_port_t<WIRETYPE_T> portIndex) noexcept
+    {
+        return m_ports[size_t(portIndex)];
+    }
 };
 
 /**
@@ -160,19 +178,27 @@ struct ACompWireNeedUpdate { };
 /**
  * Scene-wide storage for WireNodes
  */
-template<typename VALUE_T>
+template<typename WIRETYPE_T>
 struct ACompWireNodes
 {
-    std::vector< WireNode<VALUE_T> > m_nodes;
+    std::vector< WireNode<WIRETYPE_T> > m_nodes;
 
-    template<typename ARGS_T>
-    uint32_t create_node(ARGS_T&& args...)
+    template<typename ... ARGS_T>
+    std::pair<WireNode<WIRETYPE_T>&, wire_node_t<WIRETYPE_T>> create_node(
+            ARGS_T&& ... args)
     {
         uint32_t index = m_nodes.size();
-        m_nodes.emplace_back(args);
-        return index;
+        WireNode<WIRETYPE_T> &node = m_nodes.emplace_back(std::forward<ARGS_T>(args) ...);
+        return {node, wire_node_t<WIRETYPE_T>(index)};
+    }
+
+    WireNode<WIRETYPE_T>& get_node(wire_node_t<WIRETYPE_T> nodeIndex) noexcept
+    {
+        return m_nodes[size_t(nodeIndex)];
     }
 };
+
+//-----------------------------------------------------------------------------
 
 struct ACompWire
 {
@@ -185,14 +211,109 @@ struct ACompWire
 class SysWire
 {
 public:
+
+    template<typename WIRETYPE_T>
+    static bool connect(
+            WireNode<WIRETYPE_T>& node,
+            wire_node_t<WIRETYPE_T> nodeIndex,
+            ACompWirePanel<WIRETYPE_T>& panel,
+            ActiveEnt machEnt,
+            wire_port_t<WIRETYPE_T> port,
+            typename WIRETYPE_T::LinkState link);
+
+    template<typename WIRETYPE_T>
+    static void signal_notify(ActiveScene& rScene, WireNode<WIRETYPE_T> const& node);
+
     static void add_functions(ActiveScene& rScene);
-    static void setup_default(ActiveScene& rScene);
+    static void setup_default(
+            ActiveScene& rScene,
+            std::vector<ACompWire::update_func_t> updCalculate,
+            std::vector<ACompWire::update_func_t> updPropagate);
 
     static void update_wire(ActiveScene& rScene);
 
+    template<typename WIRETYPE_T>
+    static void update_construct_signal(ActiveScene& rScene);
+
 };
 
+template<typename WIRETYPE_T>
+bool SysWire::connect(
+        WireNode<WIRETYPE_T>& node,
+        wire_node_t<WIRETYPE_T> nodeIndex,
+        ACompWirePanel<WIRETYPE_T>& panel,
+        ActiveEnt machEnt,
+        wire_port_t<WIRETYPE_T> port,
+        typename WIRETYPE_T::LinkState link)
+{
+    if (panel.m_ports.size() <= size_t(port))
+    {
+        return false; // Invalid port
+    }
 
+    //uint32_t index = node.m_links.size();
+    node.m_links.emplace_back(WireLink<WIRETYPE_T>{machEnt, port, link});
+    panel.m_ports[size_t(port)].m_nodeIndex = nodeIndex;
+    return true;
+}
 
+template<typename WIRETYPE_T>
+void SysWire::signal_notify(ActiveScene& rScene, WireNode<WIRETYPE_T> const& node)
+{
+    // 0 is the output writing to the node, 1 and onwards are connected inputs
+    for (int i = 1; i < node.m_links.size(); i ++)
+    {
+        rScene.get_registry().emplace_or_replace<ACompWireNeedUpdate>(node.m_links[i].m_entity);
+    }
+}
+
+template<typename WIRETYPE_T>
+void SysWire::update_construct_signal(ActiveScene& rScene)
+{
+    using LinkState = wiretype::Signal::LinkState;
+
+    auto view = rScene.get_registry()
+            .view<osp::active::ACompVehicle,
+                  osp::active::ACompVehicleInConstruction>();
+
+    wire_id_t const id = wiretype_id<WIRETYPE_T>();
+
+    for (auto [vehEnt, rVeh, rVehConstr] : view.each())
+    {
+        // Check if the vehicle blueprint stores the right wire type
+        if (rVehConstr.m_blueprint->m_wireNodes.size() <= id)
+        {
+            continue;
+        }
+
+        // Initialize all nodes in the vehicle
+        for (BlueprintWireNode &bpNode : rVehConstr.m_blueprint->m_wireNodes[id])
+        {
+            // Create the node
+            auto &nodes = rScene.reg_get< ACompWireNodes<WIRETYPE_T> >(rScene.hier_get_root());
+
+            auto const &[node, nodeIndex] = nodes.create_node();
+
+            // Create Links
+            for (BlueprintWireLink &bpLink : bpNode.m_links)
+            {
+                // Get part entity from vehicle
+                ActiveEnt partEnt = rVeh.m_parts[bpLink.m_blueprintIndex];
+
+                // Get machine entity from vehicle
+                auto &machines = rScene.reg_get<ACompMachines>(partEnt);
+                ActiveEnt machEnt = machines.m_machines[bpLink.m_protoMachineIndex];
+
+                // Get panel to connect to
+                auto& panel = rScene.reg_get< ACompWirePanel<WIRETYPE_T> >(machEnt);
+
+                // Link them
+                connect<WIRETYPE_T>(node, nodeIndex, panel, machEnt,
+                                    wire_port_t<WIRETYPE_T>(bpLink.m_port),
+                                    { });
+            }
+        }
+    }
+}
 
 } // namespace osp::active

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -28,20 +28,10 @@
 #include "../types.h"
 #include "../Resource/blueprints.h"
 
-#include <Corrade/Containers/LinkedList.h>
-
-#include <variant>
-#include <string>
 #include <vector>
 
 namespace osp::active
 {
-
-using Corrade::Containers::LinkedList;
-using Corrade::Containers::LinkedListItem;
-
-class WireInput;
-class WireOutput;
 
 namespace wiretype
 {
@@ -116,261 +106,48 @@ namespace wiretype
 
 } // namespace wiretype
 
-// Supported data types
-using WireData = std::variant<wiretype::Attitude,
-                              wiretype::AttitudeControl,
-                              wiretype::Percent,
-                              wiretype::Deploy,
-                              wiretype::Pipe>;
 
 //-----------------------------------------------------------------------------
-
 
 /**
- * Object that have WireInputs and WireOutputs. So far, just Machines inherit.
- * keep WireInputs and WireOutputs as members. move them explicitly
+ * Stores the wire value, and connects to machine's ACompWirePanel
  */
-class IWireElement
+template<typename VALUE_T>
+struct WireNode
 {
-public:
-    // TODO: maybe get rid of the raw pointers somehow
-
-    /**
-     * Request a Dependent WireOutput's value to update, by reading the
-     * WireInputs it depends on
-     * @param pOutput [in] The output that needs to be updated
-     */
-    virtual void propagate_output(WireOutput* pOutput) = 0;
-
-    /**
-     * Request a WireOutput by port. What happens is up to the implemenation,
-     * this may access a map, array, or maybe even create a WireOutput on the
-     * fly.
-     *
-     * @param port Port to identify the WireOutput
-     * @return Pointer to found WireOutput, nullptr if not found
-     */
-    virtual WireOutput* request_output(WireOutPort port) = 0;
-
-    /**
-     * Request a WireInput by port. What happens is up to the implemenation,
-     * this may access a map, array, or maybe even create a WireInput on the
-     * fly.
-     *
-     * @param port Port to identify the WireInput
-     * @return Pointer to found WireInput, nullptr if not found
-     */
-    virtual WireInput* request_input(WireInPort port) = 0;
-
-    // TODO: maybe return ports too, as the pointers returned here can be
-    //       invalidated when the SysMachine reallocates
-
-    /**
-     * @return Vector of existing WireInputs
-     */
-    virtual std::vector<WireInput*> existing_inputs() = 0;
-
-    /**
-     * @return Vector of existing WireInputs
-     */
-    virtual std::vector<WireOutput*> existing_outputs() = 0;
-};
-
-
-//-----------------------------------------------------------------------------
-
-
-class WireInput : private LinkedListItem<WireInput, WireOutput>
-{
-    friend LinkedListItem<WireInput, WireOutput>;
-    friend LinkedList<WireInput>;
-
-public:
-    WireInput(IWireElement *element, std::string name) noexcept;
-
-    /**
-     * Move with new m_element. Use when this is a member of the WireElement
-     * where m_element becomes invalid on move
-     * @param element
-     * @param move
-     */
-    WireInput(IWireElement *element, WireInput&& move) noexcept;
-
-    // For use in move constructors / move operators of classes
-    // that aggregate WireInput. Use at own risk!!!
-    WireInput(WireInput&& move) = default;
-    WireInput& operator=(WireInput&& move) = default;
-
-    WireInput(WireInput const& copy) = delete;
-    WireInput& operator=(WireInput const& move) = delete;
-
-    void doErase() override;
-
-    //bool is_connected() { return list(); }
-    constexpr std::string const& get_name() { return m_name; }
-
-    WireOutput* connected() { return list(); }
-
-    WireData* connected_value();
-
-    /**
-     * Get value from connected WireOutput
-     */
-    template<typename T>
-    T* get_if();
-
-    /**
-     * Get const value from connected WireOutput
-     */
-    template<typename T>
-    const T* get_if() const;
-
-private:
-    IWireElement* m_element;
-    std::string m_name;
-};
-
-//-----------------------------------------------------------------------------
-
-class WireOutput : private LinkedList<WireInput>
-{
-    friend LinkedList<WireInput>;
-    friend LinkedListItem<WireInput, WireOutput>;
-
-public:
-    /**
-     * Construct a WireOutput
-     * @param element Associated WireElement, usually a Machine
-     * @param name
-     */
-    WireOutput(IWireElement* element, std::string name);
-    WireOutput(IWireElement* element, std::string name, WireInput& propagateDepend);
-
-    /**
-     * Move with new m_element. Use when this is a member of the WireElement
-     * where m_element becomes invalid on move
-     * @param element
-     * @param move
-     */
-    WireOutput(IWireElement *element, WireOutput&& move);
-
-    // For use in move constructors / move operators of classes
-    // that aggregate WireInput. Use at own risk!!!
-    WireOutput(WireOutput&& move) noexcept = default;
-    WireOutput& operator=(WireOutput&& move) = default;
-
-    WireOutput(WireOutput const& copy) = delete;
-    WireOutput& operator=(WireOutput const& move) = delete;
-
-    std::string const& get_name() { return m_name; }
-
-    using LinkedList<WireInput>::insert;
-    using LinkedList<WireInput>::cut;
-
-    void propagate()
+    struct ConnectToPanel
     {
-        //(list()->*m_propagate_output)();
-        //list()->propagate_output(this);
-        //m_element->propagate_output(this);
-    }
+        ActiveEnt m_entity; // ACompWirePanel<VALUE_T>
+        uint32_t m_index;
+        //typename VALUE_T::LinkType m_linktype;
+    };
 
-    WireData& value() { return m_value; }
-    const WireData& value() const { return m_value; }
+    std::vector<ConnectToPanel> m_connections;
 
-private:
-    WireData m_value;
-    IWireElement* m_element;
-    std::string m_name;
+    VALUE_T m_value;
 };
 
+/**
+ * Connects machines to WireNodes
+ */
+template<typename VALUE_T>
+struct ACompWirePanel
+{
+    struct ConnectToNode
+    {
+        uint32_t m_index;
+        typename VALUE_T::LinkType m_linktype;
+    };
 
-//-----------------------------------------------------------------------------
-
+    // Connect to nodes
+    std::vector<ConnectToNode> m_connections;
+};
 
 class SysWire
 {
 public:
 
-    static inline std::string smc_name = "Wire";
 
-    struct DependentOutput
-    {
-        IWireElement *m_element;
-        WireOutput *m_output;
-        unsigned depth;
-    };
-
-    static void connect(WireOutput &wireFrom, WireInput &wireTo);
-
-private:
-    std::vector<DependentOutput> m_dependentOutputs;
-    UpdateOrderHandle_t m_updateWire;
 };
-
-
-//-----------------------------------------------------------------------------
-
-
-// TODO: move this somewhere else
-template<typename T>
-T* WireInput::get_if()
-{
-    if (list() == nullptr)
-    {
-        // Not connected to any WireOutput!
-        return nullptr;
-    }
-    else
-    {
-        // Attempt to get value of variant
-        return std::get_if<T> (&(list()->value()));
-    }
-}
-//-----------------------------------------------------------------------------
-
-template<typename T>
-const T* WireInput::get_if() const
-{
-    if (list() == nullptr)
-    {
-        // Not connected to any WireOutput!
-        return nullptr;
-    }
-    else
-    {
-        // Attempt to get value of variant
-        return std::get_if<T>(&(list()->value()));
-    }
-}
-
-inline WireInput::WireInput(IWireElement* element, std::string name) noexcept
- : m_element(element)
- , m_name(std::move(name))
-{ }
-
-inline WireInput::WireInput(IWireElement *element, WireInput&& move) noexcept
- : LinkedListItem<WireInput, WireOutput>(std::move(move))
- , m_element(element)
- , m_name(std::move(move.m_name))
-{ }
-
-//-----------------------------------------------------------------------------
-
-inline WireOutput::WireOutput(IWireElement* element, std::string name)
- : m_element(element)
- , m_name(std::move(name))
-{ }
-
-inline WireOutput::WireOutput(IWireElement* element, std::string name, WireInput& propagateDepend)
- : m_element(element)
- , m_name(std::move(name))
-{ }
-
-inline WireOutput::WireOutput(IWireElement *element, WireOutput&& move)
- : LinkedList<WireInput>(std::move(move))
- , m_value(std::move(move.m_value))
- , m_element(element)
- , m_name(std::move(move.m_name))
-{ }
 
 } // namespace osp::active

--- a/src/osp/Active/SysWire.h
+++ b/src/osp/Active/SysWire.h
@@ -75,6 +75,10 @@ namespace wiretype
     struct AttitudeControl : public Signal<AttitudeControl>
     {
         static inline std::string smc_wire_name = "AttitudeControl";
+
+        AttitudeControl() = default;
+        constexpr AttitudeControl(Vector3 value) noexcept : m_attitude(value) { }
+
         //  each (-1.0 .. 1.0)
         // pitch, yaw, roll
         Vector3 m_attitude;
@@ -255,6 +259,11 @@ struct ACompWireNodes
         return m_nodes[size_t(nodeIndex)];
     }
 
+    WireNode<WIRETYPE_T> const& get_node(nodeindex_t<WIRETYPE_T> nodeIndex) const noexcept
+    {
+        return m_nodes[size_t(nodeIndex)];
+    }
+
     /**
      * Request a propagation update for a set of Nodes. This locks a mutex.
      * @param request [in] Vector of node indices
@@ -341,6 +350,15 @@ public:
     static constexpr ACompWireNodes<WIRETYPE_T>& nodes(ActiveScene& rScene)
     {
         return rScene.reg_get< ACompWireNodes<WIRETYPE_T> >(rScene.hier_get_root());
+    }
+
+    /**
+     * @return Vector of entities of a specified machine type to update
+     */
+    template<typename MACH_T>
+    static constexpr std::vector<ActiveEnt>& to_update(ActiveScene& rScene)
+    {
+        return rScene.reg_get<ACompWire>(rScene.hier_get_root()).m_entToCalculate[mach_id<MACH_T>()];
     }
 
     /**

--- a/src/osp/Resource/blueprints.h
+++ b/src/osp/Resource/blueprints.h
@@ -32,9 +32,6 @@
 namespace osp
 {
 
-using WireInPort = uint16_t;
-using WireOutPort = uint16_t;
-
 struct BlueprintMachine
 {
     NodeMap_t m_config;
@@ -52,7 +49,7 @@ struct BlueprintMachine
  * * Transformation
  */
 struct BlueprintPart
-{ 
+{
 
     BlueprintPart(uint32_t protoIndex, uint16_t machineCount,
                   Vector3 translation, Quaternion rotation, Vector3 scale)
@@ -72,30 +69,30 @@ struct BlueprintPart
     uint16_t m_machineCount;
 };
 
-/**
- * Describes a "from output -> to input" wire connection
- *
- * [  machine  out]--->[in  other machine  ]
- */
-struct BlueprintWire
+struct BlueprintWireLink
 {
-    BlueprintWire(unsigned fromPart, unsigned fromMachine, WireOutPort fromPort,
-                  unsigned toPart, unsigned toMachine, WireOutPort toPort) :
-        m_fromPart(fromPart),
-        m_fromMachine(fromMachine),
-        m_fromPort(fromPort),
-        m_toPart(toPart),
-        m_toMachine(toMachine),
-        m_toPort(toPort)
-    {}
+    // ie. Input/output; fuel flow priority
+    NodeMap_t m_config;
 
-    unsigned m_fromPart;
-    unsigned m_fromMachine;
-    WireOutPort m_fromPort;
+    // Index to a BlueprintPart in BlueprintVehicle's m_blueprints
+    uint32_t m_blueprintIndex;
 
-    unsigned m_toPart;
-    unsigned m_toMachine;
-    WireInPort m_toPort;
+    // Machine to link to, index to m_protoMachines in PrototypePart
+    uint16_t m_protoMachineIndex;
+
+    // Machine's port to connect to
+    uint16_t m_port;
+};
+
+/**
+ *
+ */
+struct BlueprintWireNode
+{
+
+    NodeMap_t m_config;
+
+    std::vector<BlueprintWireLink> m_links;
 };
 
 /**
@@ -113,10 +110,12 @@ struct BlueprintVehicle
     std::vector<BlueprintPart> m_blueprints;
 
     // Wires to connect
-    std::vector<BlueprintWire> m_wires;
+    // m_wires[wiretype id]
+    std::vector< std::vector<BlueprintWireNode> > m_wireNodes;
 
+    // All machines in the vehicle
     // m_machines[machine id]
-    std::vector<std::vector<BlueprintMachine>> m_machines;
+    std::vector< std::vector<BlueprintMachine> > m_machines;
 
 };
 

--- a/src/osp/Resource/blueprints.h
+++ b/src/osp/Resource/blueprints.h
@@ -37,7 +37,7 @@ struct BlueprintMachine
     NodeMap_t m_config;
 
     // Index to a BlueprintPart in BlueprintVehicle's m_blueprints
-    uint32_t m_blueprintIndex;
+    uint32_t m_partIndex;
     // Index to a m_protoMachines in PrototypePart
     uint16_t m_protoMachineIndex;
 };
@@ -75,7 +75,7 @@ struct BlueprintWireLink
     NodeMap_t m_config;
 
     // Index to a BlueprintPart in BlueprintVehicle's m_blueprints
-    uint32_t m_blueprintIndex;
+    uint32_t m_partIndex;
 
     // Machine to link to, index to m_protoMachines in PrototypePart
     uint16_t m_protoMachineIndex;
@@ -95,6 +95,18 @@ struct BlueprintWireNode
     std::vector<BlueprintWireLink> m_links;
 };
 
+struct BlueprintWirePanel
+{
+    // Index to a BlueprintPart in BlueprintVehicle's m_blueprints
+    uint32_t m_partIndex;
+
+    // Machine to link to, index to m_protoMachines in PrototypePart
+    uint16_t m_protoMachineIndex;
+
+    // Number of ports
+    uint16_t m_portCount;
+};
+
 /**
  * Specific information on a vehicle
  * * List of part blueprints
@@ -109,12 +121,16 @@ struct BlueprintVehicle
     // Arrangement of Individual Parts
     std::vector<BlueprintPart> m_blueprints;
 
+    // Wire panels each machine has
+    // panel = m_wirePanels[wiretype id][i]
+    std::vector< std::vector<BlueprintWirePanel> > m_wirePanels;
+
     // Wires to connect
-    // m_wires[wiretype id]
+    // wire = m_wireNodes[wiretype id][i]
     std::vector< std::vector<BlueprintWireNode> > m_wireNodes;
 
     // All machines in the vehicle
-    // m_machines[machine id]
+    // machine = m_machines[machine id][i]
     std::vector< std::vector<BlueprintMachine> > m_machines;
 
 };

--- a/src/osp/Resource/machines.h
+++ b/src/osp/Resource/machines.h
@@ -58,7 +58,12 @@ template<class WIRETYPE_T>
 using portindex_t = typename WireTypes<WIRETYPE_T>::port;
 
 template<class TYPE_T>
-constexpr TYPE_T nullvalue() { return TYPE_T(std::numeric_limits<typename std::underlying_type<TYPE_T>::type>::max()); }
+constexpr TYPE_T nullvalue()
+{
+    return TYPE_T(std::numeric_limits<
+                  typename std::underlying_type_t<TYPE_T>
+                  >::max());
+}
 
 //-----------------------------------------------------------------------------
 

--- a/src/osp/Resource/machines.h
+++ b/src/osp/Resource/machines.h
@@ -2,6 +2,8 @@
 
 #include <entt/core/family.hpp>
 
+#include <limits>
+
 namespace osp
 {
 
@@ -36,16 +38,27 @@ constexpr wire_id_t wiretype_id() noexcept
     return wire_family_t::type<WIRETYPE_T>;
 }
 
-
-// Templated enum class for ports, to prevent mixups
+// Templated enum class as integer types to prevent mixups
 
 template<class WIRETYPE_T>
-struct WireTypes {
+struct WireTypes
+{
+    enum class link : uint32_t {};
+    enum class node : uint32_t {};
     enum class port : uint16_t {};
 };
 
 template<class WIRETYPE_T>
+using wire_node_t = typename WireTypes<WIRETYPE_T>::node;
+
+template<class WIRETYPE_T>
+using wire_link_t = typename WireTypes<WIRETYPE_T>::link;
+
+template<class WIRETYPE_T>
 using wire_port_t = typename WireTypes<WIRETYPE_T>::port;
+
+template<class TYPE_T>
+constexpr TYPE_T nullvalue() { return TYPE_T(std::numeric_limits<typename std::underlying_type<TYPE_T>::type>::max()); }
 
 //-----------------------------------------------------------------------------
 

--- a/src/osp/Resource/machines.h
+++ b/src/osp/Resource/machines.h
@@ -49,13 +49,13 @@ struct WireTypes
 };
 
 template<class WIRETYPE_T>
-using wire_node_t = typename WireTypes<WIRETYPE_T>::node;
+using nodeindex_t = typename WireTypes<WIRETYPE_T>::node;
 
 template<class WIRETYPE_T>
-using wire_link_t = typename WireTypes<WIRETYPE_T>::link;
+using linkindex_t = typename WireTypes<WIRETYPE_T>::link;
 
 template<class WIRETYPE_T>
-using wire_port_t = typename WireTypes<WIRETYPE_T>::port;
+using portindex_t = typename WireTypes<WIRETYPE_T>::port;
 
 template<class TYPE_T>
 constexpr TYPE_T nullvalue() { return TYPE_T(std::numeric_limits<typename std::underlying_type<TYPE_T>::type>::max()); }

--- a/src/osp/Resource/machines.h
+++ b/src/osp/Resource/machines.h
@@ -25,4 +25,38 @@ struct RegisteredMachine
     // TODO: possibly put some info on fields for the config parser
 };
 
+//-----------------------------------------------------------------------------
+
+using wire_family_t = entt::family<struct wire_type>;
+using wire_id_t = wire_family_t::family_type;
+
+template<typename WIRETYPE_T>
+constexpr wire_id_t wiretype_id() noexcept
+{
+    return wire_family_t::type<WIRETYPE_T>;
+}
+
+
+// Templated enum class for ports, to prevent mixups
+
+template<class WIRETYPE_T>
+struct WireTypes {
+    enum class port : uint16_t {};
+};
+
+template<class WIRETYPE_T>
+using wire_port_t = typename WireTypes<WIRETYPE_T>::port;
+
+//-----------------------------------------------------------------------------
+
+// Added to Package to identify wiretypes by string for configs
+struct RegisteredWiretype
+{
+    RegisteredWiretype(wire_id_t id) : m_id(id) {}
+
+    wire_id_t m_id;
+
+    // TODO: possibly put some info on fields for the config parser
+};
+
 }

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -242,7 +242,7 @@ void DebugCameraController::update_physics_post()
     if (MachineUserControl *pMUserCtrl = find_user_control(m_scene, vehicle);
         pMUserCtrl != nullptr)
     {
-        //pMUserCtrl->enable();
+        pMUserCtrl->m_enable = true;
     }
 
 
@@ -323,12 +323,10 @@ bool DebugCameraController::try_switch_vehicle()
     if (m_scene.get_registry().valid(vehicle))
     {
         // Switching away, disable the first MachineUserControl
-        ActiveEnt firstPart
-                = *(viewActive.get<ACompVehicle>(vehicle).m_parts.begin());
         if (MachineUserControl *pMUserCtrl = find_user_control(m_scene, vehicle);
             pMUserCtrl != nullptr)
         {
-            //pMUserCtrl->disable();
+            pMUserCtrl->m_enable = false;
         }
 
         prevVehiclePos = rReg.get<ACompTransform>(vehicle).m_transform.translation();

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -242,7 +242,7 @@ void DebugCameraController::update_physics_post()
     if (MachineUserControl *pMUserCtrl = find_user_control(m_scene, vehicle);
         pMUserCtrl != nullptr)
     {
-        pMUserCtrl->enable();
+        //pMUserCtrl->enable();
     }
 
 
@@ -328,7 +328,7 @@ bool DebugCameraController::try_switch_vehicle()
         if (MachineUserControl *pMUserCtrl = find_user_control(m_scene, vehicle);
             pMUserCtrl != nullptr)
         {
-            pMUserCtrl->disable();
+            //pMUserCtrl->disable();
         }
 
         prevVehiclePos = rReg.get<ACompTransform>(vehicle).m_transform.translation();

--- a/src/test_application/VehicleBuilder.cpp
+++ b/src/test_application/VehicleBuilder.cpp
@@ -121,7 +121,7 @@ std::pair<mach_t, osp::BlueprintMachine*> VehicleBuilder::machine_find(
 {
     if (id >= m_vehicle.m_machines.size())
     {
-        return {nullvalue<mach_t>(), nullptr}; // no machines of type
+        return {osp::nullvalue<mach_t>(), nullptr}; // no machines of type
     }
 
     for (size_t i = 0; i < m_vehicle.m_machines[id].size(); i ++)
@@ -133,7 +133,7 @@ std::pair<mach_t, osp::BlueprintMachine*> VehicleBuilder::machine_find(
             return {mach_t(i), &machineBp};
         }
     }
-    return {nullvalue<mach_t>(), nullptr};
+    return {osp::nullvalue<mach_t>(), nullptr};
 }
 
 
@@ -163,7 +163,7 @@ link_t<void> VehicleBuilder::wire_connect(
     if (m_vehicle.m_wireNodes.size() <= id)
     {
         // No node of type is even registered
-        return nullvalue< link_t<void> >();
+        return osp::nullvalue< link_t<void> >();
     }
 
     // Get the BlueprintWireNode
@@ -186,11 +186,11 @@ node_t<void> VehicleBuilder::wire_connect_signal(osp::wire_id_t id,
     // Create a node
     node_t<void> node = wire_node_add(id, {});
 
-    // Link the Output first
-    wire_connect(id, node, {{"output", 1}}, partOut, machOut, portOut);
+    // Link the Output (writes into node) first
+    wire_connect(id, node, {{ }}, partOut, machOut, portOut);
 
-    // Link the Input
-    wire_connect(id, node, {{"input", 1}}, partIn, machIn, portIn);
+    // Link the Input (reads node)
+    wire_connect(id, node, {{ }}, partIn, machIn, portIn);
 
     return node;
 }

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -143,6 +143,11 @@ public:
     osp::BlueprintVehicle export_copy() { return m_vehicle; };
 
 private:
+
+    // panelIndex = m_panelMap[{id, part, machine}]
+    // panel = m_vehicle.m_wirePanels[panelIndex]
+    std::map<std::tuple<osp::wire_id_t, part_t, mach_t>, uint32_t> m_panelIndexMap;
+
     osp::BlueprintVehicle m_vehicle;
 
 };

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -36,14 +36,9 @@ namespace testapp
 enum class part_t : uint32_t {};
 enum class mach_t : uint32_t {};
 
-template<class WIRETYPE_T>
-using port_t = osp::portindex_t<WIRETYPE_T>;
-
-template<class WIRETYPE_T>
-using node_t = osp::nodeindex_t<WIRETYPE_T>;
-
-template<class WIRETYPE_T>
-using link_t = osp::linkindex_t<WIRETYPE_T>;
+using osp::portindex_t;
+using osp::nodeindex_t;
+using osp::linkindex_t;
 
 /**
  * Used to easily create Vehicle blueprints
@@ -107,36 +102,36 @@ public:
     // Wiring functions
 
 
-    node_t<void> wire_node_add(osp::wire_id_t id, osp::NodeMap_t config);
+    nodeindex_t<void> wire_node_add(osp::wire_id_t id, osp::NodeMap_t config);
 
     template<typename WIRETYPE_T>
-    node_t<WIRETYPE_T> wire_node_add(osp::ConfigNode_t config)
+    nodeindex_t<WIRETYPE_T> wire_node_add(osp::ConfigNode_t config)
     {
         return wire_node_add(osp::wiretype_id<WIRETYPE_T>(), config);
     }
 
-    link_t<void> wire_connect(
-            osp::wire_id_t id, node_t<void> node, osp::NodeMap_t config,
-            part_t part, mach_t mach, port_t<void> port);
+    linkindex_t<void> wire_connect(
+            osp::wire_id_t id, nodeindex_t<void> node, osp::NodeMap_t config,
+            part_t part, mach_t mach, portindex_t<void> port);
 
     template<typename WIRETYPE_T>
-    link_t<WIRETYPE_T> wire_connect(
-            node_t<WIRETYPE_T> node, osp::NodeMap_t config,
-            part_t part, mach_t mach, port_t<WIRETYPE_T> port)
+    linkindex_t<WIRETYPE_T> wire_connect(
+            nodeindex_t<WIRETYPE_T> node, osp::NodeMap_t config,
+            part_t part, mach_t mach, portindex_t<WIRETYPE_T> port)
     {
-        return link_t<WIRETYPE_T>(wire_connect(osp::wiretype_id<WIRETYPE_T>(), config, part, mach, port));
+        return linkindex_t<WIRETYPE_T>(wire_connect(osp::wiretype_id<WIRETYPE_T>(), config, part, mach, port));
     }
 
-    node_t<void> wire_connect_signal(osp::wire_id_t id,
-            part_t partOut, mach_t machOut, port_t<void> portOut,
-            part_t partIn, mach_t machIn, port_t<void> portIn);
+    nodeindex_t<void> wire_connect_signal(osp::wire_id_t id,
+            part_t partOut, mach_t machOut, portindex_t<void> portOut,
+            part_t partIn, mach_t machIn, portindex_t<void> portIn);
 
     template<typename WIRETYPE_T>
-    node_t<WIRETYPE_T> wire_connect_signal(
-            part_t partOut, mach_t machOut, port_t<WIRETYPE_T> portOut,
-            part_t partIn, mach_t machIn, port_t<WIRETYPE_T> portIn)
+    nodeindex_t<WIRETYPE_T> wire_connect_signal(
+            part_t partOut, mach_t machOut, portindex_t<WIRETYPE_T> portOut,
+            part_t partIn, mach_t machIn, portindex_t<WIRETYPE_T> portIn)
     {
-        return node_t<WIRETYPE_T>(wire_connect_signal(osp::wiretype_id<WIRETYPE_T>(), partOut, machOut, port_t<void>(portOut), partIn, machIn, port_t<void>(portIn)));
+        return nodeindex_t<WIRETYPE_T>(wire_connect_signal(osp::wiretype_id<WIRETYPE_T>(), partOut, machOut, portindex_t<void>(portOut), partIn, machIn, portindex_t<void>(portIn)));
     }
 
     osp::BlueprintVehicle&& export_move() { return std::move(m_vehicle); };
@@ -144,9 +139,16 @@ public:
 
 private:
 
+    // Map used to obtain a Machine's Panel
     // panelIndex = m_panelMap[{id, part, machine}]
     // panel = m_vehicle.m_wirePanels[panelIndex]
-    std::map<std::tuple<osp::wire_id_t, part_t, mach_t>, uint32_t> m_panelIndexMap;
+    std::map<std::tuple<osp::wire_id_t, part_t, mach_t>,
+             uint32_t> m_panelIndexMap;
+
+    // Map used to obtain Nodes from part
+    // nodeIndex = m_nodeIndexMap[{id, part, machine, port}]
+    std::map<std::tuple<osp::wire_id_t, part_t, mach_t, portindex_t<void>>,
+             nodeindex_t<void>> m_nodeIndexMap;
 
     osp::BlueprintVehicle m_vehicle;
 

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -26,11 +26,34 @@
 
 #include <osp/Resource/blueprints.h>
 
+#include <limits>
+
 namespace testapp
 {
 
-using partindex_t = uint32_t;
-using machindex_t = uint32_t;
+// Explicit integer types to prevent accidentally mixing them
+
+enum class part_t : uint32_t {};
+enum class mach_t : uint32_t {};
+
+template<class WIRETYPE_T>
+using port_t = osp::wire_port_t<WIRETYPE_T>;
+
+template<class WIRETYPE_T>
+struct WireTypes {
+    enum class link : uint32_t {};
+    enum class node : uint32_t {};
+};
+
+template<class WIRETYPE_T>
+using node_t = typename WireTypes<WIRETYPE_T>::node;
+
+template<class WIRETYPE_T>
+using link_t = typename WireTypes<WIRETYPE_T>::link;
+
+template<class TYPE_T>
+constexpr TYPE_T nullvalue() { return std::numeric_limits<TYPE_T>::max(); }
+
 
 /**
  * Used to easily create Vehicle blueprints
@@ -38,6 +61,21 @@ using machindex_t = uint32_t;
 class VehicleBuilder
 {
 public:
+
+    // Part functions
+
+    /**
+     * Utility: computes the displacement between two parts, relative to the
+     * specified sub-object (e.g. an attachment node).
+     *
+     * @param attachTo [in] The parent part
+     * @param attachToName [in] The name of the parent's object/attach point
+     * @param toAttach [in] The child part
+     * @param toAttachName [in] The name of the child's object/attach point
+     */
+    static osp::Vector3 part_offset(
+        osp::PrototypePart const& attachTo, std::string_view attachToName,
+        osp::PrototypePart const& toAttach, std::string_view toAttachName) noexcept;
 
     /**
      * Emplaces a BlueprintPart. This function searches the prototype vector
@@ -48,42 +86,67 @@ public:
      * @param scale
      * @return Resulting blueprint part
      */
-    partindex_t add_part(osp::DependRes<osp::PrototypePart>& part,
+    part_t part_add(osp::DependRes<osp::PrototypePart>& part,
                   const osp::Vector3& translation,
                   const osp::Quaternion& rotation,
                   const osp::Vector3& scale);
 
     /**
-     * Emplace a BlueprintWire
-     * @param fromPart
-     * @param fromMachine
-     * @param fromPort
-     * @param toPart
-     * @param toMachine
-     * @param toPort
+     * @return Current number of parts
      */
-    void add_wire(partindex_t fromPart, machindex_t fromMachine, osp::WireOutPort fromPort,
-                  partindex_t toPart, machindex_t toMachine, osp::WireInPort toPort);
+    uint32_t part_count() const noexcept { return m_vehicle.m_blueprints.size(); }
 
-    partindex_t part_count() const noexcept { return m_vehicle.m_blueprints.size(); }
+    // Machine Functions
+
+
+    std::pair<mach_t, osp::BlueprintMachine*> machine_find(
+            osp::machine_id_t id, part_t part) noexcept;
 
     template<typename MACH_T>
-    osp::BlueprintMachine* find_machine_by_type(partindex_t part)
+    osp::BlueprintMachine* machine_find_ptr(part_t part) noexcept
     {
-        osp::machine_id_t const id = osp::mach_id<MACH_T>();
-        if (id >= m_vehicle.m_machines.size())
-        {
-            return nullptr; // no machines of type
-        }
+        return machine_find(osp::mach_id<MACH_T>(), part).second;
+    }
 
-        for (osp::BlueprintMachine& machineBp : m_vehicle.m_machines[id])
-        {
-            if (machineBp.m_blueprintIndex == part)
-            {
-                return &machineBp;
-            }
-        }
-        return nullptr;
+    template<typename MACH_T>
+    mach_t machine_find(part_t part) noexcept
+    {
+        return machine_find(osp::mach_id<MACH_T>(), part).first;
+    }
+
+    // Wiring functions
+
+
+    node_t<void> wire_node_add(osp::wire_id_t id, osp::NodeMap_t config);
+
+    template<typename WIRETYPE_T>
+    node_t<WIRETYPE_T> wire_node_add(osp::ConfigNode_t config)
+    {
+        return wire_node_add(osp::wiretype_id<WIRETYPE_T>(), config);
+    }
+
+    link_t<void> wire_connect(
+            osp::wire_id_t id, node_t<void> node, osp::NodeMap_t config,
+            part_t part, mach_t mach, port_t<void> port);
+
+    template<typename WIRETYPE_T>
+    link_t<WIRETYPE_T> wire_connect(
+            node_t<WIRETYPE_T> node, osp::NodeMap_t config,
+            part_t part, mach_t mach, port_t<WIRETYPE_T> port)
+    {
+        return link_t<WIRETYPE_T>(wire_connect(osp::wiretype_id<WIRETYPE_T>(), config, part, mach, port));
+    }
+
+    node_t<void> wire_connect_signal(osp::wire_id_t id,
+            part_t partOut, mach_t machOut, port_t<void> portOut,
+            part_t partIn, mach_t machIn, port_t<void> portIn);
+
+    template<typename WIRETYPE_T>
+    node_t<WIRETYPE_T> wire_connect_signal(
+            part_t partOut, mach_t machOut, port_t<WIRETYPE_T> portOut,
+            part_t partIn, mach_t machIn, port_t<WIRETYPE_T> portIn)
+    {
+        return node_t<WIRETYPE_T>(wire_connect_signal(osp::wiretype_id<WIRETYPE_T>(), partOut, machOut, port_t<void>(portOut), partIn, machIn, port_t<void>(portIn)));
     }
 
     osp::BlueprintVehicle&& export_move() { return std::move(m_vehicle); };

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -71,7 +71,7 @@ public:
      * @param scale
      * @return Resulting blueprint part
      */
-    part_t part_add(osp::DependRes<osp::PrototypePart>& part,
+    part_t part_add(osp::DependRes<osp::PrototypePart>& protoPart,
                   const osp::Vector3& translation,
                   const osp::Quaternion& rotation,
                   const osp::Vector3& scale);

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -37,13 +37,13 @@ enum class part_t : uint32_t {};
 enum class mach_t : uint32_t {};
 
 template<class WIRETYPE_T>
-using port_t = osp::wire_port_t<WIRETYPE_T>;
+using port_t = osp::portindex_t<WIRETYPE_T>;
 
 template<class WIRETYPE_T>
-using node_t = osp::wire_node_t<WIRETYPE_T>;
+using node_t = osp::nodeindex_t<WIRETYPE_T>;
 
 template<class WIRETYPE_T>
-using link_t = osp::wire_link_t<WIRETYPE_T>;
+using link_t = osp::linkindex_t<WIRETYPE_T>;
 
 /**
  * Used to easily create Vehicle blueprints

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -40,20 +40,10 @@ template<class WIRETYPE_T>
 using port_t = osp::wire_port_t<WIRETYPE_T>;
 
 template<class WIRETYPE_T>
-struct WireTypes {
-    enum class link : uint32_t {};
-    enum class node : uint32_t {};
-};
+using node_t = osp::wire_node_t<WIRETYPE_T>;
 
 template<class WIRETYPE_T>
-using node_t = typename WireTypes<WIRETYPE_T>::node;
-
-template<class WIRETYPE_T>
-using link_t = typename WireTypes<WIRETYPE_T>::link;
-
-template<class TYPE_T>
-constexpr TYPE_T nullvalue() { return std::numeric_limits<TYPE_T>::max(); }
-
+using link_t = osp::wire_link_t<WIRETYPE_T>;
 
 /**
  * Used to easily create Vehicle blueprints

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -132,11 +132,15 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     // Setup wiring
     rScene.debug_update_add(rScene.get_update_order(), "wire_percent_construct", "vehicle_activate", "vehicle_modification",
                             &osp::active::SysSignal<wiretype::Percent>::signal_update_construct);
+    rScene.debug_update_add(rScene.get_update_order(), "wire_attctrl_construct", "vehicle_activate", "vehicle_modification",
+                            &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_construct);
     osp::active::SysWire::add_functions(rScene);
     osp::active::SysWire::setup_default(
             rScene, 5,
-            {&adera::active::machines::SysMachineRocket::update_calculate},
-            {&osp::active::SysSignal<wiretype::Percent>::signal_update_propagate});
+            {&adera::active::machines::SysMachineRocket::update_calculate,
+             &adera::active::machines::SysMachineRCSController::update_calculate},
+            {&osp::active::SysSignal<wiretype::Percent>::signal_update_propagate,
+             &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_propagate});
     rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
     rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -139,8 +139,8 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
             rScene, 5,
             {&adera::active::machines::SysMachineRocket::update_calculate,
              &adera::active::machines::SysMachineRCSController::update_calculate},
-            {&osp::active::SysSignal<wiretype::Percent>::signal_update_propagate,
-             &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_propagate});
+            {&osp::active::SysSignal<wiretype::Percent>::signal_update_nodes,
+             &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_nodes});
     rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
     rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -30,6 +30,7 @@
 #include <osp/Active/ActiveScene.h>
 #include <osp/Active/SysRender.h>
 #include <osp/Active/SysVehicle.h>
+#include <osp/Active/SysWire.h>
 #include <osp/Active/SysForceFields.h>
 #include <osp/Active/SysAreaAssociate.h>
 
@@ -129,7 +130,10 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     adera::active::machines::SysMachineUserControl::add_functions(rScene);
 
     // Setup wiring
-    auto rWire = rScene.reg_emplace<ACompWire>(rScene.hier_get_root());
+    rScene.debug_update_add(rScene.get_update_order(), "wire_percent_construct", "vehicle_activate", "vehicle_modification",
+                            &osp::active::SysWire::update_construct_signal<wiretype::Percent>);
+    osp::active::SysWire::add_functions(rScene);
+    osp::active::SysWire::setup_default(rScene, {&adera::active::machines::SysMachineRocket::update_calculate}, {});
     rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
     rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -41,6 +41,8 @@
 #include <adera/Machines/Rocket.h>
 #include <adera/Machines/UserControl.h>
 
+#include <adera/wiretypes.h>
+
 #include <adera/SysExhaustPlume.h>
 #include <adera/ShipResources.h>
 
@@ -82,11 +84,6 @@ using osp::active::ACompPerspective3DView;
 using osp::active::ACompRenderer;
 using osp::active::ACompWire;
 using osp::active::ACompWireNodes;
-
-namespace wiretype
-{
-using namespace osp::active::wiretype;
-}
 
 using adera::active::machines::SysMachineUserControl;
 using adera::active::machines::SysMachineRocket;
@@ -130,19 +127,19 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     SysMachineUserControl::add_functions(rScene);
 
     // Setup wiring
-    rScene.debug_update_add(rScene.get_update_order(), "wire_percent_construct", "vehicle_activate", "vehicle_modification",
-                            &osp::active::SysSignal<wiretype::Percent>::signal_update_construct);
+    rScene.debug_update_add(rScene.get_update_order(),"wire_percent_construct", "vehicle_activate", "vehicle_modification",
+                            &osp::active::SysSignal<adera::wire::Percent>::signal_update_construct);
     rScene.debug_update_add(rScene.get_update_order(), "wire_attctrl_construct", "vehicle_activate", "vehicle_modification",
-                            &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_construct);
+                            &osp::active::SysSignal<adera::wire::AttitudeControl>::signal_update_construct);
     osp::active::SysWire::add_functions(rScene);
     osp::active::SysWire::setup_default(
             rScene, 5,
             {&adera::active::machines::SysMachineRocket::update_calculate,
              &adera::active::machines::SysMachineRCSController::update_calculate},
-            {&osp::active::SysSignal<wiretype::Percent>::signal_update_nodes,
-             &osp::active::SysSignal<wiretype::AttitudeControl>::signal_update_nodes});
-    rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
-    rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
+            {&osp::active::SysSignal<adera::wire::Percent>::signal_update_nodes,
+             &osp::active::SysSignal<adera::wire::AttitudeControl>::signal_update_nodes});
+    rScene.reg_emplace< ACompWireNodes<adera::wire::AttitudeControl> >(rScene.hier_get_root());
+    rScene.reg_emplace< ACompWireNodes<adera::wire::Percent> >(rScene.hier_get_root());
 
 
     // create a Satellite with an ActiveArea

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -79,6 +79,13 @@ using osp::active::ACompRenderTarget;
 using osp::active::ACompRenderingAgent;
 using osp::active::ACompPerspective3DView;
 using osp::active::ACompRenderer;
+using osp::active::ACompWire;
+using osp::active::ACompWireNodes;
+
+namespace wiretype
+{
+using namespace osp::active::wiretype;
+}
 
 using adera::active::machines::SysMachineUserControl;
 using adera::active::machines::SysMachineRocket;
@@ -120,6 +127,12 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     adera::active::machines::SysMachineRCSController::add_functions(rScene);
     adera::active::machines::SysMachineRocket::add_functions(rScene);
     adera::active::machines::SysMachineUserControl::add_functions(rScene);
+
+    // Setup wiring
+    auto rWire = rScene.reg_emplace<ACompWire>(rScene.hier_get_root());
+    rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
+    rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
+
 
     // create a Satellite with an ActiveArea
     Satellite areaSat = rUni.sat_create();

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -131,12 +131,12 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     // Setup wiring
     rScene.debug_update_add(rScene.get_update_order(), "wire_percent_construct", "vehicle_activate", "vehicle_modification",
-                            &osp::active::SysWire::signal_update_construct<wiretype::Percent>);
+                            &osp::active::SysSignal<wiretype::Percent>::signal_update_construct);
     osp::active::SysWire::add_functions(rScene);
     osp::active::SysWire::setup_default(
             rScene, 5,
             {&adera::active::machines::SysMachineRocket::update_calculate},
-            {&osp::active::SysWire::signal_update_propagate<wiretype::Percent>});
+            {&osp::active::SysSignal<wiretype::Percent>::signal_update_propagate});
     rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
     rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -124,16 +124,19 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     planeta::active::SysPlanetA::add_functions(rScene);
   
-    adera::active::machines::SysMachineContainer::add_functions(rScene);
-    adera::active::machines::SysMachineRCSController::add_functions(rScene);
-    adera::active::machines::SysMachineRocket::add_functions(rScene);
-    adera::active::machines::SysMachineUserControl::add_functions(rScene);
+    SysMachineContainer::add_functions(rScene);
+    SysMachineRCSController::add_functions(rScene);
+    SysMachineRocket::add_functions(rScene);
+    SysMachineUserControl::add_functions(rScene);
 
     // Setup wiring
     rScene.debug_update_add(rScene.get_update_order(), "wire_percent_construct", "vehicle_activate", "vehicle_modification",
-                            &osp::active::SysWire::update_construct_signal<wiretype::Percent>);
+                            &osp::active::SysWire::signal_update_construct<wiretype::Percent>);
     osp::active::SysWire::add_functions(rScene);
-    osp::active::SysWire::setup_default(rScene, {&adera::active::machines::SysMachineRocket::update_calculate}, {});
+    osp::active::SysWire::setup_default(
+            rScene, 5,
+            {&adera::active::machines::SysMachineRocket::update_calculate},
+            {&osp::active::SysWire::signal_update_propagate<wiretype::Percent>});
     rScene.reg_emplace< ACompWireNodes<wiretype::AttitudeControl> >(rScene.hier_get_root());
     rScene.reg_emplace< ACompWireNodes<wiretype::Percent> >(rScene.hier_get_root());
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -263,11 +263,20 @@ bool destroy_universe()
 
 // TODO: move this somewhere else
 template<typename MACH_T>
-constexpr void register_sys_machine(osp::Package &rPkg)
+constexpr void register_machine(osp::Package &rPkg)
 {
     rPkg.add<osp::RegisteredMachine>(std::string(MACH_T::smc_mach_name),
                                      osp::mach_id<MACH_T>());
 }
+
+// TODO: move this somewhere else
+template<typename WIRETYPE_T>
+constexpr void register_wiretype(osp::Package &rPkg)
+{
+    rPkg.add<osp::RegisteredWiretype>(std::string(WIRETYPE_T::smc_wire_name),
+                                      osp::wiretype_id<WIRETYPE_T>());
+}
+
 
 void load_a_bunch_of_stuff()
 {
@@ -280,10 +289,14 @@ void load_a_bunch_of_stuff()
     using adera::active::machines::MachineUserControl;
 
     // Register machines
-    register_sys_machine<MachineContainer>(lazyDebugPack);
-    register_sys_machine<MachineRCSController>(lazyDebugPack);
-    register_sys_machine<MachineRocket>(lazyDebugPack);
-    register_sys_machine<MachineUserControl>(lazyDebugPack);
+    register_machine<MachineContainer>(lazyDebugPack);
+    register_machine<MachineRCSController>(lazyDebugPack);
+    register_machine<MachineRocket>(lazyDebugPack);
+    register_machine<MachineUserControl>(lazyDebugPack);
+
+    // Register wire types
+    register_wiretype<osp::active::wiretype::AttitudeControl>(lazyDebugPack);
+    register_wiretype<osp::active::wiretype::Percent>(lazyDebugPack);
 
     // Load sturdy glTF files
     const std::string_view datapath = {"OSPData/adera/"};

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -509,7 +509,7 @@ void debug_print_hier()
             // print arrows to indicate level
             std::cout << "  ->";
         }
-        std::cout << "[" << int(currentEnt) << "]: " << hier.m_name << "\n";
+        std::cout << "[" << scene.get_registry().entity(currentEnt) << "]: " << hier.m_name << "\n";
 
         if (hier.m_childCount != 0)
         {

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -295,8 +295,8 @@ void load_a_bunch_of_stuff()
     register_machine<MachineUserControl>(lazyDebugPack);
 
     // Register wire types
-    register_wiretype<osp::active::wiretype::AttitudeControl>(lazyDebugPack);
-    register_wiretype<osp::active::wiretype::Percent>(lazyDebugPack);
+    register_wiretype<adera::wire::AttitudeControl>(lazyDebugPack);
+    register_wiretype<adera::wire::Percent>(lazyDebugPack);
 
     // Load sturdy glTF files
     const std::string_view datapath = {"OSPData/adera/"};

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -278,14 +278,23 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     //blueprint.add_wire(Parts::FUSELAGE, 0, 0,
     //    Parts::ENGINE, 0, 3);
 
-    for (auto port : rcsPorts)
+    mach_t const partCapsuleUsrCtrl = blueprint.machine_find<MachineUserControl>(partCapsule);
+
+    for (auto partRCS : rcsPorts)
     {
+        mach_t const partRCSRocket = blueprint.machine_find<MachineRocket>(partRCS);
+        mach_t const partRCSCtrl = blueprint.machine_find<MachineRCSController>(partRCS);
+
         // Attitude control -> RCS Control
-        //blueprint.add_wire(Parts::CAPSULE, 0, 0,
-        //    port, 0, 0);
+        blueprint.wire_connect_signal<AttitudeControl>(
+                partCapsule, partCapsuleUsrCtrl, MachineUserControl::smc_woAttitude,
+                partRCS, partRCSCtrl, MachineRCSController::smc_wiCommandOrient);
+
         // RCS Control -> RCS Rocket
-        //blueprint.add_wire(port, 0, 0,
-        //    port, 1, 2);
+        blueprint.wire_connect_signal<Percent>(
+                partRCS, partRCSCtrl, MachineRCSController::m_woThrottle,
+                partRCS, partRCSRocket, MachineRocket::smc_wiThrottle);
+
         // Fuselage tank -> RCS Rocket
         //blueprint.add_wire(Parts::FUSELAGE, 0, 0,
         //    port, 1, 3);

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -55,8 +55,8 @@ using osp::BlueprintVehicle;
 using osp::BlueprintMachine;
 using osp::PrototypePart;
 
-using osp::active::wiretype::AttitudeControl;
-using osp::active::wiretype::Percent;
+using adera::wire::AttitudeControl;
+using adera::wire::Percent;
 
 using adera::active::machines::MachineContainer;
 using adera::active::machines::MachineRCSController;

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -28,7 +28,11 @@
 
 #include <adera/ShipResources.h>
 #include <adera/Machines/Container.h>
+#include <adera/Machines/RCSController.h>
+#include <adera/Machines/Rocket.h>
+#include <adera/Machines/UserControl.h>
 
+#include <osp/Active/SysWire.h>
 #include <osp/Satellites/SatVehicle.h>
 
 using namespace testapp;
@@ -48,21 +52,17 @@ using osp::universe::UCompTransformTraj;
 using osp::universe::UCompVehicle;
 
 using osp::BlueprintVehicle;
+using osp::BlueprintMachine;
 using osp::PrototypePart;
 
+using osp::active::wiretype::AttitudeControl;
+using osp::active::wiretype::Percent;
 
-/**
- * Utility: computes the displacement between two parts, relative to the
- * specified sub-object (e.g. an attachment node).
- *
- * @param attachTo [in] The parent part
- * @param attachToName [in] The name of the parent's object/attach point
- * @param toAttach [in] The child part
- * @param toAttachName [in] The name of the child's object/attach point
- */
-Vector3 part_offset(
-    PrototypePart const& attachTo, std::string_view attachToName,
-    PrototypePart const& toAttach, std::string_view toAttachName);
+using adera::active::machines::MachineContainer;
+using adera::active::machines::MachineRCSController;
+using adera::active::machines::MachineRocket;
+using adera::active::machines::MachineUserControl;
+
 
 /**
  * Adds multiple specified parts (RCS thrusters) in the same position, but
@@ -87,19 +87,19 @@ osp::universe::Satellite testapp::debug_add_deterministic_vehicle(
 
     // Part to add
     DependRes<PrototypePart> rocket = pkg.get<PrototypePart>("part_stomper");
-    blueprint.add_part(rocket, Vector3(0.0f), Quaternion(), Vector3(1.0f));
+    blueprint.part_add(rocket, Vector3(0.0f), Quaternion(), Vector3(1.0f));
 
     // Wire throttle control
     // from (output): a MachineUserControl m_woThrottle
     // to    (input): a MachineRocket m_wiThrottle
-    blueprint.add_wire(0, 0, 1,
-        0, 1, 2);
+    //blueprint.add_wire(0, 0, 1,
+    //    0, 1, 2);
 
     // Wire attitude control to gimbal
     // from (output): a MachineUserControl m_woAttitude
     // to    (input): a MachineRocket m_wiGimbal
-    blueprint.add_wire(0, 0, 0,
-        0, 1, 0);
+    //blueprint.add_wire(0, 0, 0,
+    //    0, 1, 0);
 
     // Save blueprint
     DependRes<BlueprintVehicle> depend =
@@ -140,7 +140,7 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
         randomvec /= 64.0f;
 
         // Add a new [victim] part
-        blueprint.add_part(victim, randomvec,
+        blueprint.part_add(victim, randomvec,
                            Quaternion(), Vector3(1, 1, 1));
         //std::cout << "random: " <<  << "\n";
     }
@@ -148,14 +148,14 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
     // Wire throttle control
     // from (output): a MachineUserControl m_woThrottle
     // to    (input): a MachineRocket m_wiThrottle
-    blueprint.add_wire(0, 0, 1,
-                       0, 1, 2);
+    //blueprint.add_wire(0, 0, 1,
+    //                   0, 1, 2);
 
     // Wire attitude control to gimbal
     // from (output): a MachineUserControl m_woAttitude
     // to    (input): a MachineRocket m_wiGimbal
-    blueprint.add_wire(0, 0, 0,
-                       0, 1, 0);
+    //blueprint.add_wire(0, 0, 0,
+    //                   0, 1, 0);
 
     // put blueprint in package
     DependRes<BlueprintVehicle> depend =
@@ -177,34 +177,6 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
 
 }
 
-Vector3 part_offset(PrototypePart const& attachTo,
-    std::string_view attachToName, PrototypePart const& toAttach,
-    std::string_view toAttachName)
-{
-    Vector3 oset1{0.0f};
-    Vector3 oset2{0.0f};
-
-    for (osp::PCompName const& name : attachTo.m_partName)
-    {
-        if (name.m_name == attachToName)
-        {
-            oset1 = attachTo.m_partTransform[name.m_entity].m_translation;
-            break;
-        }
-    }
-
-    for (osp::PCompName const& name : toAttach.m_partName)
-    {
-        if (name.m_name == toAttachName)
-        {
-            oset2 = toAttach.m_partTransform[name.m_entity].m_translation;
-            break;
-        }
-    }
-
-    return oset1 - oset2;
-}
-
 void blueprint_add_rcs_block(
         VehicleBuilder &rBlueprint, DependRes<PrototypePart> rRcs,
         std::vector<int> &rRcsPorts, Vector3 pos, Quaternion rot)
@@ -215,9 +187,9 @@ void blueprint_add_rcs_block(
     Vector3 constexpr zAxis{0, 0, 1};
     int hackypartnum = rBlueprint.part_count();
 
-    rBlueprint.add_part(rRcs, pos, Quaternion::rotation(90.0_degf, zAxis) * rot, scl);
+    rBlueprint.part_add(rRcs, pos, Quaternion::rotation(90.0_degf, zAxis) * rot, scl);
     //rBlueprint.add_part(rRcs, pos, rot, scl);
-    rBlueprint.add_part(rRcs, pos, Quaternion::rotation(-90.0_degf, zAxis) * rot, scl);
+    rBlueprint.part_add(rRcs, pos, Quaternion::rotation(-90.0_degf, zAxis) * rot, scl);
 
     for (int i = 0; i < 2; i ++)
     {
@@ -232,9 +204,6 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     using namespace Magnum::Math::Literals;
     using Magnum::Rad;
 
-    using osp::BlueprintMachine;
-    using adera::active::machines::MachineContainer;
-
     // Start making the blueprint
     VehicleBuilder blueprint;
 
@@ -244,9 +213,9 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     DependRes<PrototypePart> engine = pkg.get<PrototypePart>("part_phEngine");
     DependRes<PrototypePart> rcs = pkg.get<PrototypePart>("part_phLinRCS");
 
-    Vector3 cfOset = part_offset(*capsule, "attach_bottom_capsule",
+    Vector3 cfOset = VehicleBuilder::part_offset(*capsule, "attach_bottom_capsule",
         *fuselage, "attach_top_fuselage");
-    Vector3 feOset = part_offset(*fuselage, "attach_bottom_fuselage",
+    Vector3 feOset = VehicleBuilder::part_offset(*fuselage, "attach_bottom_fuselage",
         *engine, "attach_top_eng");
 
 
@@ -258,15 +227,14 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     Quaternion rotZ_180 = Quaternion::rotation(2 * qtrTurn, Vector3{0, 0, 1});
     Quaternion rotZ_270 = Quaternion::rotation(3 * qtrTurn, Vector3{0, 0, 1});
 
-    blueprint.add_part(capsule, Vector3{0}, idRot, scl);
+    part_t partCapsule = blueprint.part_add(capsule, Vector3{0}, idRot, scl);
 
-
-    partindex_t fuselageBP = blueprint.add_part(fuselage, cfOset, idRot, scl);
-    BlueprintMachine* fusalageMach= blueprint.find_machine_by_type<MachineContainer>(fuselageBP);
+    part_t partFusalage = blueprint.part_add(fuselage, cfOset, idRot, scl);
+    BlueprintMachine* fusalageMach= blueprint.machine_find_ptr<MachineContainer>(partFusalage);
     fusalageMach->m_config.emplace("resourcename", "lzdb:fuel");
     fusalageMach->m_config.emplace("fuellevel", 0.5);
 
-    blueprint.add_part(engine, cfOset + feOset, idRot, scl);
+    part_t partEngine = blueprint.part_add(engine, cfOset + feOset, idRot, scl);
 
     // Add a shit ton of RCS rings
 
@@ -292,12 +260,6 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
         }
     }
 
-    enum Parts
-    {
-        CAPSULE = 0,
-        FUSELAGE = 1,
-        ENGINE = 2
-    };
 
     std::cout << "Part vehicle has " << blueprint.part_count()
               << " Parts!\n";
@@ -305,34 +267,34 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     // Wire throttle control
     // from (output): a MachineUserControl m_woThrottle
     // to    (input): a MachineRocket m_wiThrottle
-    blueprint.add_wire(
-        Parts::CAPSULE, 0, 1,
-        Parts::ENGINE, 0, 2);
+    blueprint.wire_connect_signal<Percent>(
+        partCapsule, blueprint.machine_find<MachineUserControl>(partCapsule), MachineUserControl::smc_woThrottle,
+        partEngine, blueprint.machine_find<MachineRocket>(partEngine), MachineRocket::smc_wiThrottle);
 
     // Wire attitude contrl to gimbal
     // from (output): a MachineUserControl m_woAttitude
     // to    (input): a MachineRocket m_wiGimbal
-    blueprint.add_wire(
-        Parts::CAPSULE, 0, 0,
-        Parts::ENGINE, 0, 0);
+    //blueprint.add_wire(
+    //    Parts::CAPSULE, 0, 0,
+    //    Parts::ENGINE, 0, 0);
 
     // Pipe fuel tank to rocket engine
     // from (output): fuselage MachineContainer m_outputs;
     // to    (input): entine MachineRocket m_resourcesLines[0]
-    blueprint.add_wire(Parts::FUSELAGE, 0, 0,
-        Parts::ENGINE, 0, 3);
+    //blueprint.add_wire(Parts::FUSELAGE, 0, 0,
+    //    Parts::ENGINE, 0, 3);
 
     for (auto port : rcsPorts)
     {
         // Attitude control -> RCS Control
-        blueprint.add_wire(Parts::CAPSULE, 0, 0,
-            port, 0, 0);
+        //blueprint.add_wire(Parts::CAPSULE, 0, 0,
+        //    port, 0, 0);
         // RCS Control -> RCS Rocket
-        blueprint.add_wire(port, 0, 0,
-            port, 1, 2);
+        //blueprint.add_wire(port, 0, 0,
+        //    port, 1, 2);
         // Fuselage tank -> RCS Rocket
-        blueprint.add_wire(Parts::FUSELAGE, 0, 0,
-            port, 1, 3);
+        //blueprint.add_wire(Parts::FUSELAGE, 0, 0,
+        //    port, 1, 3);
     }
 
     // Put blueprint in package

--- a/src/test_application/universes/vehicles.cpp
+++ b/src/test_application/universes/vehicles.cpp
@@ -76,7 +76,7 @@ using adera::active::machines::MachineUserControl;
  */
 void blueprint_add_rcs_block(
         BlueprintVehicle &rBlueprint, DependRes<PrototypePart> rRcs,
-        std::vector<int> &rRcsPorts, Vector3 pos, Quaternion rot);
+        std::vector<part_t> &rRcsPorts, Vector3 pos, Quaternion rot);
 
 
 osp::universe::Satellite testapp::debug_add_deterministic_vehicle(
@@ -179,22 +179,16 @@ osp::universe::Satellite testapp::debug_add_random_vehicle(
 
 void blueprint_add_rcs_block(
         VehicleBuilder &rBlueprint, DependRes<PrototypePart> rRcs,
-        std::vector<int> &rRcsPorts, Vector3 pos, Quaternion rot)
+        std::vector<part_t> &rRcsPorts, Vector3 pos, Quaternion rot)
 {
     using namespace Magnum::Math::Literals;
 
     Vector3 constexpr scl{1};
     Vector3 constexpr zAxis{0, 0, 1};
-    int hackypartnum = rBlueprint.part_count();
 
-    rBlueprint.part_add(rRcs, pos, Quaternion::rotation(90.0_degf, zAxis) * rot, scl);
+    rRcsPorts.push_back(rBlueprint.part_add(rRcs, pos, Quaternion::rotation(90.0_degf, zAxis) * rot, scl));
     //rBlueprint.add_part(rRcs, pos, rot, scl);
-    rBlueprint.part_add(rRcs, pos, Quaternion::rotation(-90.0_degf, zAxis) * rot, scl);
-
-    for (int i = 0; i < 2; i ++)
-    {
-        rRcsPorts.push_back(hackypartnum + i);
-    }
+    rRcsPorts.push_back(rBlueprint.part_add(rRcs, pos, Quaternion::rotation(-90.0_degf, zAxis) * rot, scl));
 }
 
 osp::universe::Satellite testapp::debug_add_part_vehicle(
@@ -244,7 +238,7 @@ osp::universe::Satellite testapp::debug_add_part_vehicle(
     float rcsZStep      = 4.0f;
     float rcsRadius     = 1.1f;
 
-    std::vector<int> rcsPorts;
+    std::vector<part_t> rcsPorts;
 
     for (float z = rcsZMin; z < rcsZMax; z += rcsZStep)
     {


### PR DESCRIPTION
Depends on #99

The wiring system is the last bit of old code to de-spaghettify. See issue #56; however, the implementation in this PR does not resemble anything described in the issue.

## Structure

The new way wires are organized looks like this:

![image](https://user-images.githubusercontent.com/14708882/116317964-eb3ccd80-a768-11eb-9a7e-7f1468ca7069.png)

* Values are passed around by reading and writing into Nodes
  * One Machine writes into the node, another Machine reads the node
  * Usually there will be separate read and write fields to prevent race conditions and for correct propagation speeds
* Machine entities also have Panel components that contain Ports
* Panels can contain multiple Ports
* Each Port can connect to only one Node
* Nodes can connect to multiple Ports; connections are called Links which are stored in the Node
* Links can have custom states

There are no longer any dedicated input and output classes like before.

This system is entirely templated. Propagation mechanics and topology is up to the user. Templates functions for common logical signals are provided, known as Signals. The system can be further templated for things like serial connections, events, and resource flow.

This example diagram shows a UserControl and a Container connected to a Rocket:

![image](https://user-images.githubusercontent.com/14708882/116319805-065d0c80-a76c-11eb-893d-41c8dcbe5e4a.png)

## Updating

Mentioned earlier, Nodes need to store a read value and a write value. Consider two machines A and B: A writes to Node, and B reads the Node.
* If A updates first, then B would immediately get the new value written by A.
* If B updates first, then it would read the previous value written by A.
* If they update in parallel, then there would be a race condition.
If A writes into a specialized write field in the Node instead, then this problem would be eliminated. This also means that the Node needs its own update function where it can replace its read field with the new written value.

Wire components must also update multiple times per frame. 1/60 second propagation delays are simply unacceptable for controlling fast-moving spacecraft in real-time.

Updating wire components in the scene alternates between two different steps:

* Node update - Nodes consider their new written values and update their read values
* Machine Calculate update - Machines read connected input nodes, do calculations, and write to connected output nodes 

## Performance

So far, the current wire update in the 'simple' scene takes 0.003ms to update on a 3.0Ghz processor. 

In a modified scene with 100 vehicles each with 16 RCS controllers, 17 rockets, and a user controller, it takes only 0.3ms to update everything while RCS is firing and throttle is changing. 

## Notes:

The idea of needing an intermediate value may seem unnecessary at first, but it greatly simplifies many calculations. It also stops Machine components from having to write into each other's memory. This prevents the terrible ECS component polymorphism needed before.

The term "Node" comes from Electrical Engineering: https://en.wikipedia.org/wiki/Node_(circuits)

This PR adds the right infrastructure, but leaves a few opened gaps:
* Fuel flow is disabled entirely
* No way to delete nodes yet
