### PR TITLE
Improve Physics interface, Newton, and Vehicle separation

### DIFF
--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -115,7 +115,7 @@ MachineContainer& SysMachineContainer::instantiate(
 
     rScene.reg_emplace<ACompMass>(ent, 0.0f);
     // All tanks are cylindrical for now
-    rScene.reg_emplace<ACompShape>(ent, phys::ECollisionShape::CYLINDER);
+    rScene.reg_emplace<ACompShape>(ent, phys::EShape::Cylinder);
 
     return rScene.reg_emplace<MachineContainer>(ent, ent, capacity, resource);
 }

--- a/src/adera/Machines/RCSController.cpp
+++ b/src/adera/Machines/RCSController.cpp
@@ -59,7 +59,7 @@ namespace osp { struct Path; }
 using osp::active::ActiveScene;
 using osp::active::ActiveEnt;
 using osp::active::ACompMachines;
-using osp::active::ACompRigidBody;
+using osp::active::ACompPhysDynamic;
 using osp::active::ACompTransform;
 using osp::active::SysPhysics;
 
@@ -193,9 +193,7 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
                 auto const *pRbAncestor
                         = SysPhysics::try_get_or_find_rigidbody_ancestor(
                             rScene, ent);
-                auto const &compRb = rScene.reg_get<ACompRigidBody>(
-                            pRbAncestor->m_ancestor);
-                auto const &compTf = rScene.reg_get<ACompTransform>(
+                auto const &rDyn = rScene.reg_get<ACompPhysDynamic>(
                             pRbAncestor->m_ancestor);
 
                 Matrix4 transform = pRbAncestor->m_relTransform;
@@ -205,7 +203,7 @@ void SysMachineRCSController::update_calculate(ActiveScene& rScene)
                 Vector3 commandTransl = Vector3{0.0f};
                 Vector3 commandRot = nodeCommand.m_state.m_attitude;
                 Vector3 thrusterPos = transform.translation()
-                                    - compRb.m_centerOfMassOffset;
+                                    - rDyn.m_centerOfMassOffset;
                 Vector3 thrusterDir = transform.rotation()
                                     * Vector3{0.0f, 0.0f, 1.0f};
 

--- a/src/newtondynamics_physics/SysNewton.h
+++ b/src/newtondynamics_physics/SysNewton.h
@@ -119,12 +119,11 @@ private:
             NewtonWorld const* pNwtWorld, NewtonCollision *rCompound);
 
     /**
-     * Scan children of specified rigid body entity for ACompCollisionShapes,
-     * then combine it all into a single compound collision
+     * @brief Create Newton bodies and colliders for entities with ACompPhysBody
      *
-     * @param rScene   [in] ActiveScene containing entity and physics world
-     * @param entity   [in] Entity containing ACompNwtBody
-     * @param nwtWorld [in] Newton physics world
+     * @param rScene    [ref] ActiveScene containing entity and physics world
+     * @param entity    [in] Entity containing ACompNwtBody
+     * @param pNwtWorld [in] Newton physics world
      */
     static void create_body(
             osp::active::ActiveScene& rScene, osp::active::ActiveEnt ent,

--- a/src/newtondynamics_physics/SysNewton.h
+++ b/src/newtondynamics_physics/SysNewton.h
@@ -191,8 +191,8 @@ void SysNewton::shape_create_tri_mesh_static(
 
     newton_tree_collision_end_build(pTree, 2);
 
-    rShape.m_shape = osp::phys::ECollisionShape::TERRAIN;
     rScene.reg_emplace<ACompNwtCollider>(chunkEnt, pTree);
+
 }
 
 }

