### PR TITLE
Remove Universe from OSPApplication

### DIFF
--- a/src/osp/OSPApplication.h
+++ b/src/osp/OSPApplication.h
@@ -62,22 +62,10 @@ public:
 
     size_t debug_num_packages() const { return m_packages.size(); }
 
-    universe::Universe& get_universe() { return m_universe; }
-
-    void set_universe_update(std::function<void(universe::Universe&)> func)
-    {
-        m_universeUpdate = func;
-    }
-
-    void update_universe() { m_universeUpdate(m_universe); };
-
     const std::shared_ptr<spdlog::logger>& get_logger() { return m_logger; };
 
 private:
     std::map<ResPrefix_t, Package, std::less<>> m_packages;
-
-    universe::Universe m_universe;
-    std::function<void(universe::Universe&)> m_universeUpdate;
 
     const std::shared_ptr<spdlog::logger> m_logger;
 };

--- a/src/test_application/OSPMagnum.cpp
+++ b/src/test_application/OSPMagnum.cpp
@@ -48,10 +48,11 @@ using osp::input::EVarTrigger;
 using osp::input::EVarOperator;
 
 OSPMagnum::OSPMagnum(const Magnum::Platform::Application::Arguments& arguments,
-                     osp::OSPApplication &rOspApp) :
+                     osp::OSPApplication &rOspApp, on_draw_t onDraw) :
         Magnum::Platform::Application{
             arguments,
             Configuration{}.setTitle("OSP-Magnum").setSize({1280, 720})},
+        m_onDraw(onDraw),
         m_userInput(12),
         m_rOspApp(rOspApp)
 {
@@ -68,37 +69,34 @@ OSPMagnum::~OSPMagnum()
 
 void OSPMagnum::drawEvent()
 {
-
-    Magnum::GL::defaultFramebuffer.clear(Magnum::GL::FramebufferClear::Color
-                                         | Magnum::GL::FramebufferClear::Depth);
-
-    m_rOspApp.update_universe();
-
     m_userInput.update_controls();
 
-    for (auto &[name, entry] : m_scenes)
-    {
-        auto &[rScene, updateFunc] = entry;
-        updateFunc(rScene);
-    }
+    m_onDraw(*this);
 
     m_userInput.clear_events();
-
-    for (auto &[name, entry] : m_scenes)
-    {
-        auto &[rScene, updateFunc] = entry;
-        rScene.draw();
-    }
-
-
-    // TODO: GUI and stuff
 
     swapBuffers();
     m_timeline.nextFrame();
     redraw();
 }
 
+void OSPMagnum::update_scenes()
+{
+    for (auto &[name, entry] : m_scenes)
+    {
+        auto &[rScene, updateFunc] = entry;
+        updateFunc(rScene);
+    }
+}
 
+void OSPMagnum::draw_scenes()
+{
+    for (auto &[name, entry] : m_scenes)
+    {
+        auto &[rScene, updateFunc] = entry;
+        rScene.draw();
+    }
+}
 
 void OSPMagnum::keyPressEvent(KeyEvent& event)
 {

--- a/src/test_application/OSPMagnum.h
+++ b/src/test_application/OSPMagnum.h
@@ -58,9 +58,13 @@ class OSPMagnum : public Magnum::Platform::Application
 {
 
 public:
+
+    using on_draw_t = std::function<void(OSPMagnum&)>;
+
     explicit OSPMagnum(
             const Magnum::Platform::Application::Arguments& arguments,
-            osp::OSPApplication &ospApp);
+            osp::OSPApplication &rOspApp,
+            on_draw_t onDraw);
 
     ~OSPMagnum();
 
@@ -71,6 +75,9 @@ public:
     void mouseReleaseEvent(MouseEvent& event) override;
     void mouseMoveEvent(MouseMoveEvent& event) override;
     void mouseScrollEvent(MouseScrollEvent& event) override;
+
+    void update_scenes();
+    void draw_scenes();
 
     osp::active::ActiveScene& scene_create(std::string const& name, SceneUpdate_t upd);
     osp::active::ActiveScene& scene_create(std::string&& name, SceneUpdate_t upd);
@@ -83,6 +90,8 @@ public:
 private:
 
     void drawEvent() override;
+
+    on_draw_t m_onDraw;
 
     osp::input::UserInputHandler m_userInput;
 

--- a/src/test_application/flight.h
+++ b/src/test_application/flight.h
@@ -24,6 +24,7 @@
  */
 
 #include "OSPMagnum.h"
+#include "universes/common.h"
 
 #include <thread>
 
@@ -31,16 +32,23 @@ namespace testapp
 {
 
 /**
- * Start flight scene. This will create an ActiveArea in the universe and start
- * a Magnum application with an ActiveScene. All the necessary systems will be
- * registered to this scenes for in-universe flight, such as SysAreaAssociate.
+ * @brief Start flight scene
+ *
+ * This will create an ActiveArea in the universe and start a Magnum application
+ * with an ActiveScene setup for in-universe flight.
+ *
  * This function blocks execution until the window is closed.
  *
- * @param pMagnumApp [out] Magnum application created
- * @param rOspApp [in,out] OSP universe and resources to run the application on
- * @param args [in] Arguments to pass to Magnum
+ * @param pMagnumApp [out] Container for Magnum application to create for
+ *                         external access
+ * @param rOspApp    [ref] OSP Application containing needed resources
+ * @param rUni       [ref] Universe the flight scene will be connected to
+ * @param rUniUpd    [ref] Universe update function to be called per frame
+ * @param args       [in] Arguments to pass to Magnum
  */
 void test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
-                 osp::OSPApplication& rOspApp, OSPMagnum::Arguments args);
+                 osp::OSPApplication& rOspApp,
+                 osp::universe::Universe& rUni, universe_update_t& rUniUpd,
+                 OSPMagnum::Arguments args);
 
 }

