### PR TITLE
Universe Updates and improved Active Area

### DIFF
--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -39,7 +39,7 @@ using osp::universe::UCompActiveArea;
 
 using osp::universe::Vector3g;
 
-void SysAreaAssociate::update_scan(ActiveScene& rScene)
+void SysAreaAssociate::update_clear(ActiveScene& rScene)
 {
     ACompAreaLink *pArea = try_get_area_link(rScene);
 
@@ -54,46 +54,8 @@ void SysAreaAssociate::update_scan(ActiveScene& rScene)
 
     // Clear enter/leave event vectors
 
-    pArea->m_enter.clear();
-    pArea->m_leave.clear();
-
-    // Deal with activating satellites that have a UCompActivationRadius
-    // Satellites that have an Activation Radius have a sphere around them. If
-    // this sphere overlaps the ActiveArea's sphere 'm_areaRadius', then it
-    // will be activated.
-
-    auto viewActRadius = rUni.get_reg().view<
-            UCompActivationRadius, UCompActivatable>();
-
-    for (Satellite sat : viewActRadius)
-    {
-        auto satRadius = viewActRadius.get<UCompActivationRadius>(sat);
-
-        // Check if already activated
-        auto found = pArea->m_inside.find(sat);
-        bool alreadyInside = (found != pArea->m_inside.end());
-
-        // Simple sphere-sphere-intersection check
-        float distanceSquared = rUni.sat_calc_pos_meters(areaSat, sat).dot();
-        float radius = areaUComp.m_areaRadius + satRadius.m_radius;
-
-        if ((radius * radius) > distanceSquared)
-        {
-            if (alreadyInside)
-            {
-                continue; // Satellite already activated
-            }
-            // Satellite is nearby, activate it!
-            auto entered = pArea->m_inside.emplace(sat, entt::null).first;
-            pArea->m_enter.emplace_back(entered);
-        }
-        else if (alreadyInside)
-        {
-            // Satellite exited area
-            pArea->m_leave.emplace_back(found->first, found->second);
-            pArea->m_inside.erase(found);
-        }
-    }
+    areaUComp.m_enter.clear();
+    areaUComp.m_leave.clear();
 }
 
 ACompAreaLink* SysAreaAssociate::try_get_area_link(ActiveScene &rScene)

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -57,7 +57,7 @@ void SysAreaAssociate::update_consume(ActiveScene& rScene)
 
     Vector3g deltaTotal{};
 
-    for (Vector3g const delta : std::exchange(rAreaUComp.m_moved, {}))
+    for (Vector3g const& delta : std::exchange(rAreaUComp.m_moved, {}))
     {
         deltaTotal += delta;
     }
@@ -93,7 +93,7 @@ void SysAreaAssociate::connect(ActiveScene& rScene, universe::Universe &rUni,
 
 }
 
-void SysAreaAssociate::area_move(ActiveScene& rScene, Vector3g translate)
+void SysAreaAssociate::area_move(ActiveScene& rScene, Vector3g const& translate)
 {
     ACompAreaLink *pArea = try_get_area_link(rScene);
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -120,7 +120,7 @@ public:
      * @param rScene    [ref] Scene assicated with ActiveArea
      * @param translate [in] Amount to translate the area by
      */
-    static void area_move(ActiveScene& rScene, universe::Vector3g translate);
+    static void area_move(ActiveScene& rScene, universe::Vector3g const& translate);
 
 private:
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -52,6 +52,11 @@ struct ACompAreaLink
 
     std::reference_wrapper<universe::Universe> m_rUniverse;
 
+    std::vector<universe::Satellite> m_enter;
+    std::vector<universe::Satellite> m_leave;
+
+    Vector3 m_move;
+
 };
 
 struct ACompActivatedSat
@@ -68,23 +73,35 @@ class SysAreaAssociate
 public:
 
     /**
-     * Clears queues in associazted UCompActiveArea
+     * @brief Consume data queued in the universe's UCompActiveArea to be used
+     *        by other active systems
      *
-     * @param rScene [in/out] Scene to update
+     * @param rScene [ref] Scene assicated with ActiveArea
      */
-    static void update_clear(ActiveScene& rScene);
+    static void update_consume(ActiveScene& rScene);
 
     /**
-     * Attempt to get an ACompAreaLink from an ActiveScene
+     * @brief Translates all entities with ACompFloatingOrigin based on
+     *        UCompActiveArea::m_moved read during update_consume
+     *
+     * @param rScene [ref] Scene assicated with ActiveArea
+     */
+    static void update_translate(ActiveScene& rScene);
+
+    /**
+     * @brief Attempt to get an ACompAreaLink from an ActiveScene
+     *
+     * @param rScene [ref] Scene assicated with ActiveArea
+     *
      * @return ACompAreaLink in scene, nullptr if not found
      */
     static ACompAreaLink* try_get_area_link(ActiveScene &rScene);
 
     /**
-     * Connect the ActiveScene to the Universe using the scene's ACompAreaLink,
-     * and a Satellite containing a UCompActiveArea.
+     * @brief Connect the ActiveScene to the Universe using the scene's
+     *        ACompAreaLink, and a Satellite containing a UCompActiveArea.
      *
-     * @param rScene  [in/out] Scene containing ACompAreaLink
+     * @param rScene  [ref] Scene assicated with ActiveArea
      * @param rUni    [ref] Universe the ActiveArea satellite is contained in.
      *                      This is stored in ACompAreaLink.
      * @param areaSat [in] ActiveArea Satellite
@@ -93,41 +110,30 @@ public:
                         universe::Satellite areaSat);
 
     /**
-     * Deactivate all Activated Satellites and cut ties with ActiveArea
-     * Satellite (TODO)
+     * @brief Request to move the ActiveArea
+     *
+     * These movements are queued and accumolated, as only the universe is
+     * allowed to directly move Satellites. Once the universe updates, and moves
+     * the area, it writes into UCompActiveArea::m_moved which is read by
+     * update_consume.
+     *
+     * @param rScene    [ref] Scene assicated with ActiveArea
+     * @param translate [in] Amount to translate the area by
      */
-    static void disconnect(ActiveScene& rScene);
-
-    /**
-     * Move the ActiveArea satellite, and translate everything in the
-     * ActiveScene, aka: floating origin translation
-     */
-    static void area_move(ActiveScene& rScene,
-                          osp::universe::Vector3g translate);
-
-    /**
-     * Set the transform of a Satellite based on a transform (in meters)
-     * Satellite.
-     * @param rUni        [in/out] Universe containing satellites
-     * @param relativeSat [in] Satellite that transform is relative to
-     * @param tgtSat      [in] Satellite to set transform of
-     * @param transform   [in] Transform to set
-     */
-    static void sat_transform_set_relative(
-            universe::Universe& rUni, universe::Satellite relativeSat,
-            universe::Satellite tgtSat, Matrix4 transform);
+    static void area_move(ActiveScene& rScene, universe::Vector3g translate);
 
 private:
 
 
     /**
-     * Translate all entities in an ActiveScene that contain an
-     * ACompFloatingOrigin
+     * @brief Translate all entities in an ActiveScene that contain an
+     *        ACompFloatingOrigin
      *
-     * @param rScene      [out] Scene containing entities that can be translated
+     * @param rScene      [ref] Scene containing entities that can be translated
      * @param translation [in] Meters to translate entities by
      */
-    static void floating_origin_translate(ActiveScene& rScene, Vector3 translation);
+    static void floating_origin_translate(ActiveScene& rScene,
+                                          Vector3 translation);
 
 };
 

--- a/src/osp/Active/SysAreaAssociate.h
+++ b/src/osp/Active/SysAreaAssociate.h
@@ -29,8 +29,6 @@
 
 #include "../Satellites/SatActiveArea.h"
 
-#include <unordered_map>
-
 #include <cstdint>
 
 namespace osp::active
@@ -38,9 +36,7 @@ namespace osp::active
 
 
 struct ACompAreaLink