--- a/src/newtondynamics_physics/ospnewton.h
+++ b/src/newtondynamics_physics/ospnewton.h
@@ -32,48 +32,21 @@
 namespace ospnewton
 {
 
-/**
- * @brief Associates an entity with a NewtonBody and manages its lifetime
- */
-struct ACompNwtBody
+struct DeleterNewtonBody
 {
-
-    ACompNwtBody(NewtonBody const* pBody) noexcept
-     : m_pBody(pBody) { }
-
-    NewtonBody const* body() const noexcept { return m_pBody.get(); }
-
-private:
-    struct Deleter
-    {
-        void operator() (NewtonBody const* pCollision)
-        { NewtonDestroyBody(pCollision); }
-    };
-
-    std::unique_ptr<NewtonBody const, Deleter> m_pBody;
+    void operator() (NewtonBody const* pCollision)
+    { NewtonDestroyBody(pCollision); }
 };
 
-/**
- * @brief Associates an entity with a NewtonCollision and manages its lifetime
- */
-struct ACompNwtCollider
+using ACompNwtBody_t = std::unique_ptr<NewtonBody const, DeleterNewtonBody>;
+
+struct DeleterNewtonCollision
 {
-
-    ACompNwtCollider(NewtonCollision const* pCollision) noexcept
-     : m_pCollision(pCollision) { }
-
-    NewtonCollision const* collision() const noexcept
-    { return m_pCollision.get(); }
-
-private:
-    struct Deleter
-    {
-        void operator() (NewtonCollision const* pCollision)
-        { NewtonDestroyCollision(pCollision); }
-    };
-
-    std::unique_ptr<NewtonCollision const, Deleter> m_pCollision;
+    void operator() (NewtonCollision const* pCollision)
+    { NewtonDestroyCollision(pCollision); }
 };
+
+using ACompNwtCollider_t = std::unique_ptr<NewtonCollision const, DeleterNewtonCollision>;
 
 /**
  * @brief Represents an instance of a Newton physics world in the scane

--- a/src/newtondynamics_physics/ospnewton.h
+++ b/src/newtondynamics_physics/ospnewton.h
@@ -1,0 +1,124 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <osp/Active/SysPhysics.h>
+#include <osp/Active/ActiveScene.h>
+
+#include <Newton.h>
+
+namespace ospnewton
+{
+
+/**
+ * @brief Associates an entity with a NewtonBody and manages its lifetime
+ */
+struct ACompNwtBody
+{
+
+    ACompNwtBody(NewtonBody const* pBody) noexcept
+     : m_pBody(pBody) { }
+
+    NewtonBody const* body() const noexcept { return m_pBody.get(); }
+
+private:
+    struct Deleter
+    {
+        void operator() (NewtonBody const* pCollision)
+        { NewtonDestroyBody(pCollision); }
+    };
+
+    std::unique_ptr<NewtonBody const, Deleter> m_pBody;
+};
+
+/**
+ * @brief Associates an entity with a NewtonCollision and manages its lifetime
+ */
+struct ACompNwtCollider
+{
+
+    ACompNwtCollider(NewtonCollision const* pCollision) noexcept
+     : m_pCollision(pCollision) { }
+
+    NewtonCollision const* collision() const noexcept
+    { return m_pCollision.get(); }
+
+private:
+    struct Deleter
+    {
+        void operator() (NewtonCollision const* pCollision)
+        { NewtonDestroyCollision(pCollision); }
+    };
+
+    std::unique_ptr<NewtonCollision const, Deleter> m_pCollision;
+};
+
+/**
+ * @brief Represents an instance of a Newton physics world in the scane
+ */
+struct ACtxNwtWorld
+{
+
+    // TODO: not compiling, std::hardware_destructive_interference_size not found?
+    struct alignas(64) PerThread
+    {
+        using SetTfPair_t = std::pair<osp::active::ActiveEnt,
+                                      NewtonBody const* const>;
+
+        // transformations to set recorded in cb_set_transform
+        std::vector<SetTfPair_t> m_setTf;
+    };
+
+    struct Deleter
+    {
+        void operator() (NewtonWorld* pNwtWorld) { NewtonDestroy(pNwtWorld); }
+    };
+
+    ACtxNwtWorld(osp::active::ActiveScene &rScene, int threadCount)
+     : m_pScene(&rScene)
+     , m_nwtWorld(NewtonCreate())
+     , m_viewForce(rScene.get_registry().view<osp::active::ACompPhysNetForce>())
+     , m_viewTorque(rScene.get_registry().view<osp::active::ACompPhysNetTorque>())
+     , m_perThread(threadCount)
+    {
+        NewtonWorldSetUserData(m_nwtWorld.get(), this);
+    }
+
+    osp::active::ActiveScene *m_pScene;
+
+    std::unique_ptr<NewtonWorld, Deleter> m_nwtWorld;
+
+    entt::basic_view<osp::active::ActiveEnt, entt::exclude_t<>,
+                     osp::active::ACompPhysNetForce> m_viewForce;
+    entt::basic_view<osp::active::ActiveEnt, entt::exclude_t<>,
+                     osp::active::ACompPhysNetTorque> m_viewTorque;
+
+    std::vector<PerThread> m_perThread;
+};
+
+
+
+
+}

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -26,6 +26,8 @@
 
 #include "ActiveScene.h"
 
+#include "physics.h"
+
 using osp::active::SysAreaAssociate;
 
 using osp::active::ACompAreaLink;
