### PR TITLE
Implement Thread-local logging

### DIFF
--- a/src/adera/Machines/UserControl.cpp
+++ b/src/adera/Machines/UserControl.cpp
@@ -37,7 +37,7 @@
 #include <osp/Active/ActiveScene.h>      // for ActiveScene
 #include <osp/Active/activetypes.h>      // for ActiveEnt, ActiveReg_t
 
-#include <spdlog/spdlog.h>               // for SPDLOG_LOGGER_TRACE
+#include <osp/logging.h>                 // for OSP_LOG_...
 
 #include <iterator>                      // for std::begin, std::end
 #include <algorithm>                     // for std::sort
@@ -116,8 +116,7 @@ void SysMachineUserControl::update_construct(ActiveScene &rScene)
 
 void SysMachineUserControl::update_sensor(ActiveScene &rScene)
 {
-    SPDLOG_LOGGER_TRACE(rScene.get_application().get_logger(),
-                      "Updating all MachineUserControls");
+    OSP_LOG_TRACE("Updating all MachineUserControls");
 
     // InputDevice.IsActivated()
     // Combination

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -41,6 +41,7 @@
 #include <osp/Active/ActiveScene.h>      // for ActiveScene
 #include <osp/Active/activetypes.h>      // for entt::basic_view, entt::basic_sparse_set
 #include <osp/Active/SysHierarchy.h>     // for osp::active::SysHierarchy
+#include <osp/logging.h>                 // for OSP_LOG_...
 
 #include <osp/OSPApplication.h>          // for OSPApplication
 
@@ -48,7 +49,6 @@
 
 #include <entt/entity/entity.hpp>        // for entt::null_t, entt::null
 
-#include <spdlog/spdlog.h>               // for SPDLOG_LOGGER_ERROR, SPDLOG_...
 
 #include <string_view>                   // for string_view
 
@@ -105,15 +105,13 @@ void attach_plume_effect(ActiveScene &rScene, ActiveEnt part, ActiveEnt mach)
 
     if (plumeNode == entt::null)
     {
-        SPDLOG_LOGGER_ERROR(
-                rScene.get_application().get_logger(),
+        OSP_LOG_ERROR(
                 "ERROR: could not find plume anchor for MachineRocket {}",
                 part);
         return;
     }
 
-    SPDLOG_LOGGER_INFO(
-            rScene.get_application().get_logger(),
+    OSP_LOG_INFO(
             "MachineRocket {}'s associated plume: {}",
             part, plumeNode);
 
@@ -130,8 +128,7 @@ void attach_plume_effect(ActiveScene &rScene, ActiveEnt part, ActiveEnt mach)
     DependRes<PlumeEffectData> plumeEffect = rPkg.get<PlumeEffectData>(effectName);
     if (plumeEffect.empty())
     {
-        SPDLOG_LOGGER_ERROR(rScene.get_application().get_logger(),
-                            "ERROR: couldn't find plume effect  {}", effectName);
+        OSP_LOG_ERROR("ERROR: couldn't find plume effect  {}", effectName);
         return;
     }
 

--- a/src/newtondynamics_physics/SysNewton.cpp
+++ b/src/newtondynamics_physics/SysNewton.cpp
@@ -32,13 +32,13 @@
 #include <osp/Active/ActiveScene.h>  // for ActiveScene
 #include <osp/Active/activetypes.h>  // for ActiveReg_t
 
+#include <osp/logging.h>
+
 #include <osp/types.h>               // for Matrix4, Vector3
 #include <osp/CommonPhysics.h>       // for ECollisionShape
 
 #include <entt/signal/sigh.hpp>      // for entt::sink
 #include <entt/entity/entity.hpp>    // for entt::null, entt::null_t
-
-#include <spdlog/spdlog.h>           // for SPDLOG_LOGGER_TRACE
 
 #include <Newton.h>                  // for NewtonBodySetCollision
 
@@ -189,9 +189,8 @@ void SysNewton::update_world(ActiveScene& rScene)
     for (ActiveEnt ent : std::exchange(rPhysCtx.m_inertiaDirty, {}))
     {
         compute_rigidbody_inertia(rScene, ent);
-        SPDLOG_LOGGER_TRACE(m_scene.get_application().get_logger(),
-                            "Updating RB : new CoM Z = {}",
-                            entBody.m_centerOfMassOffset.z());
+        OSP_LOG_TRACE("Updating RB : new CoM Z = {}",
+                      entBody.m_centerOfMassOffset.z());
     }
 
     auto viewNwtBody = rReg.view<ACompNwtBody_t>();
@@ -422,6 +421,5 @@ void SysNewton::compute_rigidbody_inertia(ActiveScene& rScene, ActiveEnt entity)
         rEntDyn.m_inertia.z());
     NewtonBodySetCentreOfMass(rEntNwtBody.get(), centerOfMass.xyz().data());
 
-    SPDLOG_LOGGER_TRACE(m_scene.get_application().get_logger(), "New mass: {}",
-                        entBody.m_mass);
+    OSP_LOG_TRACE("New mass: {}", entBody.m_mass);
 }

--- a/src/osp/Active/SysVehicleSync.cpp
+++ b/src/osp/Active/SysVehicleSync.cpp
@@ -34,7 +34,8 @@
 
 #include "../Satellites/SatActiveArea.h"
 #include "../Satellites/SatVehicle.h"
-#include <osp/OSPApplication.h>
+
+#include <osp/logging.h>
 
 using namespace osp::active;
 
@@ -52,8 +53,7 @@ using namespace Magnum::Math::Literals;
 ActiveEnt SysVehicleSync::activate(ActiveScene &rScene, Universe &rUni,
                                    Satellite areaSat, Satellite tgtSat)
 {
-    SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                      "Loading a vehicle");
+    OSP_LOG_INFO("Loading a vehicle");
 
     auto &loadMeVehicle = rUni.get_reg().get<universe::UCompVehicle>(tgtSat);
     auto &tgtPosTraj = rUni.get_reg().get<universe::UCompTransformTraj>(tgtSat);

--- a/src/osp/Active/SysWire.cpp
+++ b/src/osp/Active/SysWire.cpp
@@ -26,9 +26,7 @@
 #include "SysWire.h"
 #include "ActiveScene.h"
 
-#include <osp/OSPApplication.h>
-
-#include <spdlog/spdlog.h>
+#include <osp/logging.h>
 
 using osp::active::SysWire;
 
@@ -78,8 +76,7 @@ void SysWire::update_wire(ActiveScene &rScene)
         updateLimit --;
         if (0 == updateLimit)
         {
-            SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                               "Wire update limit reached");
+            OSP_LOG_INFO("Wire update limit reached");
             break;
         }
     }