-{
-    using MapSatToEnt_t = std::unordered_map<universe::Satellite, ActiveEnt>;
-
+{    
     ACompAreaLink(universe::Universe& rUniverse, universe::Satellite areaSat)
      : m_areaSat(areaSat)
      , m_rUniverse(rUniverse)
@@ -55,13 +51,6 @@ struct ACompAreaLink
     universe::Satellite m_areaSat;
 
     std::reference_wrapper<universe::Universe> m_rUniverse;
-
-    // Satellites that are currently inside the active area
-    // possibly replace with a single entt sparse_set in ACompAreaLink
-    MapSatToEnt_t m_inside;
-
-    std::vector<MapSatToEnt_t::iterator> m_enter;
-    std::vector<std::pair<universe::Satellite, ActiveEnt>> m_leave;
 
 };
 
@@ -79,12 +68,11 @@ class SysAreaAssociate
 public:
 
     /**
-     * Scans the universe for Satellites to activate or deactivate, tracking
-     * changes into a ACompAreaLink stored in the scene.
+     * Clears queues in associazted UCompActiveArea
      *
      * @param rScene [in/out] Scene to update
      */
-    static void update_scan(ActiveScene& rScene);
+    static void update_clear(ActiveScene& rScene);
 
     /**
      * Attempt to get an ACompAreaLink from an ActiveScene

--- a/src/osp/Active/SysVehicle.h
+++ b/src/osp/Active/SysVehicle.h
@@ -26,9 +26,6 @@
 
 #include "activetypes.h"
 
-#include "SysAreaAssociate.h"
-
-#include "../Universe.h"
 #include "../Resource/Package.h"
 #include "../Resource/blueprints.h"
 #include "osp/Active/SysMachine.h"
@@ -80,37 +77,12 @@ class SysVehicle
 {
 public:
 
-    static ActiveEnt activate(ActiveScene &rScene, universe::Universe &rUni,
-                              universe::Satellite areaSat,
-                              universe::Satellite tgtSat);
-
-    static void deactivate(ActiveScene &rScene, universe::Universe &rUni,
-                           universe::Satellite areaSat,
-                           universe::Satellite tgtSat, ActiveEnt tgtEnt);
-
-    /**
-     * Activate/Deactivate vehicles that enter/exit the ActiveArea
-     *
-     * Nearby vehicles are detected by SysAreaAssociate, and are added to a
-     * queue. This function reads the queue and activates vehicles accordingly.
-     * Activated vehicles will be in an incomplete "In-Construction" state so
-     * that individual features can be handled by separate systems.
-     *
-     * This function also update Satellites transforms of the currently
-     * activated vehicles in the scene
-     *
-     * @param rScene [ref] Scene containing vehicles to update
-     */
-    static void update_activate(ActiveScene& rScene);
-
     /**
      * Deal with vehicle separations and part deletions
      *
      * @param rScene [ref] Scene containing vehicles to update
      */
     static void update_vehicle_modification(ActiveScene& rScene);
-
-private:
 
     /**
      * Compute the volume of a part
@@ -138,7 +110,6 @@ private:
     static ActiveEnt part_instantiate(
             ActiveScene& rScene, PrototypePart const& part,
             BlueprintPart const& blueprint, ActiveEnt rootParent);
-
 };
 
 

--- a/src/osp/Active/SysVehicleSync.cpp
+++ b/src/osp/Active/SysVehicleSync.cpp
@@ -1,0 +1,203 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "SysVehicleSync.h"
+
+#include "ActiveScene.h"
+#include "SysAreaAssociate.h"
+#include "SysHierarchy.h"
+#include "SysPhysics.h"
+#include "SysVehicle.h"
+#include "drawing.h"
+
+#include "../Satellites/SatActiveArea.h"
+#include "../Satellites/SatVehicle.h"
+
+using namespace osp::active;
+
+using osp::universe::Universe;
+using osp::universe::Satellite;
+
+using osp::universe::UCompActiveArea;
+using osp::universe::UCompVehicle;
+
+// for the 0xrrggbb_rgbf literalsm
+using namespace Magnum::Math::Literals;
+
+ActiveEnt SysVehicleSync::activate(ActiveScene &rScene, Universe &rUni,
+                                   Satellite areaSat, Satellite tgtSat)
+{
+    SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
+                      "Loading a vehicle");
+
+    auto &loadMeVehicle = rUni.get_reg().get<universe::UCompVehicle>(tgtSat);
+    auto &tgtPosTraj = rUni.get_reg().get<universe::UCompTransformTraj>(tgtSat);
+
+    // make sure there is vehicle data to load
+    if (loadMeVehicle.m_blueprint.empty())
+    {
+        // no vehicle data to load
+        return entt::null;
+    }
+
+    BlueprintVehicle &vehicleData = *(loadMeVehicle.m_blueprint);
+    ActiveEnt root = rScene.hier_get_root();
+
+    // Create the root entity to add parts to
+
+    ActiveEnt vehicleEnt = SysHierarchy::create_child(rScene, root, "Vehicle");
+
+    rScene.reg_emplace<ACompActivatedSat>(vehicleEnt, tgtSat);
+
+    ACompVehicle& vehicleComp = rScene.reg_emplace<ACompVehicle>(vehicleEnt);
+    rScene.reg_emplace<ACompDrawTransform>(vehicleEnt);
+    rScene.reg_emplace<ACompVehicleInConstruction>(
+                    vehicleEnt, loadMeVehicle.m_blueprint);
+
+    // Convert position of the satellite to position in scene
+    Vector3 positionInScene = rUni.sat_calc_pos_meters(areaSat, tgtSat);
+
+    ACompTransform& rVehicleTransform = rScene.get_registry()
+                                        .emplace<ACompTransform>(vehicleEnt);
+    rVehicleTransform.m_transform
+            = Matrix4::from(tgtPosTraj.m_rotation.toMatrix(), positionInScene);
+    rScene.reg_emplace<ACompFloatingOrigin>(vehicleEnt);
+    //vehicleTransform.m_enableFloatingOrigin = true;
+
+    // Create the parts
+
+    // Unique part prototypes used in the vehicle
+
+    // Access with [blueprintParts.m_partIndex]
+
+    std::vector<DependRes<PrototypePart> >& partsUsed = vehicleData.m_prototypes;
+
+
+    // All the parts in the vehicle
+    std::vector<BlueprintPart> &blueprintParts = vehicleData.m_blueprints;
+
+
+    rScene.get_registry().reserve(rScene.get_registry().capacity()
+                                   + vehicleData.m_machines.size());
+
+    // Keep track of parts
+    //std::vector<ActiveEnt> newEntities;
+    vehicleComp.m_parts.reserve(blueprintParts.size());
+
+    // Loop through list of blueprint parts, and initialize each of them into
+    // the ActiveScene
+    for (BlueprintPart& partBp : blueprintParts)
+    {
+        DependRes<PrototypePart>& partDepends =
+                partsUsed[partBp.m_protoIndex];
+
+        // Check if the part prototype this depends on still exists
+        if (partDepends.empty())
+        {
+            return entt::null;
+        }
+
+        PrototypePart &proto = *partDepends;
+
+        // Instantiate the part
+        ActiveEnt partEntity = SysVehicle::part_instantiate(
+                    rScene, proto, partBp, vehicleEnt);
+
+        vehicleComp.m_parts.push_back(partEntity);
+
+        auto& partPart = rScene.reg_emplace<ACompPart>(partEntity);
+        partPart.m_vehicle = vehicleEnt;
+
+        // Part now exists
+
+        ACompTransform& partTransform = rScene.get_registry()
+                                            .get<ACompTransform>(partEntity);
+
+        // set the transformation
+        partTransform.m_transform
+                = Matrix4::from(partBp.m_rotation.toMatrix(),
+                              partBp.m_translation)
+                * Matrix4::scaling(partBp.m_scale);
+    }
+
+
+    // temporary: make the whole thing a single rigid body
+    auto& vehicleBody = rScene.reg_emplace<ACompRigidBody>(vehicleEnt);
+    rScene.reg_emplace<ACompShape>(vehicleEnt, phys::ECollisionShape::COMBINED);
+    rScene.reg_emplace<ACompSolidCollider>(vehicleEnt);
+
+    return vehicleEnt;
+}
+
+
+void SysVehicleSync::update_universe_sync(ActiveScene &rScene)
+{
+    ACompAreaLink *pLink = SysAreaAssociate::try_get_area_link(rScene);
+
+    if (pLink == nullptr)
+    {
+        return;
+    }
+
+    Universe &rUni = pLink->get_universe();
+    auto &rArea = rUni.get_reg().get<UCompActiveArea>(pLink->m_areaSat);
+    auto &rSync = rScene.get_registry().ctx<SyncVehicles>();
+
+    // Delete vehicles that have gone too far from the ActiveArea range
+    for (Satellite sat : rArea.m_leave)
+    {
+        if (!rUni.get_reg().all_of<UCompVehicle>(sat))
+        {
+            continue;
+        }
+
+        auto foundEnt = rSync.m_inArea.find(sat);
+        SysHierarchy::mark_delete_cut(rScene, foundEnt->second);
+        rSync.m_inArea.erase(foundEnt);
+    }
+
+    // Update transforms of already-activated vehicle satellites
+    auto view = rScene.get_registry().view<ACompVehicle, ACompTransform,
+                                           ACompActivatedSat>();
+    for (ActiveEnt vehicleEnt : view)
+    {
+        auto &vehicleTf = view.get<ACompTransform>(vehicleEnt);
+        auto &vehicleSat = view.get<ACompActivatedSat>(vehicleEnt);
+        SysAreaAssociate::sat_transform_set_relative(
+            rUni, pLink->m_areaSat, vehicleSat.m_sat, vehicleTf.m_transform);
+    }
+
+    // Activate nearby vehicle satellites that have just entered the ActiveArea
+    for (Satellite sat : rArea.m_enter)
+    {
+        if (!rUni.get_reg().all_of<UCompVehicle>(sat))
+        {
+            continue;
+        }
+
+        ActiveEnt ent = activate(rScene, rUni, pLink->m_areaSat, sat);
+        rSync.m_inArea[sat] = ent;
+    }
+}

--- a/src/osp/Active/SysVehicleSync.h
+++ b/src/osp/Active/SysVehicleSync.h
@@ -1,0 +1,65 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "universe_sync.h"
+
+namespace osp::active
+{
+
+struct SyncVehicles
+{
+    MapSatToEnt_t m_inArea;
+};
+
+class SysVehicleSync
+{
+public:
+
+    static ActiveEnt activate(ActiveScene &rScene, universe::Universe &rUni,
+                              universe::Satellite areaSat,
+                              universe::Satellite tgtSat);
+
+    static void deactivate(ActiveScene &rScene, universe::Universe &rUni,
+                           universe::Satellite areaSat,
+                           universe::Satellite tgtSat, ActiveEnt tgtEnt);
+
+    /**
+     * Activate/Deactivate vehicles that enter/exit the ActiveArea
+     *
+     * Nearby vehicles are detected by SysAreaAssociate, and are added to a
+     * queue. This function reads the queue and activates vehicles accordingly.
+     * Activated vehicles will be in an incomplete "In-Construction" state so
+     * that individual features can be handled by separate systems.
+     *
+     * This function also update Satellites transforms of the currently
+     * activated vehicles in the scene
+     *
+     * @param rScene [ref] Scene containing vehicles to update
+     */
+    static void update_universe_sync(ActiveScene& rScene);
+};
+
+}

