### PR TITLE
Cleanup Hierarchy and Add Entity Deferred Delete system

### DIFF
--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -107,7 +107,7 @@ void SysMachineUserControl::update_sensor(ActiveScene &rScene)
 
     // InputDevice.IsActivated()
     // Combination
-    auto const &usrCtrl = rScene.reg_root_get_or_emplace<ACompUserControl>(rScene.get_user_input());
+    auto const &usrCtrl = rScene.reg_get<ACompUserControl>(rScene.hier_get_root());
     ACompWireNodes<Percent> &rNodesPercent = SysWire::nodes<Percent>(rScene);
     ACompWireNodes<AttitudeControl> &rNodesAttCtrl = SysWire::nodes<AttitudeControl>(rScene);
 

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -48,8 +48,8 @@ void PlumeShader::draw_plume(ActiveEnt e,
     using Magnum::GL::Texture2D;
     using Magnum::GL::Mesh;
     // Collect uniform data
-    auto& transform = rScene.reg_get<ACompTransform>(e);
-    auto& rPlumeComp = rScene.reg_get<ACompExhaustPlume>(e);
+    auto const& drawTf = rScene.reg_get<ACompDrawTransform>(e);
+    auto const& rPlumeComp = rScene.reg_get<ACompExhaustPlume>(e);
     auto const& plumedata = *rPlumeComp.m_effect;
     Mesh& rMesh = *rScene.reg_get<ACompMesh>(e).m_mesh;
 
@@ -61,7 +61,7 @@ void PlumeShader::draw_plume(ActiveEnt e,
             rScene.get_application().debug_find_package("lzdb"), resources);
     }
 
-    Magnum::Matrix4 entRelative = camera.m_inverse * transform.m_transformWorld;
+    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 
     shader
         .bindNozzleNoiseTexture(*tmpTex)

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -56,6 +56,11 @@ ActiveScene::~ActiveScene()
 void ActiveScene::update()
 {
     m_updateOrder.call(*this);
+
+    // TODO: FunctionOrder is way too inconvenient to deal with, so for now the
+    //       delete systems are called here
+    SysHierarchy::update_delete(*this);
+    update_delete(*this);
 }
 
 void ActiveScene::draw(ActiveEnt camera)

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -26,6 +26,7 @@
 
 #include "ActiveScene.h"
 #include "osp/Active/SysRender.h"
+#include "osp/Active/SysHierarchy.h"
 
 using namespace osp;
 using namespace osp::active;
@@ -39,24 +40,12 @@ void ACompCamera::calculate_projection()
 }
 
 
-ActiveScene::ActiveScene(UserInputHandler &userInput, OSPApplication &app, Package& context) :
+ActiveScene::ActiveScene(OSPApplication &app, Package& context) :
         m_app(app),
-        m_context(context),
-        m_hierarchyDirty(false),
-        m_userInput(userInput)
+        m_context(context)
 {
-    m_registry.on_construct<ACompHierarchy>()
-                    .connect<&ActiveScene::on_hierarchy_construct>(*this);
-
-    m_registry.on_destroy<ACompHierarchy>()
-                    .connect<&ActiveScene::on_hierarchy_destruct>(*this);
-
     // Create the root entity
-
     m_root = m_registry.create();
-    ACompHierarchy& hierarchy = m_registry.emplace<ACompHierarchy>(m_root);
-    hierarchy.m_name = "Root Entity";
-
 }
 
 ActiveScene::~ActiveScene()
@@ -64,171 +53,23 @@ ActiveScene::~ActiveScene()
     m_registry.clear();
 }
 