--- a/src/osp/OSPApplication.h
+++ b/src/osp/OSPApplication.h
@@ -34,13 +34,10 @@ namespace osp
 {
 
 
+// TODO: Refactor to more permanent 'package list' or something
 class OSPApplication
 {
 public:
-
-    // put more stuff into here eventually
-
-    OSPApplication();
 
     /**
      * Add a resource package to the application
@@ -62,11 +59,8 @@ public:
 
     size_t debug_num_packages() const { return m_packages.size(); }
 
-    const std::shared_ptr<spdlog::logger>& get_logger() { return m_logger; };
-
 private:
     std::map<ResPrefix_t, Package, std::less<>> m_packages;
 
-    const std::shared_ptr<spdlog::logger> m_logger;
 };
 }

--- a/src/osp/Resource/AssetImporter.h
+++ b/src/osp/Resource/AssetImporter.h
@@ -182,14 +182,6 @@ private:
             PrototypePart& part,
             PartEntity_t parentProtoIndex,
             Magnum::UnsignedInt childGltfIndex);
-
-    /*
-    * This cannot be a reference or else spdlog will complain. Don't know why.
-    */
-    static const std::shared_ptr<spdlog::logger> get_logger() 
-    {
-        return spdlog::get("assetimporter");
-    }
 };
 
 }

--- a/src/osp/UserInputHandler.cpp
+++ b/src/osp/UserInputHandler.cpp
@@ -24,17 +24,16 @@
  */
 #include "UserInputHandler.h"
 #include "string_concat.h"