--- a/src/osp/Active/universe_sync.h
+++ b/src/osp/Active/universe_sync.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -22,20 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #pragma once
 
-#include "common.h"
+#include "../Universe.h"
+#include "activetypes.h"
 
-namespace testapp::simplesolarsystem
-{
+#include <unordered_map>
 
-/**
- * @brief Create a universe with a few unrealistically small planets and some
- *        vehicles
- *
- * @param ospApp [ref] OSP Application to create universe in
- */
-void create(osp::OSPApplication& rOspApp);
-
-}
+using MapSatToEnt_t = std::unordered_map<osp::universe::Satellite,
+                                         osp::active::ActiveEnt>;

--- a/src/osp/CommonMath.h
+++ b/src/osp/CommonMath.h
@@ -24,25 +24,53 @@
  */
 #pragma once
 
-#include "types.h"
+
+#include <cstdint>
 #include <type_traits>
 
 namespace osp::math
 {
 
-template <typename UINT_T>
-constexpr UINT_T uint_2pow(UINT_T exponent)
+/**
+ * @return Integer 2^exponent
+ */
+template <typename INT_T>
+constexpr INT_T int_2pow(int exponent)
 {
-    static_assert(std::is_integral<UINT_T>::value, "Unsigned int required");
-    return UINT_T(1) << exponent;
+    static_assert(std::is_integral<INT_T>::value, "Integer required");
+    return INT_T(1) << exponent;
 }
 
-template <typename UINT_T>
-constexpr bool is_power_of_2(UINT_T value)
+/**
+ * @return true if value is power of two
+ */
+template <typename INT_T>
+constexpr bool is_power_of_2(INT_T value)
 {
-    static_assert(std::is_integral<UINT_T>::value, "Unsigned int required");
+    static_assert(std::is_integral<INT_T>::value, "Integer required");
     // Test to see if the value contains more than 1 set bit
     return !(value == 0) && !(value & (value - 1));
+}
+
+/**
+ * @brief Multiply a type by a power of two, allowing negative exponents
+ *
+ * @param value    [in] Value to multiply
+ * @param exponent [in] Exponent to raise (or lower) 2 by
+ *
+ * @tparam T     Type to multiply
+ * @tparam INT_T Integer type the power of two will be calculated in
+ *
+ * @return value multiplied by 2^exponent
+ */
+template <typename T, typename INT_T>
+constexpr T mul_2pow(T value, int exponent) noexcept
+{
+    // Multiply by power of two if exponent is positive
+    // Divide by power of two if exponent is negative
+    // exponent = 0 will multiply by 1
+    return (exponent >= 0) ? (value * int_2pow<INT_T>(exponent))
+                          : (value / int_2pow<INT_T>(-exponent));
 }
 
 } // namespace osp::math

--- a/src/osp/CoordinateSpaces/CartesianSimple.cpp
+++ b/src/osp/CoordinateSpaces/CartesianSimple.cpp
@@ -39,8 +39,8 @@ void CoordspaceCartesianSimple::update_exchange(
 
     // Sort in descending order. If any of these are the last element, then
     // then they may get invalidated in the following swaps.
-    sort(std::begin(rSpace.m_toRemove), std::end(rSpace.m_toRemove),
-         std::greater<uint32_t>());
+    std::sort(std::begin(rSpace.m_toRemove), std::end(rSpace.m_toRemove),
+              std::greater<uint32_t>());
 
     // Remove using swap-and-pop
     for (uint32_t index : rSpace.m_toRemove)

--- a/src/osp/OSPApplication.h
+++ b/src/osp/OSPApplication.h
@@ -64,13 +64,20 @@ public:
 
     universe::Universe& get_universe() { return m_universe; }
 
-    const std::shared_ptr<spdlog::logger>& get_logger() { return m_logger; };
+    void set_universe_update(std::function<void(universe::Universe&)> func)
+    {
+        m_universeUpdate = func;
+    }
 
-    std::function<void(universe::Universe&)> m_universeUpdate;
+    void update_universe() { m_universeUpdate(m_universe); };
+
+    const std::shared_ptr<spdlog::logger>& get_logger() { return m_logger; };
 
 private:
     std::map<ResPrefix_t, Package, std::less<>> m_packages;
+
     universe::Universe m_universe;
+    std::function<void(universe::Universe&)> m_universeUpdate;
 
     const std::shared_ptr<spdlog::logger> m_logger;
 };

--- a/src/osp/Satellites/SatActiveArea.cpp
+++ b/src/osp/Satellites/SatActiveArea.cpp
@@ -45,7 +45,7 @@ void SatActiveArea::move(Universe& rUni, Satellite areaSat)
 
     std::vector<Vector3g> const toMove = std::exchange(rArea.m_requestMove, {});
 