@@ -133,6 +135,9 @@ void SysAreaAssociate::floating_origin_translate(
 
         entTransform.m_transform.translation() += translation;
     }
+
+    // Tell physics engine to translate too
+    rReg.ctx<ACtxPhysics>().m_originTranslate += translation;
 }
 
 

--- a/src/osp/Active/SysAreaAssociate.cpp
+++ b/src/osp/Active/SysAreaAssociate.cpp
@@ -136,7 +136,7 @@ void SysAreaAssociate::floating_origin_translate(
         entTransform.m_transform.translation() += translation;
     }
 
-    // Tell physics engine to translate too
+    // Tell physics engine to translate its rigid bodies as well
     rReg.ctx<ACtxPhysics>().m_originTranslate += translation;
 }
 

--- a/src/osp/Active/SysForceFields.cpp
+++ b/src/osp/Active/SysForceFields.cpp
@@ -33,16 +33,16 @@ using namespace osp::active;
 void SysFFGravity::update_force(ActiveScene& rScene)
 {
 
-    auto viewFields = rScene.get_registry()
-            .view<ACompFFGravity, ACompTransform>();
+    auto const viewFields = rScene.get_registry()
+            .view<const ACompFFGravity, const ACompTransform>();
 
-    auto viewMasses = rScene.get_registry()
-            .view<ACompPhysDynamic, ACompTransform>();
+    auto const viewMasses = rScene.get_registry()
+            .view<const ACompPhysDynamic, const ACompTransform>();
 
     for (ActiveEnt fieldEnt : viewFields)
     {
-        auto &fieldFFGrav = viewFields.get<ACompFFGravity>(fieldEnt);
-        auto &fieldTransform = viewFields.get<ACompTransform>(fieldEnt);
+        auto const &fieldFFGrav = viewFields.get<const ACompFFGravity>(fieldEnt);
+        auto const &fieldTransform = viewFields.get<const ACompTransform>(fieldEnt);
 
         for (ActiveEnt massEnt : viewMasses)
         {
@@ -51,14 +51,15 @@ void SysFFGravity::update_force(ActiveScene& rScene)
                 continue;
             }
 
-            auto &massBody = viewMasses.get<ACompPhysDynamic>(massEnt);
-            auto &massTransform = viewMasses.get<ACompTransform>(massEnt);
+            auto const &massBody = viewMasses.get<const ACompPhysDynamic>(massEnt);
+            auto const &massTransform = viewMasses.get<const ACompTransform>(massEnt);
 
-            Vector3 relativePos = fieldTransform.m_transform.translation()
-                                - massTransform.m_transform.translation();
-            float r = relativePos.length();
-            Vector3 force = relativePos * fieldFFGrav.m_Gmass
-                          * massBody.m_totalMass / (r * r * r);
+            Vector3 const relativePos = fieldTransform.m_transform.translation()
+                                      - massTransform.m_transform.translation();
+            float const r = relativePos.length();
+            Vector3 const force = (relativePos * fieldFFGrav.m_Gmass
+                                               * massBody.m_totalMass)
+                                   / (r * r * r);
 
             auto &netForce = rScene.get_registry()
                     .get_or_emplace<ACompPhysNetForce>(massEnt);

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -43,7 +43,7 @@ public:
      *         hierarchy error, then {entt:null, nullptr}. If no ACompNwtBody
      *         component is found, then {level-1 entity, nullptr}
      */
-    static std::pair<ActiveEnt, ACompRigidBody*> find_rigidbody_ancestor(
+    static ActiveEnt find_rigidbody_ancestor(
             ActiveScene& rScene, ActiveEnt ent);
 
     /**
@@ -81,11 +81,6 @@ public:
      */
     static ACompRigidbodyAncestor* try_get_or_find_rigidbody_ancestor(
         ActiveScene& rScene, ActiveEnt childEntity);
-
-    // most of these are self-explanatory
-    static void body_apply_force(ACompRigidBody& body, Vector3 force) noexcept;
-    static void body_apply_accel(ACompRigidBody& body, Vector3 accel) noexcept;
-    static void body_apply_torque(ACompRigidBody& body, Vector3 torque) noexcept;
 
     enum EIncludeRootMass { Ignore, Include };
     /**

--- a/src/osp/Active/SysVehicleSync.cpp
+++ b/src/osp/Active/SysVehicleSync.cpp
@@ -147,6 +147,8 @@ ActiveEnt SysVehicleSync::activate(ActiveScene &rScene, Universe &rUni,
     // temporary: make the whole thing a single rigid body
     rScene.reg_emplace<ACompPhysBody>(vehicleEnt);
     rScene.reg_emplace<ACompPhysDynamic>(vehicleEnt);
+    rScene.reg_emplace<ACompPhysLinearVel>(vehicleEnt);
+    rScene.reg_emplace<ACompPhysAngularVel>(vehicleEnt);
     rScene.reg_emplace<ACompShape>(vehicleEnt, phys::EShape::Combined);
     rScene.reg_emplace<ACompSolidCollider>(vehicleEnt);
 

--- a/src/osp/Active/SysVehicleSync.cpp
+++ b/src/osp/Active/SysVehicleSync.cpp
@@ -145,8 +145,9 @@ ActiveEnt SysVehicleSync::activate(ActiveScene &rScene, Universe &rUni,
 
 
     // temporary: make the whole thing a single rigid body
-    auto& vehicleBody = rScene.reg_emplace<ACompRigidBody>(vehicleEnt);
-    rScene.reg_emplace<ACompShape>(vehicleEnt, phys::ECollisionShape::COMBINED);
+    rScene.reg_emplace<ACompPhysBody>(vehicleEnt);
+    rScene.reg_emplace<ACompPhysDynamic>(vehicleEnt);
+    rScene.reg_emplace<ACompShape>(vehicleEnt, phys::EShape::Combined);
     rScene.reg_emplace<ACompSolidCollider>(vehicleEnt);
 
     return vehicleEnt;

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -30,34 +30,44 @@
 namespace osp::active
 {
 
-using physchanges_t = std::vector<ActiveEnt>;
-
+/**
+ * @brief The ACtxPhysics struct
+ */
 struct ACtxPhysics
 {
     Vector3 m_originTranslate;
-    physchanges_t m_colliders;
-    physchanges_t m_inertia;
-    physchanges_t m_velocity;
+
+    // Input queues
+    std::vector<ActiveEnt> m_colliderDirty;
+    std::vector<ActiveEnt> m_inertiaDirty;
+    std::vector< std::pair<ActiveEnt, Vector3> > m_setVelocity;
 };
 
 /**
- * @brief Indicates that an entity is synced with a physics engine
+ * @brief Synchronizes an entity with a physics engine body
  */
 struct ACompPhysBody
 { };
 
 /**
- * @brief Entity is a non-static dynamic rigid body
+ * @brief Adds rigid body dynamics to entities with ACompPhysBody
  */
 struct ACompPhysDynamic
 {
-    Vector3 m_inertia{1, 1, 1};
     Vector3 m_centerOfMassOffset{0, 0, 0};
+    Vector3 m_inertia{1, 1, 1};
     float m_totalMass;
 };
 
-struct ACompLinVelocity : Vector3 { };
-struct ACompRotVelocity : Vector3 { };
+/**
+ * @brief Read-only Linear velocity for entities with ACompPhysDynamic
+ */
+struct ACompPhysLinearVel : Vector3 { };
+
+/**
+ * @brief Read-only Angular velocity for entities with ACompPhysDynamic
+ */
+struct ACompPhysAngularVel : Vector3 { };
 
 /**
  * @brief Applies force to a dynamic physics entity

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -56,7 +56,7 @@ struct ACompPhysDynamic
 {
     Vector3 m_centerOfMassOffset{0, 0, 0};
     Vector3 m_inertia{1, 1, 1};
-    float m_totalMass;
+    float m_totalMass{0.0f};
 };
 
 /**

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -30,27 +30,48 @@
 namespace osp::active
 {
 
-/**
- * Generic Rigid Body physics data
- *
- * TODO: possibly split into more components when the time comes
- */
-struct ACompRigidBody
+using physchanges_t = std::vector<ActiveEnt>;
+
+struct ACtxPhysics
 {
-    // Modify these
-    Vector3 m_inertia{1, 1, 1};
-    Vector3 m_netForce{0, 0, 0};
-    Vector3 m_netTorque{0, 0, 0};
-
-    float m_mass{1.0f};
-    Vector3 m_velocity{0, 0, 0};
-    Vector3 m_rotVelocity{0, 0, 0};
-    Vector3 m_centerOfMassOffset{0, 0, 0};
-
-    bool m_colliderDirty{false}; // set true if collider is modified
-    bool m_inertiaDirty{false}; // set true if rigidbody is modified
+    Vector3 m_originTranslate;
+    physchanges_t m_colliders;
+    physchanges_t m_inertia;
+    physchanges_t m_velocity;
 };
 
+/**
+ * @brief Indicates that an entity is synced with a physics engine
+ */
+struct ACompPhysBody
+{ };
+
+/**
+ * @brief Entity is a non-static dynamic rigid body
+ */
+struct ACompPhysDynamic
+{
+    Vector3 m_inertia{1, 1, 1};
+    Vector3 m_centerOfMassOffset{0, 0, 0};
+    float m_totalMass;
+};
+
+struct ACompLinVelocity : Vector3 { };
+struct ACompRotVelocity : Vector3 { };
+
+/**
+ * @brief Applies force to a dynamic physics entity
+ */
+struct ACompPhysNetForce : Vector3 { };
+
+/**
+ * @brief Applies torque to a dynamic physics entity
+ */
+struct ACompPhysNetTorque : Vector3 { };
+
+/**
+ * @brief Keeps track of which rigid body an entity belongs to
+*/
 struct ACompRigidbodyAncestor
 {
     ActiveEnt m_ancestor{entt::null};
@@ -62,7 +83,7 @@ struct ACompRigidbodyAncestor
  */
 struct ACompShape
 {
-    phys::ECollisionShape m_shape{phys::ECollisionShape::NONE};
+    phys::EShape m_shape{phys::EShape::None};
 };
 
 /**

--- a/src/osp/CommonPhysics.cpp
+++ b/src/osp/CommonPhysics.cpp
@@ -33,20 +33,20 @@
 namespace osp::phys
 {
 
-float shape_volume(ECollisionShape shape, Vector3 scale)
+float shape_volume(EShape shape, Vector3 scale)
 {
     static constexpr float sc_pi = Magnum::Math::Constants<Magnum::Float>::pi();
     switch (shape)
     {
-    case ECollisionShape::NONE:
+    case EShape::None:
         return 0.0f;
-    case ECollisionShape::SPHERE:
+    case EShape::Sphere:
         // Default radius: 1
         return (4.0f / 3.0f) * sc_pi * scale.x() * scale.x() * scale.x();
-    case ECollisionShape::BOX:
+    case EShape::Box:
         // Default width: 2
         return 2.0f*scale.x() * 2.0f*scale.y() * 2.0f*scale.z();
-    case ECollisionShape::CYLINDER:
+    case EShape::Cylinder:
         // Default radius: 1, default height: 2
         return sc_pi * scale.x() * scale.x() * 2.0f*scale.z();
     default:
@@ -70,11 +70,11 @@ Matrix3 transform_inertia_tensor(Matrix3 I, float mass, Vector3 translation, Mat
     return I + mass * (dot(r, r) * E3 - outerProductR);
 }
 
-Vector3 collider_inertia_tensor(ECollisionShape shape, Vector3 scale, float mass)
+Vector3 collider_inertia_tensor(EShape shape, Vector3 scale, float mass)
 {
     switch (shape)
     {
-    case ECollisionShape::CYLINDER:
+    case EShape::Cylinder:
     {
         // Default cylinder dimensions: radius 1, height 2
         const float height = 2.0f * scale.z();
@@ -82,22 +82,20 @@ Vector3 collider_inertia_tensor(ECollisionShape shape, Vector3 scale, float mass
         const float radius = scale.x();
         return cylinder_inertia_tensor(radius, height, mass);
     }
-    case ECollisionShape::BOX:
+    case EShape::Box:
     {
         // Default box dimensions: 2x2x2
         const Vector3 dimensions = 2.0f * scale;
         return cuboid_inertia_tensor(dimensions, mass);
     }
-    case ECollisionShape::SPHERE:
+    case EShape::Sphere:
     {
         // Default sphere: radius = 1
         const Vector3 semiaxes = scale;
         return ellipsoid_inertia_tensor(semiaxes, mass);
     }
-    case ECollisionShape::CAPSULE:
-    case ECollisionShape::CONVEX_HULL:
-    case ECollisionShape::TERRAIN:
-    case ECollisionShape::COMBINED:
+    case EShape::Capsule:
+
     default:
       SPDLOG_LOGGER_ERROR(spdlog::get("application"),
                           "ERROR: unknown collision shape");

--- a/src/osp/CommonPhysics.h
+++ b/src/osp/CommonPhysics.h
@@ -29,22 +29,22 @@
 namespace osp::phys
 {
 
-// Formerly PrototypePart
-enum class ECollisionShape : uint8_t
+/**
+ * @brief Basic primitive shapes used for collisions and inertia calculations
+ */
+enum class EShape : uint8_t
 {
-    NONE = 0,
-    COMBINED = 1,
-    SPHERE = 2,
-    BOX = 3,
-    CAPSULE = 4,
-    CYLINDER = 5,
-    //MESH = 6,
-    CONVEX_HULL = 7,
-    TERRAIN = 8
+    None = 0,
+    Custom = 1,
+    Combined = 2,
+    Sphere = 3,
+    Box = 4,
+    Capsule = 5,
+    Cylinder = 6
 };
 
 /**
- * Compute the volume of an ECollisionShape
+ * Compute the volume of an EShape
  * 
  * Given the type of shape and the scale in X,Y,Z, computes the volume of the
  * primitive shape. Axis-aligned shapes (e.g. cylinder, capsule) are aligned
@@ -60,7 +60,7 @@ enum class ECollisionShape : uint8_t
  * 
  * @return the volume of the shape in m^3
  */
-float shape_volume(ECollisionShape shape, Vector3 scale);
+float shape_volume(EShape shape, Vector3 scale);
 
 /**
  * Transform an inertia tensor
@@ -91,7 +91,7 @@ Matrix3 transform_inertia_tensor(Matrix3 I, float mass,
  * 
  * @return The moment of inertia about the principle axes (x, y, z)
  */
-Vector3 collider_inertia_tensor(ECollisionShape shape, Vector3 scale, float mass);
+Vector3 collider_inertia_tensor(EShape shape, Vector3 scale, float mass);
 
 /**
  * Compute the inertia tensor for a cylinder

--- a/src/osp/Resource/AssetImporter.cpp
+++ b/src/osp/Resource/AssetImporter.cpp
@@ -467,8 +467,8 @@ void AssetImporter::proto_add_obj_recurse(
         // TODO: Add support different collider shapes here!
         std::string const& shapeName = extras.Get("shape").Get<std::string>();
         // change this to some map too
-        const phys::ECollisionShape shape = (shapeName == "cylinder")
-            ? phys::ECollisionShape::CYLINDER : phys::ECollisionShape::BOX;
+        const phys::EShape shape = (shapeName == "cylinder")
+            ? phys::EShape::Cylinder : phys::EShape::Box;
 
         PCompPrimativeCollider &rCollider = rPart.m_partCollider.emplace_back();
         rCollider.m_entity = entity;

--- a/src/osp/Resource/PrototypePart.h
+++ b/src/osp/Resource/PrototypePart.h
@@ -71,7 +71,7 @@ struct PCompDrawable
 struct PCompPrimativeCollider
 {
     PartEntity_t m_entity;
-    phys::ECollisionShape m_shape;
+    phys::EShape m_shape;
 };
 // if any fancy triangle mesh or convex hull is added, make a new PComp
 

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -41,7 +41,7 @@
 
 // TODO: Decouple when a proper interface for creating static triangle meshes
 //       is made
-#include <newtondynamics_physics/SysNewton.h>
+#include "temporarynewtonmesh.h"
 
 using planeta::active::SysPlanetA;
 using planeta::universe::UCompPlanet;
@@ -130,8 +130,10 @@ void SysPlanetA::debug_create_chunk_collider(
     auto itsChunk = planet.m_planet->iterate_chunk(chunk);
 
     // Send them to the physics engine
-    ospnewton::SysNewton::shape_create_tri_mesh_static(
+    debug_create_tri_mesh_static(
                 rScene, chunkShape, chunkEnt, itsChunk.first, itsChunk.second);
+
+
 }
 
 void SysPlanetA::update_activate(ActiveScene &rScene)

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -49,6 +49,8 @@ using planeta::universe::UCompPlanet;
 using osp::active::ActiveScene;
 using osp::active::ActiveEnt;
 
+using osp::active::ACompPhysBody;
+
 using osp::active::SysHierarchy;
 using osp::active::SysAreaAssociate;
 using osp::active::SysPhysics;
@@ -110,18 +112,18 @@ void SysPlanetA::debug_create_chunk_collider(
 {
     using namespace osp::active;
 
-    using osp::phys::ECollisionShape;
+    using osp::phys::EShape;
 
     // Create entity and required components
     ActiveEnt chunkEnt = SysHierarchy::create_child(rScene, rScene.hier_get_root());
     auto &chunkTransform = rScene.reg_emplace<ACompTransform>(chunkEnt);
     auto &chunkShape = rScene.reg_emplace<ACompShape>(chunkEnt);
     rScene.reg_emplace<ACompSolidCollider>(chunkEnt);
-    rScene.reg_emplace<ACompRigidBody>(chunkEnt);
+    rScene.reg_emplace<ACompPhysBody>(chunkEnt);
     rScene.reg_emplace<ACompFloatingOrigin>(chunkEnt);
 
     // Set some stuff
-    chunkShape.m_shape = ECollisionShape::TERRAIN;
+    chunkShape.m_shape = EShape::Custom;
     chunkTransform.m_transform = rScene.reg_get<ACompTransform>(ent).m_transform;
 
     // Get triangle iterators to start and end triangles of the specified chunk

--- a/src/planet-a/Active/temporarynewtonmesh.h
+++ b/src/planet-a/Active/temporarynewtonmesh.h
@@ -1,0 +1,68 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <newtondynamics_physics/SysNewton.h>
+#include <newtondynamics_physics/ospnewton.h>
+
+template<class TRIANGLE_IT_T>
+void debug_create_tri_mesh_static(
+        osp::active::ActiveScene& rScene, osp::active::ACompShape& rShape,
+        osp::active::ActiveEnt chunkEnt,
+        TRIANGLE_IT_T const& start, TRIANGLE_IT_T const& end)
+{
+    // TODO: this is actually horrendously slow and WILL cause issues later on.
+    //       Tree collisions aren't made for real-time loading. Consider
+    //       manually hacking up serialized data instead of add face, or use
+    //       Newton's dgAABBPolygonSoup stuff directly
+
+    using osp::Vector3;
+
+    osp::active::ActiveReg_t &rReg = rScene.get_registry();
+
+    auto &rWorldCtx = rReg.ctx<ospnewton::ACtxNwtWorld>();
+    NewtonWorld const* pNwtWorld = rWorldCtx.m_nwtWorld.get();
+    NewtonCollision const* pTree = NewtonCreateTreeCollision(pNwtWorld, 0);
+
+    NewtonTreeCollisionBeginBuild(pTree);
+
+    Vector3 triangle[3];
+
+    for (TRIANGLE_IT_T it = start; it != end; it += 3)
+    {
+        triangle[0] = *reinterpret_cast<Vector3 const*>((it + 0).position());
+        triangle[1] = *reinterpret_cast<Vector3 const*>((it + 1).position());
+        triangle[2] = *reinterpret_cast<Vector3 const*>((it + 2).position());
+
+        NewtonTreeCollisionAddFace(
+                pTree, 3, reinterpret_cast<float*>(triangle), sizeof(float) * 3, 0);
+
+    }
+
+    NewtonTreeCollisionEndBuild(pTree, 2);
+
+    rReg.emplace<ospnewton::ACompNwtCollider>(chunkEnt, pTree);
+
+}

--- a/src/planet-a/Active/temporarynewtonmesh.h
+++ b/src/planet-a/Active/temporarynewtonmesh.h
@@ -63,6 +63,6 @@ void debug_create_tri_mesh_static(
 
     NewtonTreeCollisionEndBuild(pTree, 2);
 
-    rReg.emplace<ospnewton::ACompNwtCollider>(chunkEnt, pTree);
+    rReg.emplace<ospnewton::ACompNwtCollider_t>(chunkEnt, pTree);
 
 }

--- a/src/test_application/CameraController.cpp
+++ b/src/test_application/CameraController.cpp
@@ -319,12 +319,13 @@ void SysCameraController::update_view(ActiveScene &rScene)
     Matrix4 const& vehicleTf = rScene.reg_get<ACompTransform>(vehicle).m_transform;
 
     // Compute Center of Mass of target, if it's a rigid body
-    auto [rbEnt, pCompRb]
+    ActiveEnt rbEnt
             = osp::active::SysPhysics::find_rigidbody_ancestor(rScene, vehicle);
     Vector3 comOset{0.0f};
-    if (pCompRb != nullptr)
+    if (rReg.valid(rbEnt))
     {
-        comOset = vehicleTf.transformVector(pCompRb->m_centerOfMassOffset);
+        auto const& rDyn = rReg.get<osp::active::ACompPhysDynamic>(rbEnt);
+        comOset = vehicleTf.transformVector(rDyn.m_centerOfMassOffset);
     }
 
     // Process control inputs

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -146,13 +146,11 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     rScene.get_registry().set<osp::active::SyncVehicles>();
     rScene.get_registry().set<planeta::active::SyncPlanets>();
 
+    // Setup generic physics interface
     rScene.get_registry().set<osp::active::ACtxPhysics>();
 
     // Setup Newton dynamics physics
     ospnewton::SysNewton::setup(rScene);
-
-    // Add default-constructed Newton physics world to scene
-    rScene.reg_emplace<ospnewton::ACompNwtWorld>(rScene.hier_get_root());
 
     // workaround: update the scene right away to initialize physics world
     //             needed by planets for now
@@ -212,6 +210,9 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
 
     rUni.get_reg().destroy(areaSat);
 
+    // Release Newton resources
+    ospnewton::SysNewton::destroy(rScene);
+
     // destruct the application, this closes the window
     pMagnumApp.reset();
 }
@@ -223,13 +224,10 @@ void update_scene(osp::active::ActiveScene& rScene)
     using namespace adera::active::machines;
     using namespace planeta::active;
 
-    // Search Universe for nearby activatable Satellites
-    //SysAreaAssociate::update_scan(rScene);
-
-
     SysAreaAssociate::update_consume(rScene);
 
     SysAreaAssociate::update_translate(rScene);
+    ospnewton::SysNewton::update_translate(rScene);
 
     // Activate or deactivate nearby planets
     SysPlanetA::update_activate(rScene);

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -146,6 +146,8 @@ void testapp::test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
     rScene.get_registry().set<osp::active::SyncVehicles>();
     rScene.get_registry().set<planeta::active::SyncPlanets>();
 
+    rScene.get_registry().set<osp::active::ACtxPhysics>();
+
     // Setup Newton dynamics physics
     ospnewton::SysNewton::setup(rScene);
 


### PR DESCRIPTION
Physics is quite lacking in functionality. For example, there's no way to set velocity (as shown in #127), not to mention how we'd even handle detecting collision events. This PR is a step towards a more solid physics interface.

[This blog post](https://www.gamasutra.com/blogs/NiklasGray/20190611/344437/Syncing_a_dataoriented_ECS_with_a_stateful_external_system.php) talks about the same problem. I've leaned towards the 'list of changes' as the most practical approach for our case.

## Physics Interface

See `src/osp/Active/physics.h`. Note that none of these are specifically related to Newton. I've also been thinking of adding PhysX support some time later.

### ACtxPhysics

Additional communication with the physics system is now handled through ACtxPhysics, the 'context' struct, which is stored in the registry. It is obtainable through `registry.ctx<ACtxPhysics>()`. This EnTT feature of contexts kind of went unnoticed for most of the project's duration.

### Rigid body component?

The rigid body component (ACompRigidBody) is now split into more components:
* ACompPhysBody
* ACompPhysDynamic
* ACompPhysLinearVel
* ACompPhysAngularVel

An entity with only ACompPhysBody and without ACompPhysDynamic will be static, and does not need mass, motion, or inertia data that dynamic bodies need.

Forces and torques can be applied by adding ACompPhysNetForce and ACompPhysNetTorque components.

Dirty flags for updating colliders and inertia are replaced with queues (vectors) stored in ACtxPhysics.

### Setting velocity

Setting velocity is handled through queues alone, without directly modifying ACompPhysLinearVel. There can be cases where multiple systems would want to read the current velocity. If ACompPhysLinearVel was intentionally writable, then that would introduce unnecessary dependency.

Dirty flags are okay for colliders and inertia, because they don't change often and imply a change in other components. Colliders and any other way to describe physics objects ends up being an INPUT read by the physics system. Velocity is an OUTPUT written by the physics engine. Changing it should be handled on some separate channel.

### Origin translation

This is previously handled by SysAreaAssociate alone, which simply translates every entity. The transformation of entities with physics should be fully controlled by the physics system, where the need to modify transformation should be a rare case. Origin translation is a bit of a special case, and there are potential optimizations for moving multiple objects vs individually moving each one (I'm mostly concerned about some broadphase structure getting messed up on the inside). PhysX has origin shifting as a built-in function.

Origin translations for physics can be handled by adding to m_originTranslate in ACtxPhysics.

## Newton improvements

Improved the general 'sturdiness' of the code, and things to comply with the new physics interface changes. There's less reliance on brute force, and better use of callbacks that in theory should improve performance.

## Vehicle separation

Most of the vehicle separation code is still sort of temporary, as a separate 'vehicle structure' system should be the way to go in the future. Aside from changes to how rigid bodies are created, the new set velocity features were used to properly explode the vehicle (not yet for angular velocity however). Separated sections of the vehicle now have the same velocity as the original. 

There was a bug where separated parts are placed without accounting for the vehicle's rotation. This was fixed by removing some outdated center-of-mass calculations. It was simply conflicting with z-adams' inertia calculations. 
