### PR TITLE
Add ccache to mac and linux builds to reduce CI times

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,12 +18,18 @@ jobs:
     env:
       CC:  ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang'   }}
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
         submodules: recursive
+
+    - uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: linux-${{ matrix.compiler }}-${{ matrix.config }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,11 +14,19 @@ jobs:
       matrix:
         config: [Release, Debug]
 
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
         submodules: recursive
+
+    - uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: macos-${{ matrix.config }}
 
     - name: Install dependencies
       run: brew install cmake


### PR DESCRIPTION
Sadly, ccache does not work on windows yet.