-ActiveEnt ActiveScene::hier_create_child(ActiveEnt parent,
-                                            std::string const& name)
-{
-    ActiveEnt child = m_registry.create();
-    ACompHierarchy& childHierarchy = m_registry.emplace<ACompHierarchy>(child);
-    //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
-    childHierarchy.m_name = name;
-
-    hier_set_parent_child(parent, child);
-
-    return child;
-}
-
-void ActiveScene::hier_set_parent_child(ActiveEnt parent, ActiveEnt child)
-{
-    ACompHierarchy& childHierarchy = m_registry.get<ACompHierarchy>(child);
-    //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
-
-    ACompHierarchy& parentHierarchy = m_registry.get<ACompHierarchy>(parent);
-
-    // if child has an existing parent, cut first
-    if (m_registry.valid(childHierarchy.m_parent))
-    {
-        hier_cut(child);
-    }
-
-    // set new child's parent
-    childHierarchy.m_parent = parent;
-    childHierarchy.m_level = parentHierarchy.m_level + 1;
-
-    // If has siblings (not first child)
-    if (parentHierarchy.m_childCount)
-    {
-        ActiveEnt sibling = parentHierarchy.m_childFirst;
-        auto& siblingHierarchy = m_registry.get<ACompHierarchy>(sibling);
-
-        // Set new child and former first child as siblings
-        siblingHierarchy.m_siblingPrev = child;
-        childHierarchy.m_siblingNext = sibling;
-    }
-
-    // Set parent's first child to new child just created
-    parentHierarchy.m_childFirst = child;
-    parentHierarchy.m_childCount ++; // increase child count
-}
-
-void ActiveScene::hier_destroy(ActiveEnt ent)
-{
-    auto *pEntHier = &m_registry.get<ACompHierarchy>(ent);
-
-    // Destroy children first recursively, if there is any
-    while (pEntHier->m_childCount > 0)
-    {
-        hier_destroy(pEntHier->m_childFirst);
-        // previous hier_destroy might have caused a reallocation
-        pEntHier = m_registry.try_get<ACompHierarchy>(ent);
-    }
-
-    hier_cut(ent);
-    m_registry.destroy(ent);
-}
-
-void ActiveScene::hier_cut(ActiveEnt ent)
-{
-    auto &entHier = m_registry.get<ACompHierarchy>(ent);
-
-    // TODO: deal with m_depth
-
-    // Set sibling's sibling's to each other
-
-    if (m_registry.valid(entHier.m_siblingNext))
-    {
-        m_registry.get<ACompHierarchy>(entHier.m_siblingNext).m_siblingPrev
-                = entHier.m_siblingPrev;
-    }
-
-    if (m_registry.valid(entHier.m_siblingPrev))
-    {
-        m_registry.get<ACompHierarchy>(entHier.m_siblingPrev).m_siblingNext
-                = entHier.m_siblingNext;
-    }
-
-    // deal with parent
-
-    auto &parentHier = m_registry.get<ACompHierarchy>(entHier.m_parent);
-    parentHier.m_childCount --;
-
-    if (parentHier.m_childFirst == ent)
-    {
-        parentHier.m_childFirst = entHier.m_siblingNext;
-    }
-
-    entHier.m_parent = entHier.m_siblingNext = entHier.m_siblingPrev
-            = entt::null;
-}
-
-void ActiveScene::on_hierarchy_construct(ActiveReg_t& reg, ActiveEnt ent)
-{
-    m_hierarchyDirty = true;
-}
-
-void ActiveScene::on_hierarchy_destruct(ActiveReg_t& reg, ActiveEnt ent)
-{
-    m_hierarchyDirty = true;
-}
-
 void ActiveScene::update()
 {
-
     m_updateOrder.call(*this);
-}
-
-
-void ActiveScene::update_hierarchy_transforms()
-{
-    if (m_hierarchyDirty)
-    {
-        // Sort by level, so that objects at the top of the hierarchy are
-        // updated first
-        m_registry.sort<ACompHierarchy>([](ACompHierarchy const& lhs,
-                                           ACompHierarchy const& rhs)
-        {
-            return lhs.m_level < rhs.m_level;
-        }, entt::insertion_sort());
-
-        m_registry.sort<ACompTransform, ACompHierarchy>();
-
-        m_hierarchyDirty = false;
-    }
-
-    auto view = m_registry.view<ACompHierarchy, ACompTransform>();
-
-    for(ActiveEnt entity : view)
-    {
-        auto& hierarchy = view.get<ACompHierarchy>(entity);
-        auto& transform = view.get<ACompTransform>(entity);
-
-        if (hierarchy.m_parent == m_root)
-        {
-            // top level object, parent is root
-
-            transform.m_transformWorld = transform.m_transform;
-
-        }
-        else
-        {
-            auto& parentTransform
-                    = view.get<ACompTransform>(hierarchy.m_parent);
-
-            // set transform relative to parent
-            transform.m_transformWorld = parentTransform.m_transformWorld
-                                          * transform.m_transform;
-        }
-    }
 }
 
 void ActiveScene::draw(ActiveEnt camera)
 {
+    SysHierarchy::sort(*this);
+    SysRender::update_hierarchy_transforms(*this);
+
     auto renderView = m_registry.view<ACompRenderingAgent, ACompPerspective3DView, ACompRenderer>();
     for (auto [e, agent, view, renderer] : renderView.each())
     {
         DependRes<RenderPipeline> render =
             get_context_resources().get<RenderPipeline>(renderer.m_name);
         auto& camera = reg_get<ACompCamera>(view.m_camera);
-        auto& cameraTransform = reg_get<ACompTransform>(view.m_camera);
+        auto& cameraDrawTransform = reg_get<ACompDrawTransform>(view.m_camera);
         auto& target = reg_get<ACompRenderTarget>(agent.m_target);
         target.m_fbo->bind();
         using Magnum::GL::FramebufferClear;
@@ -237,7 +78,7 @@ void ActiveScene::draw(ActiveEnt camera)
             | FramebufferClear::Depth
             | FramebufferClear::Stencil);
 
-        camera.m_inverse = cameraTransform.m_transformWorld.inverted();
+        camera.m_inverse = cameraDrawTransform.m_transformWorld.inverted();
 
         render->m_order.call(*this, camera);
     }

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -110,11 +110,33 @@ public:
         return m_registry.emplace<T>(ent, std::forward<Args>(args)...);
     }
 
+
+    /**
+     * Mark an entity for deletion
+     *
+     * @param ent [in] Entity to delete
+     */
+    void mark_delete(ActiveEnt ent)
+    {
+        m_registry.emplace_or_replace<ACompDelete>(ent);
+    }
+
     /**
      * Update everything in the update order, including all systems and stuff
      */
     void update();
 
+    /**
+     * Delete entities with ACompDelete
+     *
+     * @param rScene [ref] scene with entities
+     */
+    static void update_delete(ActiveScene& rScene)
+    {
+        ActiveReg_t &rReg = rScene.get_registry();
+        auto view = rReg.view<ACompDelete>();
+        rScene.get_registry().destroy(std::begin(view), std::end(view));
+    }
 
     /**
      * Calculate transformations relative to camera, and draw every

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -52,7 +52,6 @@ class ActiveScene
 public:
 
     ActiveScene(OSPApplication& app, Package& context);
-    ~ActiveScene();
 
     OSPApplication& get_application() { return m_app; };
 
@@ -135,15 +134,13 @@ public:
     {
         ActiveReg_t &rReg = rScene.get_registry();
         auto view = rReg.view<ACompDelete>();
-        rScene.get_registry().destroy(std::begin(view), std::end(view));
+        rReg.destroy(std::begin(view), std::end(view));
     }
 
     /**
-     * Calculate transformations relative to camera, and draw every
-     * CompDrawableDebug
-     * @param camera [in] Entity containing a ACompCamera
+     * Calculate world transformations and draw to all render targets
      */
-    void draw(ActiveEnt camera);
+    void draw();
 
     constexpr UpdateOrder_t& get_update_order() { return m_updateOrder; }
 
@@ -166,14 +163,14 @@ private:
     OSPApplication& m_app;
     Package& m_context;
 
-    ActiveReg_t m_registry;
-    ActiveEnt m_root;
-
     UpdateOrder_t m_updateOrder;
     RenderOrder_t m_renderOrder;
 
     std::vector<UpdateOrderHandle_t> m_updateHandles;
     std::vector<RenderOrderHandle_t> m_renderHandles;
+
+    ActiveReg_t m_registry;
+    ActiveEnt m_root;
 
 };
 