-    for (Vector3g delta: toMove)
+    for (Vector3g const& delta: toMove)
     {
         rPos += delta;
         rArea.m_moved.push_back(delta);
@@ -64,16 +64,17 @@ void SatActiveArea::scan_radius(Universe& rUni, Satellite areaSat)
     auto viewActRadius = rUni.get_reg().view<UCompActivationRadius,
                                              UCompActivatable>();
 
-    for (Satellite sat : viewActRadius)
+    for (Satellite const sat : viewActRadius)
     {
-        auto satRadius = viewActRadius.get<UCompActivationRadius>(sat);
+        auto const satRadius = viewActRadius.get<UCompActivationRadius>(sat);
 
         // Check if already activated
         bool alreadyInside = rArea.m_inside.contains(sat);
 
         // Simple sphere-sphere-intersection check
-        float distanceSquared = rUni.sat_calc_pos_meters(areaSat, sat).value().dot();
-        float radius = rArea.m_areaRadius + satRadius.m_radius;
+        float const distanceSquared
+                        = rUni.sat_calc_pos_meters(areaSat, sat).value().dot();
+        float const radius = rArea.m_areaRadius + satRadius.m_radius;
 
         if ((radius * radius) > distanceSquared)
         {

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -70,8 +70,17 @@ struct UCompActiveArea
 {
     float m_areaRadius{ 1024.0f };
 
-    // true when the ActiveArea is moving
-    bool m_inMotion{false};
+    entt::basic_sparse_set<Satellite> m_inside;
+
+    coordspace_index_t m_coordSpace;
+
+    // capture satellite
+    // new satellite
+    //std::vector<Satellite> ;
+
+    // Output queues
+    std::vector<Satellite> m_enter;
+    std::vector<Satellite> m_leave;
 };
 
 
@@ -81,8 +90,11 @@ public:
 
     static constexpr std::string_view smc_name = "ActiveArea";
 
+    static void scan(osp::universe::Universe& rUni, Satellite areaSat);
+
     /**
-     * Set the type of a Satellite and add a UCompActiveArea to it
+     * @brief Set the type of a Satellite and add a UCompActiveArea to it
+     *
      * @param rUni [out] Universe containing satellite
      * @param sat  [in] Satellite add a UCompActiveArea to
      * @return Reference to UCompActiveArea created

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -78,6 +78,11 @@ struct UCompActiveArea
 
     coordspace_index_t m_captureSpace;
 
+    coordspace_index_t m_releaseSpace;
+
+    // maybe have multiple release coordspaces with priorities?
+    //std::vector<coordspace_index_t> m_releaseSpaces;
+
     // Input queues
     std::vector<Vector3g> m_requestMove;
 
@@ -121,7 +126,7 @@ public:
     static void scan_radius(Universe& rUni, Satellite areaSat);
 
     /**
-     * @brief Request to move a Satellites into the ActiveArea's 'capture'
+     * @brief Request to move Satellites into the ActiveArea's 'capture'
      *        coordinate space.
      *
      * This will give the ActiveArea full control over the Satellite's
@@ -133,6 +138,14 @@ public:
      */
     static void capture(Universe& rUni, Satellite areaSat,
                         Corrade::Containers::ArrayView<Satellite> toCapture);
+
+    /**
+     * @brief Update positions of captured objects
+     *
+     * @param rUni    [ref] Universe containing ActiveArea satellite
+     * @param capture [in] Index to capture coordinate space
+     */
+    static void update_capture(Universe& rUni, coordspace_index_t capture);
 };
 
 }

--- a/src/osp/Satellites/SatVehicle.h
+++ b/src/osp/Satellites/SatVehicle.h
@@ -56,6 +56,9 @@ public:
     static UCompVehicle& add_vehicle(
         osp::universe::Universe& rUni, osp::universe::Satellite sat,
         DependRes<BlueprintVehicle> blueprint);
+
+
+
 };
 
 }

--- a/src/osp/Satellites/SatVehicle.h
+++ b/src/osp/Satellites/SatVehicle.h
@@ -56,9 +56,6 @@ public:
     static UCompVehicle& add_vehicle(
         osp::universe::Universe& rUni, osp::universe::Satellite sat,
         DependRes<BlueprintVehicle> blueprint);
-
-
-
 };
 
 }

--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -64,24 +64,19 @@ Vector3g Universe::sat_calc_pos(Satellite referenceFrame, Satellite target) cons
     auto const &targetCoordIndex
             = viewCoordIndex.get<const UCompCoordspaceIndex>(target);
 
-    if (frameInCoord.m_coordSpace == targetInCoord.m_coordSpace)
+    CoordinateSpace const& frameCoord = coordspace_get(frameInCoord.m_coordSpace);
+    CoordinateSpace const& targetCoord = coordspace_get(targetInCoord.m_coordSpace);
+
+    if (frameCoord.m_parentSat == targetCoord.m_parentSat)
     {
-        // Both Satellites are in the same coordinate system
+        // Both Satellites are positioned relative to the same Satellite
+        // TODO: deal with varrying precisions and possibly rotation
 
-        std::optional<CoordinateSpace> const &rSpace
-                = m_coordSpaces.at(frameInCoord.m_coordSpace);
+        auto frameView = frameCoord.ccomp_view_tuple<CCompX, CCompY, CCompZ>();
+        auto targetView = targetCoord.ccomp_view_tuple<CCompX, CCompY, CCompZ>();
 
-        ViewCComp_t<CCompX> const& viewX = rSpace->ccomp_view<CCompX>();
-        ViewCComp_t<CCompY> const& viewY = rSpace->ccomp_view<CCompY>();
-        ViewCComp_t<CCompZ> const& viewZ = rSpace->ccomp_view<CCompZ>();
-
-        Vector3g const pos{
-            viewX[targetCoordIndex.m_myIndex] - viewX[frameCoordIndex.m_myIndex],
-            viewY[targetCoordIndex.m_myIndex] - viewY[frameCoordIndex.m_myIndex],
-            viewZ[targetCoordIndex.m_myIndex] - viewZ[frameCoordIndex.m_myIndex],
-        };
-
-        return pos;
+        return targetView->as<Vector3g>(targetCoordIndex.m_myIndex)
+                - frameView->as<Vector3g>(frameCoordIndex.m_myIndex);
     }
 
     // TODO: calculation for positions across different coordinate spaces
@@ -95,12 +90,75 @@ Vector3 Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target
     return Vector3(sat_calc_pos(referenceFrame, target)) / gc_units_per_meter;
 }
 
-std::pair<coordspace_index_t, CoordinateSpace&> Universe::coordspace_create()
+std::pair<coordspace_index_t, CoordinateSpace&> Universe::coordspace_create(Satellite parentSat)
 {
     coordspace_index_t const index = m_coordSpaces.size();
-    return {index, *m_coordSpaces.emplace_back(CoordinateSpace{})};
+    std::optional<CoordinateSpace>& rCoord = m_coordSpaces.emplace_back();
+    rCoord.emplace(parentSat);
+    return {index, *rCoord};
 
     // TODO: find deleted spaces instead of emplacing back each time
+}
+
+
+std::optional<CoordspaceTransform> Universe::coordspace_transform(
+        CoordinateSpace const &fromCoord, CoordinateSpace const &toCoord)
+{
+
+    auto get_parent = [this] (CoordinateSpace const* current) -> CoordinateSpace*
+    {
+        coordspace_index_t const parent = m_registry.get<UCompInCoordspace>(current->m_parentSat).m_coordSpace;
+        return &coordspace_get(parent);
+    };
+
+    auto get_pos = [this] (CoordinateSpace const* current, CoordinateSpace const* parent) -> Vector3g
+    {
+        uint32_t const index = m_registry.get<UCompCoordspaceIndex>(current->m_parentSat).m_myIndex;
+        auto const posTuple = parent->ccomp_view_tuple<CCompX, CCompY, CCompZ>();
+        return posTuple->as<Vector3g>(index);
+    };
+
+    CoordspaceTransform fromTransform;
+    CoordspaceTransform toTransform;
+
+    CoordinateSpace const *currentFrom = &fromCoord;
+    CoordinateSpace const *currentTo = &toCoord;
+
+    // Current depth to check for a common satellite
+    int16_t testDepth = std::min({fromCoord.m_depth, toCoord.m_depth});
+
+    while (true)
+    {
+        while (currentFrom->m_depth > testDepth)
+        {
+            CoordinateSpace const *parent = get_parent(currentFrom);
+            // a->b(x);   b->c(x);   a->c(x) = b->c(a->b(x))
+            fromTransform = transform::child_to_parent(get_pos(currentFrom, parent), currentFrom->m_pow2scale, parent->m_pow2scale)(fromTransform);
+            currentFrom = parent;
+        }
+
+        while (currentTo->m_depth > testDepth)
+        {
+            CoordinateSpace const *parent = get_parent(currentTo);
+            // b->a(x);   c->b(x);   c->a(x) = b->a(c->b(x))
+            toTransform = transform::parent_to_child(get_pos(currentTo, parent), currentTo->m_pow2scale, parent->m_pow2scale)(toTransform);
+            currentTo = parent;
+        }
+
+        if (currentFrom->m_parentSat == currentTo->m_parentSat)
+        {
+            // Common ancestor found
+            return transform::scaled(toTransform(fromTransform), currentFrom->m_pow2scale, currentTo->m_pow2scale);
+        }
+        else
+        {
+            if (testDepth == 0)
+            {
+                return std::nullopt;
+            }
+            testDepth --;
+        }
+    }
 }
 
 void Universe::coordspace_update_sats(uint32_t coordSpace)
@@ -112,5 +170,21 @@ void Universe::coordspace_update_sats(uint32_t coordSpace)
         auto &rInCoordspace = view.get<UCompInCoordspace>(sat);
         rInCoordspace.m_coordSpace = coordSpace;
     }
+}
+
+void Universe::coordspace_update_depth(coordspace_index_t coordSpace)
+{
+    CoordinateSpace &rCoord = coordspace_get(coordSpace);
+
+    coordspace_index_t parentCoord = m_registry.get<UCompInCoordspace>(
+                rCoord.m_parentSat).m_coordSpace;
+
+    if (entt::null == parentCoord)
+    {
+        rCoord.m_depth = 0;
+        return;
+    }
+
+    rCoord.m_depth = coordspace_get(parentCoord).m_depth + 1;
 }
 