+#include "logging.h"
 
 #include <Magnum/Math/Functions.h>
 
 namespace osp::input
 {
 
-UserInputHandler::UserInputHandler(std::size_t deviceCount) :
-    m_deviceToButtonRaw(deviceCount)
-{
-    p_logger = spdlog::get("userinput");
-}
+UserInputHandler::UserInputHandler(std::size_t deviceCount)
+ : m_deviceToButtonRaw(deviceCount)
+{ }
 
 bool UserInputHandler::eval_button_expression(
         ControlExpr_t const& expression,
@@ -159,7 +158,7 @@ EButtonControlIndex UserInputHandler::button_subscribe(std::string_view name)
     if (cfgIt == m_btnControlCfg.end())
     {
         // Config not found, no way to have an empty key so far, so throw an exception
-        SPDLOG_LOGGER_ERROR(p_logger, "No config for{}", name);
+        OSP_LOG_ERROR("No config for{}", name);
         throw std::runtime_error(string_concat("Error: no config with ", name));
     }
 
@@ -272,7 +271,7 @@ void UserInputHandler::event_raw(DeviceId deviceId, int buttonEnum,
         return; // button not registered
     }
 
-    SPDLOG_LOGGER_TRACE(p_logger, "sensitive button pressed");
+    OSP_LOG_TRACE("sensitive button pressed");
         
     ButtonRaw &btnRaw = btnIt->second;
 
@@ -337,7 +336,7 @@ void UserInputHandler::update_controls()
                 rControl.m_exprRelease.clear();
                 m_btnControlEvents.emplace_back(index,
                                                 EButtonControlEvent::Triggered);
-                SPDLOG_LOGGER_TRACE(m_to->p_logger, "RELEASE");
+                OSP_LOG_TRACE("RELEASE");
             }
         }
         else if (rControl.m_triggered)
@@ -345,7 +344,7 @@ void UserInputHandler::update_controls()
             // start holding down the control. control.m_exprRelease should
             // have been generated earlier
             rControl.m_held = true;
-            SPDLOG_LOGGER_TRACE(m_to->p_logger, "HOLD");
+            OSP_LOG_TRACE("HOLD");
         }
     }
 

--- a/src/osp/UserInputHandler.h
+++ b/src/osp/UserInputHandler.h
@@ -26,13 +26,13 @@
 
 #include <array>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <map>
 #include <string>
 #include <vector>
-#include <optional>
-#include "types.h"
 
-#include <spdlog/spdlog.h>
+#include "types.h"
 
 namespace osp::input
 {
@@ -337,8 +337,6 @@ private:
     std::vector<ButtonControl> m_btnControls;
 
     std::vector<ButtonControlEvent> m_btnControlEvents;
-
-    std::shared_ptr<spdlog::logger> p_logger;
 
 }; // class UserInputHandler
 

--- a/src/osp/logging.h
+++ b/src/osp/logging.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -22,22 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "OSPApplication.h"
+#pragma once
 
-using namespace osp;
+#include <spdlog/spdlog.h>
 