--- a/src/osp/Active/Shader.h
+++ b/src/osp/Active/Shader.h
@@ -30,14 +30,5 @@
 
 namespace osp::active
 {
-/**
- * A function pointer to a Shader's draw() function
- * @param ActiveEnt - The entity being drawn; used to fetch component data
- * @param ActiveScene - The scene containing the entity's component data
- * @param ACompCamera - Camera used to draw the scene
- */
-using ShaderDrawFnc_t = void (*)(
-    ActiveEnt,
-    ActiveScene&,
-    ACompCamera const&) noexcept;
+
 }

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -165,22 +165,25 @@ void SysAreaAssociate::sat_transform_set_relative(
 void SysAreaAssociate::floating_origin_translate(
         ActiveScene& rScene,Vector3 translation)
 {
+    auto &rReg = rScene.get_registry();
+
     auto view = rScene.get_registry()
             .view<ACompFloatingOrigin, ACompTransform>();
 
-    for (ActiveEnt ent : view)
+    for (ActiveEnt const ent : view)
     {
         auto &entTransform = view.get<ACompTransform>(ent);
         //auto &entFloatingOrigin = view.get<ACompFloatingOrigin>(ent);
 
-        if (entTransform.m_controlled)
+        if (rReg.all_of<ACompTransformControlled>(ent))
         {
-            if (!entTransform.m_mutable)
+            auto *tfMutable = rReg.try_get<ACompTransformMutable>(ent);
+            if (tfMutable == nullptr)
             {
                 continue;
             }
 
-            entTransform.m_transformDirty = true;
+            tfMutable->m_dirty = true;
         }
 
         entTransform.m_transform.translation() += translation;

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -167,8 +167,7 @@ void SysAreaAssociate::floating_origin_translate(
 {
     auto &rReg = rScene.get_registry();
 
-    auto view = rScene.get_registry()
-            .view<ACompFloatingOrigin, ACompTransform>();
+    auto view = rReg.view<ACompFloatingOrigin, ACompTransform>();
 
     for (ActiveEnt const ent : view)
     {

--- a/src/osp/Active/SysHierarchy.cpp
+++ b/src/osp/Active/SysHierarchy.cpp
@@ -1,0 +1,153 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "SysHierarchy.h"
+
+using osp::active::SysHierarchy;
+using osp::active::ActiveEnt;
+
+void SysHierarchy::setup(ActiveScene& rScene)
+{
+    auto &rReg = rScene.get_registry();
+
+    rReg.emplace<ACompHierarchy>(rScene.hier_get_root());
+    //hierarchy.m_name = "Root Entity";
+}
+
+ActiveEnt SysHierarchy::create_child(ActiveScene& rScene, ActiveEnt parent,
+                                            std::string const& name)
+{
+    auto &rReg = rScene.get_registry();
+    ActiveEnt child = rReg.create();
+    ACompHierarchy& childHierarchy = rReg.emplace<ACompHierarchy>(child);
+    //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
+
+    if (!name.empty())
+    {
+        rScene.reg_emplace<ACompName>(child, name);
+    }
+    //childHierarchy.m_name = name;
+
+    set_parent_child(rScene, parent, child);
+
+    return child;
+}
+
+void SysHierarchy::set_parent_child(ActiveScene& rScene, ActiveEnt parent, ActiveEnt child)
+{
+    auto &rReg = rScene.get_registry();
+
+    ACompHierarchy& childHierarchy = rReg.get<ACompHierarchy>(child);
+    //ACompTransform& transform = m_registry.emplace<ACompTransform>(ent);
+
+    ACompHierarchy& parentHierarchy = rReg.get<ACompHierarchy>(parent);
+
+    // if child has an existing parent, cut first
+    if (rReg.valid(childHierarchy.m_parent))
+    {
+        cut(rScene, child);
+    }
+
+    // set new child's parent
+    childHierarchy.m_parent = parent;
+    childHierarchy.m_level = parentHierarchy.m_level + 1;
+
+    // If has siblings (not first child)
+    if (parentHierarchy.m_childCount)
+    {
+        ActiveEnt sibling = parentHierarchy.m_childFirst;
+        auto& siblingHierarchy = rReg.get<ACompHierarchy>(sibling);
+
+        // Set new child and former first child as siblings
+        siblingHierarchy.m_siblingPrev = child;
+        childHierarchy.m_siblingNext = sibling;
+    }
+
+    // Set parent's first child to new child just created
+    parentHierarchy.m_childFirst = child;
+    parentHierarchy.m_childCount ++; // increase child count
+}
+
+void SysHierarchy::destroy(ActiveScene& rScene, ActiveEnt ent)
+{
+    auto &rReg = rScene.get_registry();
+
+    auto *pEntHier = &rReg.get<ACompHierarchy>(ent);
+
+    // Destroy children first recursively, if there is any
+    while (pEntHier->m_childCount > 0)
+    {
+        destroy(rScene, pEntHier->m_childFirst);
+        // previous hier_destroy might have caused a reallocation
+        pEntHier = rReg.try_get<ACompHierarchy>(ent);
+    }
+
+    cut(rScene, ent);
+    rReg.destroy(ent);
+}
+
+void SysHierarchy::cut(ActiveScene& rScene, ActiveEnt ent)
+{
+    auto &rReg = rScene.get_registry();
+    auto &entHier = rReg.get<ACompHierarchy>(ent);
+
+    // TODO: deal with m_depth
+
+    // Set sibling's sibling's to each other
+
+    if (rReg.valid(entHier.m_siblingNext))
+    {
+        rReg.get<ACompHierarchy>(entHier.m_siblingNext).m_siblingPrev
+                = entHier.m_siblingPrev;
+    }
+
+    if (rReg.valid(entHier.m_siblingPrev))
+    {
+        rReg.get<ACompHierarchy>(entHier.m_siblingPrev).m_siblingNext
+                = entHier.m_siblingNext;
+    }
+
+    // deal with parent
+
+    auto &parentHier = rReg.get<ACompHierarchy>(entHier.m_parent);
+    parentHier.m_childCount --;
+
+    if (parentHier.m_childFirst == ent)
+    {
+        parentHier.m_childFirst = entHier.m_siblingNext;
+    }
+
+    entHier.m_parent = entHier.m_siblingNext = entHier.m_siblingPrev
+            = entt::null;
+}
+
+void SysHierarchy::sort(ActiveScene& rScene)
+{
+    rScene.get_registry().sort<ACompHierarchy>(
+            [](ACompHierarchy const& lhs, ACompHierarchy const& rhs)
+    {
+        return lhs.m_level < rhs.m_level;
+    }, entt::insertion_sort());
+}

--- a/src/osp/Active/SysHierarchy.h
+++ b/src/osp/Active/SysHierarchy.h
@@ -150,7 +150,8 @@ void SysHierarchy::traverse(ActiveScene& rScene,
             // is last sibling, move to parent's (or ancestor's) next sibling
             currentEnt = parentNextSibling.top();
             parentNextSibling.pop();
-        } else
+        }
+        else
         {
             break;
         }

--- a/src/osp/Active/SysHierarchy.h
+++ b/src/osp/Active/SysHierarchy.h
@@ -1,0 +1,131 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "ActiveScene.h"
+
+namespace osp::active
+{
+
+class SysHierarchy
+{
+public:
+    static void setup(ActiveScene& rScene);
+
+    /**
+     * Create a new entity, and add a ACompHierarchy to it
+     * @param parent [in] Entity to assign as parent
+     * @param name   [in] Name of entity
+     * @return New entity created
+     */
+    static ActiveEnt create_child(ActiveScene& rScene, ActiveEnt parent,
+                                  std::string const& name = {});
+
+    /**
+     * Set parent-child relationship between two nodes containing an
+     * ACompHierarchy
+     *
+     * @param parent [in]
+     * @param child  [in]
+     */
+    static void set_parent_child(ActiveScene& rScene,
+                                 ActiveEnt parent, ActiveEnt child);
+
+    /**
+     * @deprecated
+     */
+    static void destroy(ActiveScene& rScene, ActiveEnt ent);
+
+    /**
+     * Cut an entity out of it's parent. This will leave the entity with no
+     * parent.
+     * @param ent [in]
+     */
+    static void cut(ActiveScene& rScene, ActiveEnt ent);
+
+    /**
+     * Traverse the scene hierarchy
+     *
+     * Calls the specified callable on each entity of the scene hierarchy
+     * @param root The entity whose sub-tree to traverse
+     * @param callable A function that accepts an ActiveEnt as an argument and
+     *                 returns false if traversal should stop, true otherwise
+     */
+    template <typename FUNC_T>
+    static void traverse(ActiveScene& rScene,
+                                   ActiveEnt root, FUNC_T callable);
+
+    static void sort(ActiveScene& rScene);
+};
+
+template<typename FUNC_T>
+void SysHierarchy::traverse(ActiveScene& rScene,
+                                      ActiveEnt root, FUNC_T callable)
+{
+    using osp::active::ACompHierarchy;
+
+    std::stack<ActiveEnt> parentNextSibling;
+    ActiveEnt currentEnt = root;
+
+    unsigned int rootLevel = rScene.reg_get<ACompHierarchy>(root).m_level;
+
+    while (true)
+    {
+        ACompHierarchy &hier = rScene.reg_get<ACompHierarchy>(currentEnt);
+
+        if (callable(currentEnt) == EHierarchyTraverseStatus::Stop) { return; }
+
+        if (hier.m_childCount > 0)
+        {
+            // entity has some children
+            currentEnt = hier.m_childFirst;
+
+            // Save next sibling for later if it exists
+            // Don't check siblings of the root node
+            if ((hier.m_siblingNext != entt::null) && (hier.m_level > rootLevel))
+            {
+                parentNextSibling.push(hier.m_siblingNext);
+            }
+        }
+        else if ((hier.m_siblingNext != entt::null) && (hier.m_level > rootLevel))
+        {
+            // no children, move to next sibling
+            currentEnt = hier.m_siblingNext;
+        }
+        else if (parentNextSibling.size() > 0)
+        {
+            // last sibling, and not done yet
+            // is last sibling, move to parent's (or ancestor's) next sibling
+            currentEnt = parentNextSibling.top();
+            parentNextSibling.pop();
+        } else
+        {
+            break;
+        }
+    }
+}
+
+
+}

--- a/src/osp/Active/SysHierarchy.h
+++ b/src/osp/Active/SysHierarchy.h
@@ -32,10 +32,18 @@ namespace osp::active
 class SysHierarchy
 {
 public:
+
+    /**
+     * Add hierarchy component to root entity in scene
+     *
+     * @param rScene [ref] scene with no hierarchy yet
+     */
     static void setup(ActiveScene& rScene);
 
     /**
      * Create a new entity, and add a ACompHierarchy to it
+     *
+     * @param rScene [ref] Scene with hierarchy
      * @param parent [in] Entity to assign as parent
      * @param name   [in] Name of entity
      * @return New entity created
@@ -47,6 +55,7 @@ public:
      * Set parent-child relationship between two nodes containing an
      * ACompHierarchy
      *
+     * @param rScene [ref] Scene with hierarchy
      * @param parent [in]
      * @param child  [in]
      */
@@ -54,13 +63,21 @@ public:
                                  ActiveEnt parent, ActiveEnt child);
 
     /**
-     * @deprecated
+     * Mark a hierarchy entity for deletion, and cut it out of the hierarchy
+     *
+     * @param rScene [ref] Scene with hierarchy
+     * @param ent [in] Entity to delete
      */
-    static void destroy(ActiveScene& rScene, ActiveEnt ent);
+    static void mark_delete_cut(ActiveScene& rScene, ActiveEnt ent)
+    {
+        cut(rScene, ent);
+        rScene.mark_delete(ent);
+    }
 
     /**
-     * Cut an entity out of it's parent. This will leave the entity with no
-     * parent.
+     * Cut an entity out of the hierarchy.
+     *
+     * @param rScene [ref] Scene with hierarchy
      * @param ent [in]
      */
     static void cut(ActiveScene& rScene, ActiveEnt ent);
@@ -69,15 +86,28 @@ public:
      * Traverse the scene hierarchy
      *
      * Calls the specified callable on each entity of the scene hierarchy
+     *
+     * @param rScene [ref] Scene with hierarchy
      * @param root The entity whose sub-tree to traverse
      * @param callable A function that accepts an ActiveEnt as an argument and
      *                 returns false if traversal should stop, true otherwise
      */
     template <typename FUNC_T>
-    static void traverse(ActiveScene& rScene,
-                                   ActiveEnt root, FUNC_T callable);
+    static void traverse(ActiveScene& rScene, ActiveEnt root, FUNC_T callable);
 
+    /**
+     * Sort hierarchy component pool
+     *
+     * @param rScene [ref] Scene with hierarchy
+     */
     static void sort(ActiveScene& rScene);
+
+    /**
+     * Mark descendents of deleted hierarchy entities as deleted too
+     *
+     * @param rScene [ref] Scene with hierarchy
+     */
+    static void update_delete(ActiveScene& rScene);
 };
 
 template<typename FUNC_T>

--- a/src/osp/Active/SysRender.cpp
+++ b/src/osp/Active/SysRender.cpp
@@ -194,3 +194,39 @@ void SysRender::display_default_rendertarget(ActiveScene& rScene)
 
     shader->display_texure(*surface, *target.m_tex);
 }
+
+void SysRender::update_hierarchy_transforms(ActiveScene& rScene)
+{
+
+    auto &rReg = rScene.get_registry();
+
+    rReg.sort<ACompDrawTransform, ACompHierarchy>();
+
+    auto viewHier = rReg.view<ACompHierarchy>();
+    auto viewTf = rReg.view<ACompTransform>();
+    auto viewDrawTf = rReg.view<ACompDrawTransform>();
+
+    for(ActiveEnt const entity : viewDrawTf)
+    {
+        auto const &hier = viewHier.get<ACompHierarchy>(entity);
+        auto const &tf = viewTf.get<ACompTransform>(entity);
+        auto &rDrawTf = viewDrawTf.get<ACompDrawTransform>(entity);
+
+        if (hier.m_parent == rScene.hier_get_root())
+        {
+            // top level object, parent is root
+
+            rDrawTf.m_transformWorld = tf.m_transform;
+
+        }
+        else
+        {
+            auto const& parentDrawTf
+                    = viewDrawTf.get<ACompDrawTransform>(hier.m_parent);
+
+            // set transform relative to parent
+            rDrawTf.m_transformWorld = parentDrawTf.m_transformWorld
+                                     * tf.m_transform;
+        }
+    }
+}

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -29,6 +29,8 @@
 #include "osp/Active/activetypes.h"
 #include "osp/Shaders/Phong.h"
 
+#include "drawing.h"
+
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
 #include <Magnum/GL/Framebuffer.h>
@@ -36,8 +38,6 @@
 
 namespace osp::active
 {
-
-/* ########## USER COMPONENTS ########## */
 
 /**
  * Stores a mesh to be drawn by the renderer
@@ -62,39 +62,6 @@ struct ACompRenderTarget
 {
     Magnum::Vector2i m_size;
     osp::DependRes<Magnum::GL::Framebuffer> m_fbo;
-};
-
-/**
- * Represents an entity which requests the scene to be drawn to m_target
- */
-struct ACompRenderingAgent
-{
-    ActiveEnt m_target;  // Must have ACompRenderTarget
-};
-
-/**
- * Describes the type of view used by a rendering agent
- */
-struct ACompPerspective3DView
-{
-    ActiveEnt m_camera;
-};
-
-/* An object that is completely opaque */
-struct ACompOpaque {};
-
-/* An object with transparency */
-struct ACompTransparent {};
-
-/* Visibility state of this object */
-struct ACompVisible {};
-
-/**
- * Stores a shader draw function to be used to draw the object
- */
-struct ACompShader
-{
-    ShaderDrawFnc_t m_drawCall{shader::Phong::draw_entity};  // default shader
 };
 
 /**
@@ -132,6 +99,15 @@ public:
 
     /* Draw the default render target to the screen */
     static void display_default_rendertarget(ActiveScene& rScene);
+
+    /**
+     * Update the m_transformWorld of entities with ACompTransform and
+     * ACompHierarchy. Intended for physics interpolation
+     */
+    static void update_hierarchy_transforms(ActiveScene& rScene);
+
+    static ShaderDrawFnc_t get_default_shader() { return shader::Phong::draw_entity; };
+
 private:
     /* Define render passes */
     static RenderPipeline create_forward_renderer();

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -23,6 +23,7 @@
  * SOFTWARE.
  */
 #include "ActiveScene.h"
+#include "SysHierarchy.h"
 #include "SysVehicle.h"
 #include "SysRender.h"
 #include "physics.h"
@@ -79,11 +80,12 @@ ActiveEnt SysVehicle::activate(ActiveScene &rScene, universe::Universe &rUni,
 
     // Create the root entity to add parts to
 
-    ActiveEnt vehicleEnt = rScene.hier_create_child(root, "Vehicle");
+    ActiveEnt vehicleEnt =  SysHierarchy::create_child(rScene, root, "Vehicle");
 
     rScene.reg_emplace<ACompActivatedSat>(vehicleEnt, tgtSat);
 
     ACompVehicle& vehicleComp = rScene.reg_emplace<ACompVehicle>(vehicleEnt);
+    rScene.reg_emplace<ACompDrawTransform>(vehicleEnt);
     rScene.reg_emplace<ACompVehicleInConstruction>(
                     vehicleEnt, loadMeVehicle.m_blueprint);
 
@@ -177,7 +179,7 @@ float SysVehicle::compute_hier_volume(ActiveScene& rScene, ActiveEnt part)
         return EHierarchyTraverseStatus::Continue;
     };
 
-    rScene.hierarchy_traverse(part, std::move(checkVol));
+    SysHierarchy::traverse(rScene, part, std::move(checkVol));
 
     return volume;
 }
@@ -217,7 +219,7 @@ ActiveEnt SysVehicle::part_instantiate(
         }
 
         // Create the new entity
-        ActiveEnt currentEnt = rScene.hier_create_child(parentEnt);
+        ActiveEnt currentEnt = SysHierarchy::create_child(rScene, parentEnt);
         newEntities[i] = currentEnt;
 
         // Add and set transform component
@@ -227,13 +229,12 @@ ActiveEnt SysVehicle::part_instantiate(
                 = Matrix4::from(pcompTransform.m_rotation.toMatrix(),
                                 pcompTransform.m_translation)
                 * Matrix4::scaling(pcompTransform.m_scale);
+        rScene.reg_emplace<ACompDrawTransform>(currentEnt);
     }
 
-    // TODO: add an ACompName because putting name in hierarchy is pretty stupid
     for (PCompName const& pcompName : part.m_partName)
     {
-        auto &hier = rScene.reg_get<ACompHierarchy>(newEntities[pcompName.m_entity]);
-        hier.m_name = pcompName.m_name;
+        rScene.reg_emplace<ACompName>(newEntities[pcompName.m_entity], pcompName.m_name);
     }
 
     // Create drawables
@@ -278,7 +279,7 @@ ActiveEnt SysVehicle::part_instantiate(
         // as components to be consumed by the Phong shader
         rScene.reg_emplace<ACompVisible>(currentEnt);
         rScene.reg_emplace<ACompOpaque>(currentEnt);
-        rScene.reg_emplace<ACompShader>(currentEnt);
+        rScene.reg_emplace<ACompShader>(currentEnt, SysRender::get_default_shader());
         rScene.reg_emplace<ACompMesh>(currentEnt, meshRes);
         rScene.reg_emplace<ACompDiffuseTex>(currentEnt, std::move(textureResources[0]));
     }
@@ -328,7 +329,7 @@ ActiveEnt SysVehicle::part_instantiate(
         return EHierarchyTraverseStatus::Continue;
     };
 
-    rScene.hierarchy_traverse(rootEntity, applyMasses);
+    SysHierarchy::traverse(rScene, rootEntity, applyMasses);
 
     // Initialize entities for individual machines. This is done now in one
     // place, as creating new entities can be problematic for concurrency
@@ -340,7 +341,7 @@ ActiveEnt SysVehicle::part_instantiate(
     {
         ActiveEnt parent = newEntities[pcompMachine.m_entity];
         ActiveEnt machEnt = machines.m_machines.emplace_back(
-                    rScene.hier_create_child(parent, "Machine"));
+                    SysHierarchy::create_child(rScene, parent, "Machine"));
         rScene.reg_emplace<ACompMachineType>(machEnt, pcompMachine.m_type);
     }
 
@@ -375,7 +376,7 @@ void SysVehicle::update_activate(ActiveScene &rScene)
             continue;
         }
 
-        rScene.hier_destroy(ent);
+        SysHierarchy::destroy(rScene, ent);
     }
 
     // Update transforms of already-activated vehicle satellites
@@ -436,7 +437,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                 if (pRBA) { pRBA->m_ancestor = entt::null; }
                 return EHierarchyTraverseStatus::Continue;
             };