--- a/src/osp/Universe.cpp
+++ b/src/osp/Universe.cpp
@@ -78,9 +78,12 @@ std::optional<Vector3g> Universe::sat_calc_pos(Satellite referenceFrame, Satelli
     auto targetPos = targetCoord.ccomp_view_tuple<CCompX, CCompY, CCompZ>();
 
     Vector3g targetPosTf = transform.value()(
-                targetPos->as<Vector3g>(targetCoordIndex.m_myIndex));
+                make_from_ccomp<Vector3g>(*targetPos,
+                                          targetCoordIndex.m_myIndex));
 
-    return targetPosTf - framePos->as<Vector3g>(frameCoordIndex.m_myIndex);
+
+    return targetPosTf - make_from_ccomp<Vector3g>(*framePos,
+                                                   frameCoordIndex.m_myIndex);
 }
 
 std::optional<Vector3> Universe::sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const
@@ -121,7 +124,7 @@ std::optional<CoordspaceTransform> Universe::coordspace_transform(
     {
         uint32_t const index = m_registry.get<UCompCoordspaceIndex>(current->m_parentSat).m_myIndex;
         auto const posTuple = parent->ccomp_view_tuple<CCompX, CCompY, CCompZ>();
-        return posTuple->as<Vector3g>(index);
+        return make_from_ccomp<Vector3g>(*posTuple, index);
     };
 
     CoordspaceTransform fromTransform;

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -124,6 +124,11 @@ public:
         return m_coordSpaces.at(coordSpace).value();
     }
 
+    void coordspace_clear()
+    {
+        m_coordSpaces.clear();
+    };
+
     /**
      * @brief Ressign indices in the UCompInCoordspace components of satellites
      *        in a CoordinateSpace's m_toAdd queue

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -87,22 +87,28 @@ public:
     void sat_remove(Satellite sat);
 
     /**
-     * @brief Calculate position between two satellites.
+     * @brief Calculate position between two satellites; works between
+     *        coordinate spaces.
+     *
+     * This function is rather inefficient and only calculates for ONE
+     * satellite. Avoid using this for hot code.
      *
      * @param referenceFrame [in] Satellite used as reference frame
      * @param target         [in] Satellite to calculate position to
+     *
      * @return relative position of target in spaceint_t vector
      */
-    Vector3g sat_calc_pos(Satellite referenceFrame, Satellite target) const;
+    std::optional<Vector3g> sat_calc_pos(
+            Satellite referenceFrame, Satellite target) const;
 
     /**
-     * @brief Calculate position between two satellites.
+     * @brief Calls sat_calc_pos, and converts results to meters
      *
      * @param referenceFrame [in] Satellite used as reference frame
      * @param target         [in] Satellite to calculate position to
      * @return relative position of target in meters
      */
-    Vector3 sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const;
+    std::optional<Vector3> sat_calc_pos_meters(Satellite referenceFrame, Satellite target) const;
 
     /**
      * @brief Create a coordinate space
@@ -141,7 +147,7 @@ public:
      * @return Optional CoordspaceTransform. Empty if no common ancestor.
      */
     std::optional<CoordspaceTransform> coordspace_transform(
-            CoordinateSpace const &coordFrom, CoordinateSpace const &coordTo);
+            CoordinateSpace const &coordFrom, CoordinateSpace const &coordTo) const;
 
     /**
      * @brief Reassign indices in the UCompInCoordspace components of satellites

--- a/src/osp/Universe.h
+++ b/src/osp/Universe.h
@@ -112,7 +112,7 @@ public:
      *
      * @return {Index to coordinate space, Reference to coordinate space}
      */
-    std::pair<coordspace_index_t, CoordinateSpace&> coordspace_create();
+    std::pair<coordspace_index_t, CoordinateSpace&> coordspace_create(Satellite parentSat);
 
     CoordinateSpace& coordspace_get(coordspace_index_t coordSpace)
     {
@@ -130,12 +130,34 @@ public:
     };
 
     /**
-     * @brief Ressign indices in the UCompInCoordspace components of satellites
+     * @brief Calculate a CoordspaceTransform to transform coordinates from one
+     *        coordinate space to another.
+     *
+     * This function will chain together parent->child and child->parent
+     * transforms until a common ancestor is found.
+     *
+     * @param coordFrom [in]
+     * @param coordTo   [in]
+     * @return Optional CoordspaceTransform. Empty if no common ancestor.
+     */
+    std::optional<CoordspaceTransform> coordspace_transform(
+            CoordinateSpace const &coordFrom, CoordinateSpace const &coordTo);
+
+    /**
+     * @brief Reassign indices in the UCompInCoordspace components of satellites
      *        in a CoordinateSpace's m_toAdd queue
      *
      * @param coordSpace [in] Index to CoordinateSpace in m_coordSpaces
      */
     void coordspace_update_sats(coordspace_index_t coordSpace);
+
+    /**
+     * @brief Update m_depth of coordinate space based on the m_depth of its
+     *        parent
+     *
+     * @param coordSpace [in] Index to CoordinateSpace in m_coordSpaces
+     */
+    void coordspace_update_depth(coordspace_index_t coordSpace);
 
     constexpr Reg_t& get_reg() noexcept { return m_registry; }
     constexpr const Reg_t& get_reg() const noexcept

--- a/src/osp/coordinates.h
+++ b/src/osp/coordinates.h
@@ -113,7 +113,7 @@ struct CoordinateSpace
 
     using CmdValue_t = std::variant<CmdPosition, CmdVelocity>;
 
-    using Command_t = std::tuple<ECmdOp, CmdValue_t>;
+    struct Command { Satellite m_sat; ECmdOp m_op; CmdValue_t m_value; };
 
     CoordinateSpace(Satellite parentSat) : m_parentSat(parentSat) { }
 
@@ -150,7 +150,7 @@ struct CoordinateSpace
      *
      * @param cmd
      */
-    void command(Command_t cmd)
+    void command(Command cmd)
     {
         m_commands.emplace_back(std::move(cmd));
     }
@@ -202,7 +202,7 @@ struct CoordinateSpace
     // Queues for systems to communicate
     std::vector<SatToAdd_t> m_toAdd;
     std::vector<uint32_t> m_toRemove;