-void OSPApplication::debug_add_package(Package&& p)
+namespace osp
 {
-    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
-    assert(success);
+
+using logger_t = std::shared_ptr<spdlog::logger>;
+
+inline thread_local logger_t t_currentLogger;
+
+inline void set_thread_logger(logger_t const logger)
+{
+    t_currentLogger = std::move(logger);
 }
 
-Package& OSPApplication::debug_find_package(std::string_view prefix)
-{
-    if (auto it = m_packages.find(prefix); it != m_packages.end())
-    {
-        return it->second;
-    }
-    throw std::out_of_range("Package not found");
 }
 
+#define OSP_LOG_TRACE(...) SPDLOG_LOGGER_TRACE(osp::t_currentLogger, __VA_ARGS__)
+#define OSP_LOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(osp::t_currentLogger, __VA_ARGS__)
+#define OSP_LOG_INFO(...) SPDLOG_LOGGER_INFO(osp::t_currentLogger, __VA_ARGS__)
+#define OSP_LOG_WARN(...) SPDLOG_LOGGER_TRACE(osp::t_currentLogger, __VA_ARGS__)
+#define OSP_LOG_ERROR(...) SPDLOG_LOGGER_TRACE(osp::t_currentLogger, __VA_ARGS__)
+#define OSP_LOG_CRITICAL(...) SPDLOG_LOGGER_TRACE(osp::t_currentLogger, __VA_ARGS__)

--- a/src/planet-a/Active/SysPlanetA.cpp
+++ b/src/planet-a/Active/SysPlanetA.cpp
@@ -31,13 +31,13 @@
 #include <osp/Active/SysRender.h>
 #include <osp/Universe.h>
 #include <osp/string_concat.h>
+#include <osp/logging.h>
 
 #include <Corrade/Containers/ArrayViewStl.h>
 #include <Magnum/Math/Color.h>
 #include <Magnum/GL/Renderer.h>
 
 #include <Magnum/Shaders/MeshVisualizerGL.h>
-#include <osp/OSPApplication.h>
 
 // TODO: Decouple when a proper interface for creating static triangle meshes
 //       is made
@@ -71,8 +71,7 @@ ActiveEnt SysPlanetA::activate(
 {
     using namespace osp::active;
 
-    SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                      "Activating a planet");
+    OSP_LOG_INFO("Activating a planet");
 
     //SysPlanetA& self = scene.get_system<SysPlanetA>();
     auto &loadMePlanet = rUni.get_reg().get<universe::UCompPlanet>(tgtSat);
@@ -192,9 +191,8 @@ void SysPlanetA::update_geometry(ActiveScene& rScene)
             PlanetGeometryA &rPlanetGeo = *(planet.m_planet);
 
             // initialize planet if not done so yet
-            SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                                "Initializing planet because that was not done "
-                                "for some reason");
+            OSP_LOG_INFO("Initializing planet because that was not done "
+                         "for some reason");
             planet.m_icoTree = std::make_shared<IcoSphereTree>();
 
             planet.m_icoTree->initialize(planet.m_radius);
@@ -225,19 +223,16 @@ void SysPlanetA::update_geometry(ActiveScene& rScene)
             rScene.get_registry().ctx<ACtxRenderGroups>().add<MaterialTerrain>(ent);
 
             //planet_update_geometry(ent, planet);
-            SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                                "Initialized planet, constructing colliders");
+            OSP_LOG_INFO("Initialized planet, constructing colliders");
 
             // temporary: make colliders for all the chunks
             for (chindex_t i = 0; i < rPlanetGeo.get_chunk_count(); i ++)
             {
                 debug_create_chunk_collider(rScene, ent, planet, i);
-                SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                                  "* completed chunk collider: {}", i);
+                OSP_LOG_INFO("* completed chunk collider: {}", i);
             }
 
-            SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(),
-                                "Completed planet colliders");
+            OSP_LOG_INFO("Completed planet colliders");
 
             planet.m_vrtxBufGL.setData(rPlanetGeo.get_vertex_buffer());
             planet.m_indxBufGL.setData(rPlanetGeo.get_index_buffer());

--- a/src/planet-a/IcoSphereTree.cpp
+++ b/src/planet-a/IcoSphereTree.cpp
@@ -28,7 +28,7 @@
 #include <cmath>
 #include <array>
 
-#include <spdlog/spdlog.h>
+#include <osp/logging.h>
 
 using namespace planeta;
 
@@ -627,14 +627,13 @@ bool IcoSphereTree::debug_verify_state()
                           tri.m_parent - tri.m_parent % 4)
                 !=  m_trianglesFree.end())
             {
-                SPDLOG_LOGGER_WARN(spdlog::get("application"), "* Invalid triangle {}: Parent is deleted", t);
+                OSP_LOG_WARN("* Invalid triangle {}: Parent is deleted", t);
                 error = true;
             }
 
             if (parent.m_children + tri.m_siblingIndex != t)
             {
-                SPDLOG_LOGGER_WARN(spdlog::get("application"), "* Invalid triangle {}: Parent does not have child",
-                  t);
+                OSP_LOG_WARN("* Invalid triangle {}: Parent does not have child", t);
                 error = true;
             }
 
@@ -643,9 +642,7 @@ bool IcoSphereTree::debug_verify_state()
                              tri.m_children)
                 !=  m_trianglesFree.end())
             {
-                SPDLOG_LOGGER_WARN(spdlog::get("application"),
-                                 "* Invalid triangle {}: Children are deleted",
-                                 t);
+                OSP_LOG_WARN("* Invalid triangle {}: Children are deleted", t);
                 error = true;
             }
         }