-            rScene.hierarchy_traverse(vehicleEnt, invalidateAncestors);
+            SysHierarchy::traverse(rScene, vehicleEnt, invalidateAncestors);
 
             // Create the islands vector
             // [0]: current vehicle
@@ -450,11 +451,12 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
             //       when emplacing new ones.
             for (size_t i = 1; i < islands.size(); i ++)
             {
-                ActiveEnt islandEnt = rScene.hier_create_child(
-                            rScene.hier_get_root());
+                ActiveEnt islandEnt = SysHierarchy::create_child(
+                            rScene, rScene.hier_get_root());
                 rScene.reg_emplace<ACompVehicle>(islandEnt);
                 auto &islandTransform
                         = rScene.reg_emplace<ACompTransform>(islandEnt);
+                rScene.reg_emplace<ACompDrawTransform>(islandEnt);
                 auto &islandBody
                         = rScene.reg_emplace<ACompRigidBody_t>(islandEnt);
                 auto &islandShape
@@ -485,7 +487,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                 if (partPart.m_destroy)
                 {
                     // destroy this part
-                    rScene.hier_destroy(partEnt);
+                    SysHierarchy::destroy(rScene, partEnt);
                     return true;
                 }
 
@@ -498,7 +500,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                                 islandEnt);
                     islandVehicle.m_parts.push_back(partEnt);
 