-    std::vector<Command_t> m_commands;
+    std::vector<Command> m_commands;
 
     // Data and component views are managed by the external system
     // m_data is usually something like CoordspaceCartesianSimple

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -92,7 +92,7 @@ ActiveEnt SysPlanetA::activate(
     auto &loadMePlanet = rUni.get_reg().get<universe::UCompPlanet>(tgtSat);
 
     // Convert position of the satellite to position in scene
-    Vector3 positionInScene = rUni.sat_calc_pos_meters(areaSat, tgtSat);
+    Vector3 positionInScene = rUni.sat_calc_pos_meters(areaSat, tgtSat).value();
 
     // Create planet entity and add components to it
 

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -151,19 +151,18 @@ void SysPlanetA::update_activate(ActiveScene &rScene)
 {
     using osp::universe::UCompActiveArea;
 
-    ACompAreaLink *pArea = SysAreaAssociate::try_get_area_link(rScene);
+    ACompAreaLink *pLink = SysAreaAssociate::try_get_area_link(rScene);
 
-    if (pArea == nullptr)
+    if (pLink == nullptr)
     {
         return;
     }
 
-    Universe &rUni = pArea->get_universe();
-    auto &rArea = rUni.get_reg().get<UCompActiveArea>(pArea->m_areaSat);
+    Universe &rUni = pLink->get_universe();
     auto &rSync = rScene.get_registry().ctx<SyncPlanets>();
 
     // Delete planets that have exited the ActiveArea
-    for (Satellite sat : rArea.m_leave)
+    for (Satellite sat : pLink->m_leave)
     {
         if (!rUni.get_reg().all_of<UCompPlanet>(sat))
         {
@@ -176,14 +175,14 @@ void SysPlanetA::update_activate(ActiveScene &rScene)
     }
 
     // Activate planets that have just entered the ActiveArea
-    for (Satellite sat : rArea.m_enter)
+    for (Satellite sat : pLink->m_enter)
     {
         if (!rUni.get_reg().all_of<UCompPlanet>(sat))
         {
             continue;
         }
 
-        ActiveEnt ent = activate(rScene, rUni, pArea->m_areaSat, sat);
+        ActiveEnt ent = activate(rScene, rUni, pLink->m_areaSat, sat);
         rSync.m_inArea[sat] = ent;
     }
 }

--- a/src/planet-a/Active/SysPlanetA.h
+++ b/src/planet-a/Active/SysPlanetA.h
@@ -31,12 +31,18 @@
 #include <osp/Active/SysForceFields.h>
 #include <osp/Active/activetypes.h>
 
+#include <osp/Active/universe_sync.h>
+
 #include <Magnum/Shaders/MeshVisualizer.h>
 #include <Magnum/GL/Mesh.h>
 
-
 namespace planeta::active
 {
+
+struct SyncPlanets
+{
+    MapSatToEnt_t m_inArea;
+};
 
 struct ACompPlanet
 {

--- a/src/planet-a/Satellites/SatPlanet.cpp
+++ b/src/planet-a/Satellites/SatPlanet.cpp
@@ -35,10 +35,8 @@ using planeta::universe::SatPlanet;
 
 UCompPlanet& SatPlanet::add_planet(
         osp::universe::Universe& rUni, Satellite sat, double radius, float mass,
-        float resolutionSurfaceMax, float resolutionScreenMax)
+        float activateRadius, float resolutionSurfaceMax, float resolutionScreenMax)
 {
-
-    float activateRadius = float(radius) * 256.0f;
 
     rUni.get_reg().emplace<UCompActivatable>(sat);
     rUni.get_reg().emplace<UCompActivationRadius>(sat, activateRadius);

--- a/src/planet-a/Satellites/SatPlanet.h
+++ b/src/planet-a/Satellites/SatPlanet.h
@@ -70,14 +70,15 @@ public:
      * @param sat                  [in] Satellite add a planet to
      * @param radius               [in] Radius of planet in meters
      * @param mass                 [in] Mass of planet in kg
+     * @param activateRadius       [in] Activation radius
      * @param resolutionSurfaceMax [in] See UCompPlanet definition
      * @param resolutionScreenMax  [in] See UCompPlanet definition
      * @return Reference to new UCompPlanet added
      */
     static UCompPlanet& add_planet(
         osp::universe::Universe& rUni, osp::universe::Satellite sat,
-        double radius, float mass, float resolutionSurfaceMax,
-        float resolutionScreenMax);
+        double radius, float mass, float activateRadius,
+        float resolutionSurfaceMax, float resolutionScreenMax);
 };
 
 }

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -55,7 +55,7 @@ OSPMagnum::OSPMagnum(const Magnum::Platform::Application::Arguments& arguments,
             arguments,
             Configuration{}.setTitle("OSP-Magnum").setSize({1280, 720})},
         m_userInput(12),
-        m_ospApp(rOspApp)
+        m_rOspApp(rOspApp)
 {
     //.setWindowFlags(Configuration::WindowFlag::Hidden)
 
@@ -73,6 +73,8 @@ void OSPMagnum::drawEvent()
 
     Magnum::GL::defaultFramebuffer.clear(Magnum::GL::FramebufferClear::Color
                                          | Magnum::GL::FramebufferClear::Depth);
+
+    m_rOspApp.update_universe();
 
     m_userInput.update_controls();
 
@@ -140,7 +142,7 @@ osp::active::ActiveScene& OSPMagnum::scene_create(std::string const& name, Scene
 {
     auto const& [it, success] =
         m_scenes.try_emplace(
-            name, osp::active::ActiveScene{m_ospApp, m_glResources}, upd);
+            name, osp::active::ActiveScene{m_rOspApp, m_glResources}, upd);
     return it->second.first;
 }
 
@@ -149,7 +151,7 @@ osp::active::ActiveScene& OSPMagnum::scene_create(std::string && name, SceneUpda
     auto const& [it, success] =
         m_scenes.try_emplace(
             std::move(name),
-            osp::active::ActiveScene{m_ospApp, m_glResources}, upd);
+            osp::active::ActiveScene{m_rOspApp, m_glResources}, upd);
     return it->second.first;
 }
 

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -92,7 +92,7 @@ private:
 
     Magnum::Timeline m_timeline;
 
-    osp::OSPApplication& m_ospApp;
+    osp::OSPApplication& m_rOspApp;
 };
 
 void config_controls(OSPMagnum& rOspApp);

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -123,11 +123,11 @@ int main(int argc, char** argv)
     {
         if(args.value("scene") == "simple")
         {
-            create_simple_solar_system(g_osp);
+            simplesolarsystem::create(g_osp);
         }
         else if(args.value("scene") == "moon")
         {
-            create_real_moon(g_osp);
+            moon::create(g_osp);
         }
         else
         {
@@ -180,14 +180,14 @@ int debug_cli_loop()
         {
             if (destroy_universe())
             {
-                create_simple_solar_system(g_osp);
+                simplesolarsystem::create(g_osp);
             }
         }
         else if (command == "moon")
         {
             if (destroy_universe())
             {
-                create_real_moon(g_osp);
+                moon::create(g_osp);
             }
         }
         else if (command == "flight")
@@ -247,6 +247,8 @@ bool destroy_universe()
 
     // Destroy all satellites
     g_osp.get_universe().get_reg().clear();
+
+    g_osp.get_universe().coordspace_clear();
 
     // Destroy blueprints as part of destroying all vehicles
     g_osp.debug_find_package("lzdb").clear<osp::BlueprintVehicle>();

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -543,15 +543,6 @@ void debug_print_sats()
         auto const &inCoord = rReg.get<const UCompInCoordspace>(sat);
         auto const &coordIndex = rReg.get<const UCompCoordspaceIndex>(sat);
 
-        CoordinateSpace const &rSpace
-                = rUni.coordspace_get(inCoord.m_coordSpace);
-
-        osp::universe::Vector3g const pos{
-            rSpace.ccomp_view<osp::universe::CCompX>()[coordIndex.m_myIndex],
-            rSpace.ccomp_view<osp::universe::CCompY>()[coordIndex.m_myIndex],
-            rSpace.ccomp_view<osp::universe::CCompZ>()[coordIndex.m_myIndex]
-        };
-
         std::cout << "* SATELLITE: \"" << posTraj.m_name << "\"\n";
 
         rReg.visit(sat, [&rReg] (entt::type_info info) {
@@ -559,11 +550,23 @@ void debug_print_sats()
             std::cout << "  * UComp: " << storage->value_type().name() << "\n";
         });
 
-        auto posM = osp::Vector3(pos) / 1024.0f;
-        std::cout << "  * Position: ["
-                  << pos.x() << ", " << pos.y() << ", " << pos.z() << "], ["
-                  << posM.x() << ", " << posM.y() << ", " << posM.z()
-                  << "] meters\n";
+        if (inCoord.m_coordSpace != entt::null)
+        {
+            CoordinateSpace const &rSpace
+                    = rUni.coordspace_get(inCoord.m_coordSpace);
+
+            auto viewPos = rSpace.ccomp_view_tuple<osp::universe::CCompX,
+                                                     osp::universe::CCompY,
+                                                     osp::universe::CCompZ>();
+
+            auto const pos = viewPos->as<osp::universe::Vector3g>(coordIndex.m_myIndex);
+
+            auto posM = osp::Vector3(pos) / 1024.0f;
+            std::cout << "  * Position: ["
+                      << pos.x() << ", " << pos.y() << ", " << pos.z() << "], ["
+                      << posM.x() << ", " << posM.y() << ", " << posM.z()
+                      << "] meters in coordspace " << inCoord.m_coordSpace << "\n";
+        }
     });
 
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -527,11 +527,7 @@ void debug_print_hier()
 
 void debug_print_sats()
 {
-    using osp::universe::Universe;
-    using osp::universe::UCompTransformTraj;
-    using osp::universe::UCompInCoordspace;
-    using osp::universe::UCompCoordspaceIndex;
-    using osp::universe::CoordinateSpace;
+    using namespace osp::universe;
 
     Universe const &rUni = g_osp.get_universe();
 
@@ -555,11 +551,9 @@ void debug_print_sats()
             CoordinateSpace const &rSpace
                     = rUni.coordspace_get(inCoord.m_coordSpace);
 
-            auto viewPos = rSpace.ccomp_view_tuple<osp::universe::CCompX,
-                                                     osp::universe::CCompY,
-                                                     osp::universe::CCompZ>();
+            auto viewPos = rSpace.ccomp_view_tuple<CCompX, CCompY, CCompZ>();
 
-            auto const pos = viewPos->as<osp::universe::Vector3g>(coordIndex.m_myIndex);
+            auto const pos = make_from_ccomp<Vector3g>(*viewPos, coordIndex.m_myIndex);
 
             auto posM = osp::Vector3(pos) / 1024.0f;
             std::cout << "  * Position: ["

--- a/src/test_application/universes/common.cpp
+++ b/src/test_application/universes/common.cpp
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -23,19 +23,43 @@
  * SOFTWARE.
  */
 
-#pragma once
-
 #include "common.h"
 
-namespace testapp::simplesolarsystem
+#include <osp/CoordinateSpaces/CartesianSimple.h>
+#include <osp/Satellites/SatActiveArea.h>
+
+
+using namespace testapp;
+
+using osp::universe::Universe;
+
+using osp::universe::SatActiveArea;
+using osp::universe::UCompActiveArea;
+
+using osp::universe::CoordinateSpace;
+using osp::universe::CoordspaceCartesianSimple;
+
+std::function<void(Universe&)> testapp::generate_simple_universe_update(
+        osp::universe::coordspace_index_t cartesian)
 {
+    return [cartesian] (Universe &rUni) {
 
-/**
- * @brief Create a universe with a few unrealistically small planets and some
- *        vehicles
- *
- * @param ospApp [ref] OSP Application to create universe in
- */
-void create(osp::OSPApplication& rOspApp);
+        CoordinateSpace &rSpace = rUni.coordspace_get(cartesian);
 
+        auto *pData = entt::any_cast<CoordspaceCartesianSimple>(&rSpace.m_data);
+
+        rUni.coordspace_update_sats(cartesian);
+        CoordspaceCartesianSimple::update_exchange(rUni, rSpace, *pData);
+        rSpace.m_toAdd.clear();
+        CoordspaceCartesianSimple::update_views(rSpace, *pData);
+
+        // Update ActiveArea if exists
+
+        auto viewAreas = rUni.get_reg().view<UCompActiveArea>();
+
+        if (!viewAreas.empty())
+        {
+            SatActiveArea::scan(rUni, viewAreas.front());
+        }
+    };
 }

--- a/src/test_application/universes/common.cpp
+++ b/src/test_application/universes/common.cpp
@@ -78,10 +78,15 @@ std::function<void(Universe&)> testapp::generate_simple_universe_update(
 
         // Trajectory functions and other movement goes here
 
-        // Move ActiveArea and scan for new satellites
         if (hasArea)
         {
+            // Update moved satellites in capture space
+            SatActiveArea::update_capture(rUni, pArea->m_captureSpace);
+
+            // Move the area itself
             SatActiveArea::move(rUni, areaSat);
+
+            // Scan for nearby satellites
             SatActiveArea::scan_radius(rUni, areaSat);
         }
     };

--- a/src/test_application/universes/common.h
+++ b/src/test_application/universes/common.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -25,17 +25,20 @@
 
 #pragma once
 
-#include "common.h"
+#include <osp/OSPApplication.h>
 
-namespace testapp::simplesolarsystem
+namespace testapp
 {
 
 /**
- * @brief Create a universe with a few unrealistically small planets and some
- *        vehicles
+ * @brief Generate an update function for a universe consisting of just a single
+ *        CoordspaceCartesianSimple coordinate space and no movement
  *
- * @param ospApp [ref] OSP Application to create universe in
+ * @param cartesian [in] Index to cartesian coordinate space
+ *
+ * @return Universe update function
  */
-void create(osp::OSPApplication& rOspApp);
+std::function<void(osp::universe::Universe&)> generate_simple_universe_update(
+        osp::universe::coordspace_index_t cartesian);
 
 }

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -44,6 +44,7 @@ using osp::universe::Universe;
 using osp::universe::SatActiveArea;
 using osp::universe::SatVehicle;
 
+using osp::universe::CoordinateSpace;
 using osp::universe::CoordspaceCartesianSimple;
 
 using osp::universe::UCompInCoordspace;
@@ -55,12 +56,10 @@ using planeta::universe::UCompPlanet;
 using osp::universe::Vector3g;
 using osp::universe::spaceint_t;
 
-void testapp::create_real_moon(osp::OSPApplication& ospApp)
+void moon::create(osp::OSPApplication& rOspApp)
 {
-    using osp::universe::CoordinateSpace;
-
-    Universe &rUni = ospApp.get_universe();
-    Package &rPkg = ospApp.debug_find_package("lzdb");
+    Universe &rUni = rOspApp.get_universe();
+    Package &rPkg = rOspApp.debug_find_package("lzdb");
 
     // Create a coordinate space used to position Satellites
     auto const& [coordIndex, rSpace] = rUni.coordspace_create();
@@ -102,21 +101,11 @@ void testapp::create_real_moon(osp::OSPApplication& ospApp)
         rSpace.add(sat, pos, {});
     }
 
-    {
-        // create a Satellite with an ActiveArea
-        Satellite sat = rUni.sat_create();
-
-        // assign sat as an ActiveArea
-        SatActiveArea::add_active_area(rUni, sat);
-
-        rSpace.add(sat, {}, {});
-    }
+    // Add universe update function
+    rOspApp.set_universe_update(generate_simple_universe_update(coordIndex));
 
     // Update CoordinateSpace to finish adding the new Satellites
-    rUni.coordspace_update_sats(coordIndex);
-    CoordspaceCartesianSimple::update_exchange(rUni, rSpace, *pData);
-    rSpace.m_toAdd.clear();
-    CoordspaceCartesianSimple::update_views(rSpace, *pData);
+    rOspApp.update_universe();
 
-    SPDLOG_LOGGER_INFO(ospApp.get_logger(), "Created large moon");
+    SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created large moon");
 }

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -61,8 +61,10 @@ void moon::create(osp::OSPApplication& rOspApp)
     Universe &rUni = rOspApp.get_universe();
     Package &rPkg = rOspApp.debug_find_package("lzdb");
 