@@ -664,27 +661,25 @@ bool IcoSphereTree::debug_verify_state()
                 if (side == -1)
                 {
 
-                    SPDLOG_LOGGER_WARN(
-                        spdlog::get("application"),
-                        "* Invalid triangle {}: Neighbour {} does not recognize "
-                        "this triangle as a neighbour\n",
-                        t, i);
+                    OSP_LOG_WARN(
+                            "* Invalid triangle {}: Neighbour {} does not recognize "
+                            "this triangle as a neighbour\n",
+                            t, i);
                     error = true;
                 }
                 else if (side != tri.m_neighbourSide[i])
                 {
-                    SPDLOG_LOGGER_WARN(
-                        spdlog::get("application"),
-                        "* Invalid triangle {}: Incorrect Neighbour's side\n", t);
+                    OSP_LOG_WARN(
+                            "* Invalid triangle {}: Incorrect Neighbour's side\n",
+                            t);
                     error = true;
                 }
             }
             else if (tri.m_depth < neighbourTri->m_depth)
             {
-                SPDLOG_LOGGER_WARN(
-                    spdlog::get("application"),
-                    "* Invalid triangle {}: Neighbour {} has larger depth\n", t,
-                    i);
+                OSP_LOG_WARN(
+                        "* Invalid triangle {}: Neighbour {} has larger depth\n",
+                        t, i);
                 error = true;
             }
 

--- a/src/planet-a/PlanetGeometryA.cpp
+++ b/src/planet-a/PlanetGeometryA.cpp
@@ -29,9 +29,8 @@
 #include <array>
 #include <cassert>
 
-#include <osp/OSPApplication.h>
+#include <osp/logging.h>
 
-#include <spdlog/spdlog.h>
 #include <Magnum/Math/Functions.h>
 
 
@@ -1207,7 +1206,7 @@ bool PlanetGeometryA::debug_verify_state()
     // Verify vertex sharing if chunked
     // * Loop through shared vertices and make sure the neighbours use them too
 
-    SPDLOG_LOGGER_INFO(spdlog::get("application"), "PlanetGeometryA Verify:");
+    OSP_LOG_INFO("PlanetGeometryA Verify:");
 
     std::vector<uint8_t> recountVrtxSharedUsers(m_vrtxSharedUsers.size(), 0);
 
@@ -1234,9 +1233,7 @@ bool PlanetGeometryA::debug_verify_state()
         if (countDescendentChunked != chunk.m_descendentChunked)
         {
 
-            SPDLOG_LOGGER_WARN(
-              spdlog::get("application"),
-              "* Invalid chunk {}: Incorrect chunked descendent count", t);
+            OSP_LOG_WARN("* Invalid chunk {}: Incorrect chunked descendent count", t);
             error = true;
         }
 
@@ -1262,9 +1259,7 @@ bool PlanetGeometryA::debug_verify_state()
 
             if (ancestorChunked != chunk.m_ancestorChunked)
             {
-                SPDLOG_LOGGER_WARN(
-                    spdlog::get("application"),
-                    "* Invalid chunk {}: Incorrect chunked ancestor", t);
+                OSP_LOG_WARN("* Invalid chunk {}: Incorrect chunked ancestor", t);
                 error = true;
             }
         }