-                    rScene.hier_set_parent_child(islandEnt, partEnt);
+                    SysHierarchy::set_parent_child(rScene, islandEnt, partEnt);
 
                     return true;
                 }

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -376,7 +376,7 @@ void SysVehicle::update_activate(ActiveScene &rScene)
             continue;
         }
 
-        SysHierarchy::destroy(rScene, ent);
+        SysHierarchy::mark_delete_cut(rScene, ent);
     }
 
     // Update transforms of already-activated vehicle satellites
@@ -487,7 +487,7 @@ void SysVehicle::update_vehicle_modification(ActiveScene& rScene)
                 if (partPart.m_destroy)
                 {
                     // destroy this part
-                    SysHierarchy::destroy(rScene, partEnt);
+                    SysHierarchy::mark_delete_cut(rScene, partEnt);
                     return true;
                 }
 

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -38,9 +38,9 @@ namespace osp::active
  * @param ACompCamera - Camera used to draw the scene
  */
 using ShaderDrawFnc_t = void (*)(
-    ActiveEnt,
-    ActiveScene&,
-    ACompCamera const&) noexcept;
+        ActiveEnt,
+        ActiveScene&,
+        ACompCamera const&) noexcept;
 
 /**
  * Represents an entity which requests the scene to be drawn to m_target
@@ -78,6 +78,10 @@ struct ACompShader
     ShaderDrawFnc_t m_drawCall;
 };
 
+/**
+ * World transform used for rendering. All ascendents of an entity using this
+ * must also have this component
+ */
 struct ACompDrawTransform
 {
     Matrix4 m_transformWorld;

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -1,0 +1,86 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+
+#include "activetypes.h"
+#include "../types.h"
+
+namespace osp::active
+{
+
+/**
+ * A function pointer to a Shader's draw() function
+ * @param ActiveEnt - The entity being drawn; used to fetch component data
+ * @param ActiveScene - The scene containing the entity's component data
+ * @param ACompCamera - Camera used to draw the scene
+ */
+using ShaderDrawFnc_t = void (*)(
+    ActiveEnt,
+    ActiveScene&,
+    ACompCamera const&) noexcept;
+
+/**
+ * Represents an entity which requests the scene to be drawn to m_target
+ */
+struct ACompRenderingAgent
+{
+    ActiveEnt m_target;  // Must have ACompRenderTarget
+};
+
+/**
+ * Describes the type of view used by a rendering agent
+ */
+struct ACompPerspective3DView
+{
+    ActiveEnt m_camera;
+};
+
+/* An object that is completely opaque */
+struct ACompOpaque {};
+
+/* An object with transparency */
+struct ACompTransparent {};
+
+/* Visibility state of this object */
+struct ACompVisible {};
+
+/**
+ * Stores a shader draw function to be used to draw the object
+ */
+struct ACompShader
+{
+    constexpr ACompShader(ShaderDrawFnc_t drawCall) noexcept
+     : m_drawCall(drawCall)
+    { }
+    ShaderDrawFnc_t m_drawCall;
+};
+
+struct ACompDrawTransform
+{
+    Matrix4 m_transformWorld;
+};
+
+}

--- a/src/osp/Active/scene.h
+++ b/src/osp/Active/scene.h
@@ -51,7 +51,7 @@ struct ACompDelete{ };
 
 struct ACompName
 {
-    ACompName(std::string name) : m_name(name) { }
+    ACompName(std::string name) : m_name(std::move(name)) { }
     std::string m_name;
 };
 

--- a/src/osp/Active/scene.h
+++ b/src/osp/Active/scene.h
@@ -37,28 +37,12 @@ namespace osp::active
  */
 struct ACompTransform
 {
-    //Matrix4 m_transformPrev;
     osp::Matrix4 m_transform;
-    //Matrix4 m_transformWorld;
-    //bool m_enableFloatingOrigin;
-
-    // For when transform is controlled by a specific system.
-    // Examples of this behaviour:
-    // * Entities with ACompRigidBody are controlled by SysPhysics, transform
-    //   is updated each frame
-    //bool m_controlled{false};
-
-    // if this is true, then transform can be modified, as long as
-    // m_transformDirty is set afterwards
-    //bool m_mutable{true};
-    //bool m_transformDirty{false};
 };
 
 struct ACompTransformControlled { };
 
 struct ACompTransformMutable{ bool m_dirty{false}; };
-
-//struct ACompTransformDirty{ };
 
 /**
  * Added to an entity to mark it for deletion

--- a/src/osp/Active/scene.h
+++ b/src/osp/Active/scene.h
@@ -1,0 +1,107 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2020 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "../types.h"
+#include "activetypes.h"
+
+#include <entt/entity/entity.hpp>
+
+namespace osp::active
+{
+
+/**
+ * Component for transformation (in meters)
+ */
+struct ACompTransform
+{
+    //Matrix4 m_transformPrev;
+    osp::Matrix4 m_transform;
+    //Matrix4 m_transformWorld;
+    //bool m_enableFloatingOrigin;
+
+    // For when transform is controlled by a specific system.
+    // Examples of this behaviour:
+    // * Entities with ACompRigidBody are controlled by SysPhysics, transform
+    //   is updated each frame
+    //bool m_controlled{false};
+
+    // if this is true, then transform can be modified, as long as
+    // m_transformDirty is set afterwards
+    //bool m_mutable{true};
+    //bool m_transformDirty{false};
+};
+
+struct ACompTransformControlled { };
+
+struct ACompTransformMutable{ bool m_dirty{false}; };
+
+//struct ACompTransformDirty{ };
+
+/**
+ * Added to an entity to mark it for deletion
+ */
+struct ACompDelete{ };
+
+struct ACompName
+{
+    ACompName(std::string name) : m_name(name) { }
+    std::string m_name;
+};
+
+struct ACompHierarchy
+{
+    unsigned m_level{0}; // 0 for root entity, 1 for root's child, etc...
+    ActiveEnt m_parent{entt::null};
+    ActiveEnt m_siblingNext{entt::null};
+    ActiveEnt m_siblingPrev{entt::null};
+
+    // as a parent
+    unsigned m_childCount{0};
+    ActiveEnt m_childFirst{entt::null};
+};
+
+// Stores the mass of entities
+struct ACompMass
+{
+    float m_mass;
+};
+
+/**
+ * Component that represents a camera
+ */
+struct ACompCamera
+{
+    float m_near, m_far;
+    Magnum::Deg m_fov;
+    Vector2 m_viewport;
+
+    Matrix4 m_projection;
+    Matrix4 m_inverse;
+
+    void calculate_projection();
+};
+
+}

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -36,11 +36,11 @@ void Phong::draw_entity(ActiveEnt e,
     Phong& shader = *rScene.get_context_resources().get<Phong>(smc_resourceName);
 
     // Collect uniform information
-    auto& transform = rScene.reg_get<ACompTransform>(e);
+    auto& drawTf = rScene.reg_get<ACompDrawTransform>(e);
     Magnum::GL::Texture2D& rDiffuse = *rScene.reg_get<ACompDiffuseTex>(e).m_tex;
     Magnum::GL::Mesh& rMesh = *rScene.reg_get<ACompMesh>(e).m_mesh;
 
-    Magnum::Matrix4 entRelative = camera.m_inverse * transform.m_transformWorld;
+    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 
     /* 4th component indicates light type. A value of 0.0f indicates that the
      * light is a direction light coming from the specified direction relative
@@ -55,6 +55,6 @@ void Phong::draw_entity(ActiveEnt e,
         .setLightPositions({light})
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(camera.m_projection)
-        .setNormalMatrix(Matrix3{transform.m_transformWorld})
+        .setNormalMatrix(Matrix3{drawTf.m_transformWorld})
         .draw(rMesh);
 }

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -171,7 +171,7 @@ void SysPlanetA::update_activate(ActiveScene &rScene)
             continue;
         }
 
-        SysHierarchy::destroy(rScene, ent);
+        SysHierarchy::mark_delete_cut(rScene, ent);
     }
 
     // Activate planets that have just entered the ActiveArea

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -31,8 +31,6 @@
 #include <osp/Active/SysForceFields.h>
 #include <osp/Active/activetypes.h>
 
-#include <osp/UserInputHandler.h>
-
 #include <Magnum/Shaders/MeshVisualizer.h>
 #include <Magnum/GL/Mesh.h>
 

--- a/src/test_application/DebugObject.cpp
+++ b/src/test_application/DebugObject.cpp
@@ -79,7 +79,8 @@ using adera::active::machines::MachineUserControl;
 //}
 
 
-DebugCameraController::DebugCameraController(ActiveScene &rScene, ActiveEnt ent)
+DebugCameraController::DebugCameraController(ActiveScene &rScene, ActiveEnt ent,
+                                             osp::UserInputHandler &rInput)
  : DebugObject(rScene, ent)
  , m_selected(entt::null)
  , m_orbitPos(0, 0, 1)
@@ -91,16 +92,16 @@ DebugCameraController::DebugCameraController(ActiveScene &rScene, ActiveEnt ent)
                       [this] (ActiveScene&) { this->update_physics_pre(); })
  , m_updatePhysicsPost(rScene.get_update_order(), "dbg_cam_post", "physics", "",
                        [this] (ActiveScene&) { this->update_physics_post(); })
- , m_userInput(rScene.get_user_input())
- , m_mouseMotion(m_userInput.mouse_get())
- , m_scrollInput(m_userInput.scroll_get())
- , m_rmb(m_userInput.config_get("ui_rmb"))
- , m_up(m_userInput.config_get("ui_up"))
- , m_dn(m_userInput.config_get("ui_dn"))
- , m_lf(m_userInput.config_get("ui_lf"))
- , m_rt(m_userInput.config_get("ui_rt"))
- , m_switch(m_userInput.config_get("game_switch"))
- , m_selfDestruct(m_userInput.config_get("vehicle_self_destruct"))
+ , m_userInput(rInput)
+ , m_mouseMotion(rInput.mouse_get())
+ , m_scrollInput(rInput.scroll_get())
+ , m_rmb(rInput.config_get("ui_rmb"))
+ , m_up(rInput.config_get("ui_up"))
+ , m_dn(rInput.config_get("ui_dn"))
+ , m_lf(rInput.config_get("ui_lf"))
+ , m_rt(rInput.config_get("ui_rt"))
+ , m_switch(rInput.config_get("game_switch"))
+ , m_selfDestruct(rInput.config_get("vehicle_self_destruct"))
 { }
 
 void DebugCameraController::update_vehicle_mod_pre()

--- a/src/test_application/DebugObject.h
+++ b/src/test_application/DebugObject.h
@@ -78,7 +78,8 @@ class DebugCameraController : public DebugObject<DebugCameraController>
 
 public:
     DebugCameraController(osp::active::ActiveScene &scene,
-                          osp::active::ActiveEnt ent);
+                          osp::active::ActiveEnt ent,
+                          osp::UserInputHandler &rInput);
     ~DebugCameraController() = default;
     void update_vehicle_mod_pre();
     void update_physics_pre();

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -25,6 +25,7 @@
 
 #include "OSPMagnum.h"
 #include "osp/types.h"
+#include "osp/Active/SysHierarchy.h"
 
 #include <Magnum/Math/Color.h>
 #include <Magnum/PixelFormat.h>
@@ -62,26 +63,6 @@ void OSPMagnum::drawEvent()
     Magnum::GL::defaultFramebuffer.clear(Magnum::GL::FramebufferClear::Color
                                          | Magnum::GL::FramebufferClear::Depth);
 
-//    if (m_area)
-//    {
-//        //Scene3D& scene = m_area->get_scene();
-//        //if (!m_area->is_loaded_active())
-//        //{
-//        //    // Enable active area if not already done so
-//        //    m_area->activate();
-//        //}
-
-//       // std::cout << "deltaTime: " << m_timeline.previousFrameDuration() << "\n";
-
-//        // TODO: physics update
-//        m_userInput.update_controls();
-//        m_area->update_physics(1.0f / 60.0f);
-//        m_userInput.clear_events();
-//        // end of physics update
-
-//        m_area->draw_gl();
-//    }
-
     m_userInput.update_controls();
 
     for (auto &[name, scene] : m_scenes)
@@ -93,8 +74,6 @@ void OSPMagnum::drawEvent()
 
     for (auto &[name, scene] : m_scenes)
     {
-        scene.update_hierarchy_transforms();
-
 
         // temporary: draw using first camera component found
         scene.draw(scene.get_registry().view<osp::active::ACompCamera>().front());
@@ -149,14 +128,14 @@ void OSPMagnum::mouseScrollEvent(MouseScrollEvent & event)
 osp::active::ActiveScene& OSPMagnum::scene_create(std::string const& name)
 {
     auto const& [it, success] =
-        m_scenes.try_emplace(name, m_userInput, m_ospApp, m_glResources);
+        m_scenes.try_emplace(name, m_ospApp, m_glResources);
     return it->second;
 }
 
 osp::active::ActiveScene& OSPMagnum::scene_create(std::string && name)
 {
     auto const& [it, success] =
-        m_scenes.try_emplace(std::move(name), m_userInput, m_ospApp, m_glResources);
+        m_scenes.try_emplace(std::move(name), m_ospApp, m_glResources);
     return it->second;
 }
 

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -74,9 +74,7 @@ void OSPMagnum::drawEvent()
 
     for (auto &[name, scene] : m_scenes)
     {
-
-        // temporary: draw using first camera component found
-        scene.draw(scene.get_registry().view<osp::active::ACompCamera>().front());
+        scene.draw();
     }
 
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -466,8 +466,9 @@ void debug_print_machines()
 
     for (ActiveEnt ent : view)
     {
-        auto const &hier = scene.reg_get<ACompHierarchy>(ent);
-        std::cout << "[" << int(ent) << "]: " << hier.m_name << "\n";
+        auto const *name = scene.get_registry().try_get<osp::active::ACompName>(ent);
+        std::string_view nameview = (name != nullptr) ? std::string_view(name->m_name) : "untitled";
+        std::cout << "[" << int(ent) << "]: " << nameview << "\n";
 
         // Loop through each of that vehicle's Machines
         auto const &machines = scene.reg_get<ACompMachines>(ent);
@@ -509,7 +510,10 @@ void debug_print_hier()
             // print arrows to indicate level
             std::cout << "  ->";
         }
-        std::cout << "[" << scene.get_registry().entity(currentEnt) << "]: " << hier.m_name << "\n";
+        auto const *name = scene.get_registry().try_get<osp::active::ACompName>(currentEnt);
+        std::string_view nameview = (name != nullptr) ? std::string_view(name->m_name) : "untitled";
+        std::cout << "[" << scene.get_registry().entity(currentEnt)
+                     << "]: " << nameview << "\n";
 
         if (hier.m_childCount != 0)
         {


### PR DESCRIPTION
This PR is mostly just clearing up a bit of technical debt by separating systems and components.

### Hierarchy changes

* Hierarchy functions are moved from ActiveScene to the new SysHierarchy
* ACompName was split off from ACompHierarchy

### Transform component changes

ACompTransform is now just a single Matrix4, as it was split into many other components:

* ACompTransformControlled - For components that are controlled by specific systems. (ie. entities with rigid bodies are fully controlled by physics)
* ACompTransformMutable - For controlled entities that allow their transform to be modified. (ie. to allow teleporting rigid bodies)
* ACompDrawTransform - Holds the world transform used only for drawing. These are only used for drawing. Also consider that this may be used for interpolation for rendering between physics frames.

### Deferred Delete System

Deleting entities right away (using `entt::basic_registry::destroy()`) can be problematic for future concurrency as it modifies every component pool the entity is associated with. To avoid any potential issues, the ACompDelete tag component was added. When added to entities, other systems can operate on them like destructors until it is fully deleted at the end of the frame.

Functions for deleting entities:
* `ActiveScene::mark_delete` adds the delete component to an entity
* `SysHierarchy::mark_delete_cut` Cuts an entity out of the hierarchy, then calls ActiveScene::mark_delete.

Two new systems:
* `SysHierarchy::update_delete` adds the ACompDelete component to the descendants of deleted hierarchy components. This allows any system to delete hierarchy entities while being decoupled from the hierarchy system.
* `ActiveScene::update_delete` finally deletes marked components at the end of the frame

These two are called directly in ActiveScene::update, as it's difficult to get FunctionOrder to put it at the end.

### Other changes

* Remove UserInputHandler from ActiveScene. Only UserControl needs it, so it's injected in flight.cpp instead.
* Add scene.h and drawing.h for components and similar data not bound to any particular system.

TODO: some more comments probably