+    Satellite root = rUni.sat_create();
+
     // Create a coordinate space used to position Satellites
-    auto const& [coordIndex, rSpace] = rUni.coordspace_create();
+    auto const& [coordIndex, rSpace] = rUni.coordspace_create(root);
 
     // Use CoordspaceSimple as data, which can store positions and velocities
     // of satellites

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -89,12 +89,13 @@ void moon::create(osp::OSPApplication& rOspApp)
         float radius = 1.737E+6;
         float mass = 7.347673E+22;
 
+        float activateRadius = radius * 256.0f;
         float resolutionScreenMax = 0.056f;
         float resolutionSurfaceMax = 12.0f;
 
         // assign sat as a planet
-        SatPlanet::add_planet(rUni, sat, radius, mass, resolutionSurfaceMax,
-                              resolutionScreenMax);
+        SatPlanet::add_planet(rUni, sat, radius, mass, activateRadius,
+                              resolutionSurfaceMax, resolutionScreenMax);
 
         // Surface will appear 200 meters below the origin
         // 1024 units = 1 meter

--- a/src/test_application/universes/planets.h
+++ b/src/test_application/universes/planets.h
@@ -25,11 +25,16 @@
 
 #pragma once
 
-#include <osp/OSPApplication.h>
+#include "common.h"
 
-namespace testapp
+namespace testapp::moon
 {
 
-void create_real_moon(osp::OSPApplication& ospApp);
+/**
+ * @brief Create a universe featuring of a life-sized moon and vehicles
+ *
+ * @param ospApp [ref] OSP Application to create universe in
+ */
+void create(osp::OSPApplication& rOspApp);
 
 }

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -26,7 +26,6 @@
 #include "simple.h"
 #include "vehicles.h"
 
-#include <osp/Satellites/SatActiveArea.h>
 #include <osp/Satellites/SatVehicle.h>
 
 #include <osp/CoordinateSpaces/CartesianSimple.h>
@@ -44,6 +43,7 @@ using osp::universe::Universe;
 using osp::universe::SatActiveArea;
 using osp::universe::SatVehicle;
 
+using osp::universe::CoordinateSpace;
 using osp::universe::CoordspaceCartesianSimple;
 
 using osp::universe::UCompInCoordspace;
@@ -54,10 +54,8 @@ using planeta::universe::UCompPlanet;
 
 using osp::universe::Vector3g;
 
-void testapp::create_simple_solar_system(osp::OSPApplication& rOspApp)
+void simplesolarsystem::create(osp::OSPApplication& rOspApp)
 {
-    using osp::universe::CoordinateSpace;
-
     Universe &rUni = rOspApp.get_universe();
     Package &rPkg = rOspApp.debug_find_package("lzdb");
 
@@ -119,21 +117,15 @@ void testapp::create_simple_solar_system(osp::OSPApplication& rOspApp)
         }
     }
 