@@ -1287,23 +1282,22 @@ bool PlanetGeometryA::debug_verify_state()
 
     if (chunkCount + m_chunkFree.size() != m_chunkCount)
     {
-        SPDLOG_LOGGER_WARN(spdlog::get("application"), "* Invalid chunk count");
+        OSP_LOG_WARN("* Invalid chunk count");
         error = true;
     }
 
     if (recountVrtxSharedUsers != m_vrtxSharedUsers)
     {
-        SPDLOG_LOGGER_WARN(spdlog::get("application"),
-                         "* Invalid Shared vertex user count");
+        OSP_LOG_WARN("* Invalid Shared vertex user count");
 
         for (planeta::vrindex_t i = 0; i < m_vrtxSharedMax; i ++)
         {
             if (m_vrtxSharedUsers[i] != recountVrtxSharedUsers[i])
             {
-                SPDLOG_LOGGER_WARN(spdlog::get("application"),
-                               "  * Vertex: {}, expected: {}, obtained: {}", i,
-                               int(recountVrtxSharedUsers[i]),
-                               int(m_vrtxSharedUsers[i]));
+                OSP_LOG_WARN("  * Vertex: {}, expected: {}, obtained: {}",
+                             i,
+                             int(recountVrtxSharedUsers[i]),
+                             int(m_vrtxSharedUsers[i]));
             }
         }
 

--- a/src/test_application/CameraController.cpp
+++ b/src/test_application/CameraController.cpp
@@ -33,7 +33,8 @@
 #include <osp/Active/SysPhysics.h>
 #include <osp/Active/SysVehicle.h>
 #include <osp/Active/SysVehicleSync.h>
-#include <osp/OSPApplication.h>
+
+#include <osp/logging.h>
 
 using testapp::SysCameraController;
 using testapp::ACompCameraController;
@@ -116,7 +117,7 @@ bool SysCameraController::try_switch_vehicle(ActiveScene &rScene,
 
     if (rUni.get_reg().valid(rCamCtrl.m_selected))
     {
-      SPDLOG_LOGGER_INFO(rScene.get_application().get_logger(), "Selected: {} ",
+      OSP_LOG_INFO("Selected: {} ",
           rUni.get_reg().get<osp::universe::UCompTransformTraj>(rCamCtrl.m_selected).m_name);
         return true;
     }
@@ -295,8 +296,7 @@ void SysCameraController::update_area(ActiveScene &rScene)
 
     if (!translate.isZero())
     {
-        SPDLOG_LOGGER_TRACE(m_scene.get_application().get_logger(),
-                            "Floating origin translation!");
+        OSP_LOG_TRACE("Floating origin translation!");
 
         // Move the active area to center on the camera
         SysAreaAssociate::area_move(rScene, translate);

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -42,6 +42,8 @@
 #include <osp/Satellites/SatActiveArea.h>
 #include <osp/Satellites/SatVehicle.h>
 
+#include <osp/logging.h>
+
 #include <adera/Machines/Container.h>
 #include <adera/Machines/RCSController.h>
 #include <adera/Machines/Rocket.h>
@@ -210,8 +212,7 @@ void testapp::test_flight(
 
     // Window has been closed
 
-    SPDLOG_LOGGER_INFO(rOspApp.get_logger(),
-                       "Closed Magnum Application");
+    OSP_LOG_INFO("Closed Magnum Application");
 
     rUniUpd(rUni); // make sure universe is in a valid state
 

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -31,6 +31,7 @@
 
 #include <osp/CoordinateSpaces/CartesianSimple.h>
 #include <osp/Trajectories/Stationary.h>
+#include <osp/logging.h>
 
 #include <planet-a/Satellites/SatPlanet.h>
 
@@ -110,5 +111,5 @@ void moon::create(osp::OSPApplication& rOspApp,
     // Update CoordinateSpace to finish adding the new Satellites
     rUpdater(rUni);
 
-    SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created large moon");
+    OSP_LOG_INFO("Created large moon");
 }

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -30,6 +30,7 @@
 
 #include <osp/CoordinateSpaces/CartesianSimple.h>
 #include <osp/Trajectories/Stationary.h>
+#include <osp/logging.h>
 
 #include <planet-a/Satellites/SatPlanet.h>
 
@@ -132,7 +133,7 @@ void simplesolarsystem::create(osp::OSPApplication& rOspApp,
     // Update CoordinateSpace to finish adding the new Satellites
     rUpdater(rUni);
 
-    SPDLOG_LOGGER_INFO(rOspApp.get_logger(), "Created simple solar system");
+    OSP_LOG_INFO("Created simple solar system");
 }
 
 


### PR DESCRIPTION
Step 2 to removing OSPApplication. Important bits are in `src/osp/logging.h` and `src/test_application/main.cpp`.

Storing loggers in thread-local storage avoids global state, without the inconvenience of having to locate them somewhere or passing through function arguments. 

Loggers can be switched between using `osp::set_thread_logger` on the application-level.

```cpp
set_thread_logger(systemALogger);

system_a();

set_thread_logger(systemBLogger);

system_b();
```

Due to the nature of this project, its unlikely that systems (or just most functions in general) would directly call functions into other 'services' (synchronous message passing). This makes thread-local loggers a practical choice.

Contrary what's written above, systems like SysVehicle directly calls AssetImporter, but this will likely not be the case on first release.

Loggers are all managed in main.cpp. This can be moved elsewhere in the future, as long as they're all created or configured in one place.