--- a/src/test_application/universes/common.h
+++ b/src/test_application/universes/common.h
@@ -30,6 +30,8 @@
 namespace testapp
 {
 
+using universe_update_t = std::function<void(osp::universe::Universe&)>;
+
 /**
  * @brief Generate an update function for a universe consisting of just a single
  *        CoordspaceCartesianSimple coordinate space and no movement

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -56,9 +56,9 @@ using planeta::universe::UCompPlanet;
 using osp::universe::Vector3g;
 using osp::universe::spaceint_t;
 
-void moon::create(osp::OSPApplication& rOspApp)
+void moon::create(osp::OSPApplication& rOspApp,
+                  Universe& rUni, universe_update_t &rUpdater)
 {
-    Universe &rUni = rOspApp.get_universe();
     Package &rPkg = rOspApp.debug_find_package("lzdb");
 
     Satellite root = rUni.sat_create();
@@ -105,10 +105,10 @@ void moon::create(osp::OSPApplication& rOspApp)
     }
 
     // Add universe update function
-    rOspApp.set_universe_update(generate_simple_universe_update(coordIndex));
+    rUpdater = generate_simple_universe_update(coordIndex);
 
     // Update CoordinateSpace to finish adding the new Satellites
-    rOspApp.update_universe();
+    rUpdater(rUni);
 
     SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created large moon");
 }

--- a/src/test_application/universes/planets.h
+++ b/src/test_application/universes/planets.h
@@ -33,8 +33,11 @@ namespace testapp::moon
 /**
  * @brief Create a universe featuring of a life-sized moon and vehicles
  *
- * @param ospApp [ref] OSP Application to create universe in
+ * @param rOspApp [ref] OSP Application with required resources
+ * @param rUni    [ref] Universe to setup; usually this is empty
+ * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::OSPApplication& rOspApp);
+void create(osp::OSPApplication& rOspApp,
+            osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -54,9 +54,9 @@ using planeta::universe::UCompPlanet;
 
 using osp::universe::Vector3g;
 
-void simplesolarsystem::create(osp::OSPApplication& rOspApp)
+void simplesolarsystem::create(osp::OSPApplication& rOspApp,
+                               Universe& rUni, universe_update_t& rUpdater)
 {
-    Universe &rUni = rOspApp.get_universe();
     Package &rPkg = rOspApp.debug_find_package("lzdb");
 
     Satellite root = rUni.sat_create();
@@ -127,10 +127,10 @@ void simplesolarsystem::create(osp::OSPApplication& rOspApp)
     }
 
     // Add universe update function
-    rOspApp.set_universe_update(generate_simple_universe_update(coordIndex));
+    rUpdater = generate_simple_universe_update(coordIndex);
 
     // Update CoordinateSpace to finish adding the new Satellites
-    rOspApp.update_universe();
+    rUpdater(rUni);
 
     SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created simple solar system");
 }

--- a/src/test_application/universes/simple.h
+++ b/src/test_application/universes/simple.h
@@ -34,8 +34,11 @@ namespace testapp::simplesolarsystem
  * @brief Create a universe with a few unrealistically small planets and some
  *        vehicles
  *
- * @param ospApp [ref] OSP Application to create universe in
+ * @param rOspApp [ref] OSP Application with required resources
+ * @param rUni    [ref] Universe to setup; usually this is empty
+ * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::OSPApplication& rOspApp);
+void create(osp::OSPApplication& rOspApp,
+            osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }


### PR DESCRIPTION
I was explaining the code to an imaginary crow (screw rubber ducks) and realized OSPApplication is not really an application, nor does it have to exist. 

The upcoming architecture.md says that it's the user application's job to manage their own Universes and ActiveScenes. Yet, this mysterious OSPApplication class only allows storing 1 universe.

This PR is the first step to removing OSPApplication, by moving its Universe member to the Test Application.

Changes: 

* Moved universe variable to main.cpp
* Added function arguments in various parts of test_application for universe and its update function
* Added customizable on_draw std::function for OSPMagnum