-    {
-        // create a Satellite with an ActiveArea
-        Satellite sat = rUni.sat_create();
-
-        // assign sat as an ActiveArea
-        SatActiveArea::add_active_area(rUni, sat);
-
-        rSpace.add(sat, {}, {});
-    }
+    // Add universe update function
+    rOspApp.set_universe_update(generate_simple_universe_update(coordIndex));
 
     // Update CoordinateSpace to finish adding the new Satellites
-    rUni.coordspace_update_sats(coordIndex);
-    CoordspaceCartesianSimple::update_exchange(rUni, rSpace, *pData);
-    rSpace.m_toAdd.clear();
-    CoordspaceCartesianSimple::update_views(rSpace, *pData);
+    rOspApp.update_universe();
 
     SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created simple solar system");
 }
+
+
+
+

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -59,8 +59,11 @@ void simplesolarsystem::create(osp::OSPApplication& rOspApp)
     Universe &rUni = rOspApp.get_universe();
     Package &rPkg = rOspApp.debug_find_package("lzdb");
 
+    Satellite root = rUni.sat_create();
+
     // Create a coordinate space used to position Satellites
-    auto const& [coordIndex, rSpace] = rUni.coordspace_create();
+    auto const& [coordIndex, rSpace] = rUni.coordspace_create(root);
+    rUni.coordspace_update_depth(coordIndex);
 
     // Use CoordspaceSimple as data, which can store positions and velocities
     // of satellites

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -71,30 +71,36 @@ void simplesolarsystem::create(osp::OSPApplication& rOspApp)
     auto *pData = entt::any_cast<CoordspaceCartesianSimple>(&rSpace.m_data);
 
 
-    // Create 2 random vehicles
+    // Create 2 random (non-functional) vehicles
     for (int i = 0; i < 2; i ++)
     {
         // Creates a random mess of spamcans as a vehicle
-        Satellite sat = debug_add_random_vehicle(rUni, rPkg, "TestyMcTestFace Mk"
-                                                 + std::to_string(i));
+        Satellite sat = debug_add_random_vehicle(
+                    rUni, rPkg, "TestyMcTestFace Mk " + std::to_string(i));
+
+        Vector3g pos{i * 1024l * 5l, 0l, -10l * 1024l};
 
         // Add it to the CoordspaceSimple directly
-        rSpace.add(sat, {i * 1024l * 5l, 0l, 0l}, {});
+        rSpace.add(sat, pos, {});
     }
 
+    // Create 10 part-vehicles
+    for (int i = 0; i < 10; i ++)
     {
-        Satellite sat = testapp::debug_add_part_vehicle(rUni, rPkg, "Placeholder Mk. I");
+        Satellite sat = testapp::debug_add_part_vehicle(
+                    rUni, rPkg, "Placeholder Mk. " + std::to_string(i));
 
-        Vector3g pos{22 * 1024l * 5l, 0l, 0l};
+        // stack along the y-axis (vertically)
+        Vector3g pos{0l, i * 1024l * 10l, 0l};
 
         rSpace.add(sat, pos, {});
     }
 
-    // Add Grid of planets too
+    // Add Grid of planets too (3x3)
 
-    for (int x = -0; x < 1; x ++)
+    for (int x = -1; x <= 1; x ++)
     {
-        for (int z = -1; z < 1; z ++)
+        for (int z = -1; z <= 1; z ++)
         {
             Satellite sat = rUni.sat_create();
 
@@ -102,17 +108,18 @@ void simplesolarsystem::create(osp::OSPApplication& rOspApp)
             float radius = 256;
             float mass = 7.03E7 * 99999999; // volume of sphere * density
 
+            float activateRadius = 6000.0f;
             float resolutionScreenMax = 0.056f;
             float resolutionSurfaceMax = 2.0f;
 
             // assign sat as a planet
-            SatPlanet::add_planet(rUni, sat, radius, mass,
+            SatPlanet::add_planet(rUni, sat, radius, mass, activateRadius,
                                   resolutionSurfaceMax, resolutionScreenMax);
 
-            // space planets 400m apart from each other
+            // space planets 6000m apart from each other
             // 1024 units = 1 meter
             osp::universe::Vector3g pos{
-                x * 1024l * 400l,
+                x * 1024l * 6000l,
                 1024l * -300l,
                 z * 1024l * 6000l};
 


### PR DESCRIPTION
This PR progresses towards a more sophisticated Universe required to meet the project's goals.

Interactions between the ActiveScene and Universe were not that well thought out before, and gets rather ugly when considering asynchronous updates and rotating planets among other possible features.

### Universe Updates

The Universe now relies only on queues (just std::vectors for now) for communication with the ActiveScene. 

Updating the universe appears to have two main steps:
* Exchange update: Add, remove, and transfer Satellites between coordinate systems
* Trajectory update: Step through time and move the Satellites (none yet implemented)

The update function is called each frame for now. Since there are many possible test universes (only 'simple' and 'moon' so far), the update function is handled by an std::function that can be a injected into the application.

See [common.cpp](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/universes/common.cpp#L43) and [simple.cpp](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/universes/simple.cpp#L131)

There is also the possibility of some parts of the universe updating more frequently than others. ie. solar system's moves around the galaxy once every day, solar system updates every second, ActiveArea can move every 2 frames.

### ActiveArea Capture and Domain CoordinateSpaces

Imagine there's a solar system in an N-body simulation being explored by an ActiveArea.

The ActiveArea is moving itself; it has no mass, not affected by gravity, and has nothing to do with the N-body simulation whatsoever. This means its position data should NOT be in the N-body's coordinate space. Instead, the ActiveArea can live in its own coordinate space layered over top of the N-body coordinate space. This is implemented as the "Domain CoordinateSpace."

Now a vehicle enters the area, and can get modified by the user. This means the area now has full control over the vehicle Satellite's position, and should no longer be part of the N-body coordinate space. The ActiveArea can steal the vehicle, and store it in its own "Capture CoordinateSpace" instead.

The creation of both of these coordinate spaces can be found in [flight.cpp](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/flight.cpp#L321)

Capturing a Satellite (or just transferring Satellites between CoordinateSpaces) is done by queuing remove() from the source, and add() to the destination.
https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/osp/Satellites/SatActiveArea.cpp#L113-L114

### Coordinate Space Transforms

Satellites need to be handed off from one coordinate space to another. For example:
* between spheres of influence in a patched conics simulation
* from space to a rotating planet and its surface
* multiple coordinate spaces of varying precision for gigantic universe sizes

So far, 1024 space units is 1 meter globally. The upcoming system is similar to [the one planned for urho-osp](https://github.com/TheOpenSpaceProgramArchive/urho-osp/wiki/Dealing-with-a-Large-Universe#precision), but each CoordinateSpace having a precision, instead of individual Satellites.

The transformation required to transfer a Satellite between CoordinateSpaces is a translation, rotation, and scale. This can be represented by a Matrix4, but precision may be an issue due to converting between floating points and 64-bit ints. Instead, this solution takes a functional-style approach that uses only integers:

https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/osp/coordinates.h#L228

[Example usage](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/flight.cpp#L225) for when the scene is closed, and the ActiveArea is about to be deleted. CoordspaceTransform is used to transform positions from the Capture coordinate space back into the 'main' coordinate space.

The idea works for now, but is untested and does not yet support rotation.

Rotation is a rare case, only really useful for planet surfaces. Using floating points to rotate coordinates (such as with Quaterinions) should be acceptable.

### Improved Scene-Universe Synchronization

Before, SysAreaAssociate (system in ActiveScene) was responsible for calculating distances to nearby Satellites. This is impractical, as this task should be handled during the Universe update, which it now is.

[SatActiveArea.cpp](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/osp/Satellites/SatActiveArea.cpp#L55) now does the scanning, and uses queues in [UCompActiveArea](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/osp/Satellites/SatActiveArea.h#L73) to communicate with SysAreaAssociate.

Moving the scene and area is now a more robust 3-step process.
1. [CameraController requests to move](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/CameraController.cpp#L283) when the camera gets too far from the scene origin. this writes into UCompActiveArea's m_requestMove
2. Universe update [moves the ActiveArea in its Domain CoordinateSpace](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/test_application/universes/common.cpp#L87)
3. [SysAreaAssociate notices the area moves, and translates all floating origin entities in the scene](https://github.com/TheOpenSpaceProgram/osp-magnum/blob/f486e6842524b87294e84fa0c7a9b46bb3514167/src/osp/Active/SysAreaAssociate.cpp#L74)

Step 1 can be replaced by other external requests.

### Splitting SysVehicle

SysVehicle.cpp was getting a bit crammed, so most of the ActiveScene-Universe synchronization was moved to SysVehicleSync.h/cpp instead. 


