### PR TITLE
Refactor OSPApplication and OSPMagnum, and Improve Package

### DIFF
--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -106,9 +106,9 @@ MachineContainer& SysMachineContainer::instantiate(
     {
         std::string const& resName = std::get<std::string>(resItr->second);
         Path resPath = decompose_path(resName);
-        Package& pkg = rScene.get_application().debug_find_package(resPath.prefix);
+        Package &rPkg = rScene.get_packages().find(resPath.prefix);
 
-        resource.m_type = pkg.get<ShipResourceType>(resPath.identifier);
+        resource.m_type = rPkg.get<ShipResourceType>(resPath.identifier);
         double fuelLevel = std::get<double>(settings.m_config.at("fuellevel"));
         resource.m_quantity = resource.m_type->resource_capacity(capacity * fuelLevel);
     }

--- a/src/adera/Machines/Container.cpp
+++ b/src/adera/Machines/Container.cpp
@@ -22,28 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "Container.h"                   // IWYU pragma: associated
+#include "Container.h"                    // IWYU pragma: associated
 
-#include <adera/ShipResources.h>         // for ShipResource, ShipResourceType
+#include <adera/ShipResources.h>          // for ShipResource, ShipResourceType
 
-#include <osp/Active/scene.h>            // for ACompMass
+#include <osp/Active/scene.h>             // for ACompMass
 #include <osp/Active/physics.h>
 #include <osp/Active/SysVehicle.h>
-#include <osp/Active/SysMachine.h>       // for ACompMachines
-#include <osp/Active/activetypes.h>      // for ActiveEnt, ActiveReg_t, active
+#include <osp/Active/SysMachine.h>        // for ACompMachines
+#include <osp/Active/activetypes.h>       // for ActiveEnt, ActiveReg_t, active
 #include <osp/Active/ActiveScene.h>
 
-#include <osp/Resource/Package.h>        // for Path, decompose_path, Package
-#include <osp/Resource/machines.h>       // for mach_id, machine_id_t
-#include <osp/Resource/Resource.h>       // for DependRes
-#include <osp/Resource/blueprints.h>     // for BlueprintMachine, BlueprintV...
+#include <osp/Resource/Package.h>         // for Path, decompose_path, Package
+#include <osp/Resource/machines.h>        // for mach_id, machine_id_t
+#include <osp/Resource/Resource.h>        // for DependRes
+#include <osp/Resource/blueprints.h>      // for BlueprintMachine, BlueprintV...
 #include <osp/Resource/PrototypePart.h>
 
-#include <osp/CommonPhysics.h>           // for ECollisionShape, ECollisionS...
-#include <osp/OSPApplication.h>          // for OSPApplication
+#include <osp/CommonPhysics.h>            // for ECollisionShape, ECollisionS...
+#include <osp/Resource/PackageRegistry.h> // for PackageRegistry
 
-#include <variant>                       // for std::get
-#include <utility>                       // for std::exchange
+#include <variant>                        // for std::get
+#include <utility>                        // for std::exchange
 
 // IWYU pragma: no_include <map>
 // IWYU pragma: no_include <vector>

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -35,19 +35,19 @@
 #include <osp/Active/SysMachine.h>       // for ACompMachines
 #include <osp/Active/ActiveScene.h>
 
-#include <osp/Resource/Package.h>        // for Path, decompose_path
-#include <osp/Resource/Resource.h>       // for DependRes
-#include <osp/Resource/machines.h>       // for mach_id, machine_id_t
-#include <osp/Resource/blueprints.h>     // for BlueprintMachine
-#include <osp/Resource/PrototypePart.h>  // for NodeMap_t, PCompMachine
+#include <osp/Resource/Package.h>         // for Path, decompose_path
+#include <osp/Resource/PackageRegistry.h> // for PackageRegistry
+#include <osp/Resource/Resource.h>        // for DependRes
+#include <osp/Resource/machines.h>        // for mach_id, machine_id_t
+#include <osp/Resource/blueprints.h>      // for BlueprintMachine
+#include <osp/Resource/PrototypePart.h>   // for NodeMap_t, PCompMachine
 
-#include <osp/types.h>                   // for Vector3, Matrix4
-#include <osp/OSPApplication.h>
+#include <osp/types.h>                    // for Vector3, Matrix4
 
-#include <vector>                        // for std::vector
-#include <utility>                       // for std::forward
-#include <variant>                       // for std::get
-#include <string_view>                   // for std::string_view
+#include <vector>                         // for std::vector
+#include <utility>                        // for std::forward
+#include <variant>                        // for std::get
+#include <string_view>                    // for std::string_view
 
 // IWYU pragma: no_include "adera/wiretypes.h"
 

--- a/src/adera/Machines/Rocket.cpp
+++ b/src/adera/Machines/Rocket.cpp
@@ -304,7 +304,7 @@ MachineRocket& SysMachineRocket::instantiate(
 
     std::string const& fuelIdent = config_get_if<std::string>(config.m_config, "fueltype", "");
     Path resPath = osp::decompose_path(fuelIdent);
-    Package& pkg = rScene.get_application().debug_find_package(resPath.prefix);
+    Package& pkg = rScene.get_packages().find(resPath.prefix);
     DependRes<ShipResourceType> fuel = pkg.get<ShipResourceType>(resPath.identifier);
 
     return rocket;

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -88,7 +88,7 @@ void PlumeShader::draw_plume(
     if (tmpTex.empty())
     {
         tmpTex = AssetImporter::compile_tex(texName,
-            rScene.get_application().debug_find_package("lzdb"), rResources);
+            rScene.get_packages().find("lzdb"), rResources);
     }
 
     Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -37,7 +37,7 @@
 #include <osp/Active/ActiveScene.h>       // for ActiveScene
 #include <osp/Active/activetypes.h>       // for basic_sparse_set, ActiveEnt
 
-#include <osp/OSPApplication.h>           // for OSPApplication
+#include <osp/Resource/PackageRegistry.h> // for PackageRegistry
 
 #include <Magnum/GL/Shader.h>             // for Shader, Shader::Type
 #include <Magnum/GL/Texture.h>            // for Texture2D

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -120,7 +120,7 @@ void attach_plume_effect(ActiveScene &rScene, ActiveEnt part, ActiveEnt mach)
     using osp::DependRes;
     using osp::Package;
 
-    Package &rPkg = rScene.get_application().debug_find_package("lzdb");
+    Package &rPkg = rScene.get_packages().find("lzdb");
 
     std::string_view effectName = rScene.reg_get<ACompName>(plumeNode).m_name;
     effectName.remove_prefix(3); // removes "fx_"

--- a/src/adera/SysExhaustPlume.cpp
+++ b/src/adera/SysExhaustPlume.cpp
@@ -22,35 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "SysExhaustPlume.h"             // IWYU pragma: associated
+#include "SysExhaustPlume.h"              // IWYU pragma: associated
 
-#include <adera/Plume.h>                 // for PlumeEffectData
-#include <adera/Machines/Rocket.h>       // for MachineRocket
+#include <adera/Plume.h>                  // for PlumeEffectData
+#include <adera/Machines/Rocket.h>        // for MachineRocket
 
-#include <osp/Resource/Package.h>        // for Package
-#include <osp/Resource/machines.h>       // for mach_id, machine_id_t
-#include <osp/Resource/Resource.h>       // for DependRes
-#include <osp/Resource/blueprints.h>     // for BlueprintMachine, BlueprintV...
-#include <osp/Resource/AssetImporter.h>  // for AssetImporter
+#include <osp/Resource/Package.h>         // for Package
+#include <osp/Resource/machines.h>        // for mach_id, machine_id_t
+#include <osp/Resource/Resource.h>        // for DependRes
+#include <osp/Resource/blueprints.h>      // for BlueprintMachine, BlueprintV...
+#include <osp/Resource/AssetImporter.h>   // for AssetImporter
 
-#include <osp/Active/scene.h>            // for ACompName
-#include <osp/Active/drawing.h>          // for ACompShader, ACompVisible
-#include <osp/Active/SysRender.h>        // for ACompMesh
-#include <osp/Active/SysMachine.h>       // for ACompMachines
-#include <osp/Active/SysVehicle.h>       // for ACompVehicle
-#include <osp/Active/ActiveScene.h>      // for ActiveScene
-#include <osp/Active/activetypes.h>      // for entt::basic_view, entt::basic_sparse_set
-#include <osp/Active/SysHierarchy.h>     // for osp::active::SysHierarchy
-#include <osp/logging.h>                 // for OSP_LOG_...
+#include <osp/Active/scene.h>             // for ACompName
+#include <osp/Active/drawing.h>           // for ACompShader, ACompVisible
+#include <osp/Active/SysRender.h>         // for ACompMesh
+#include <osp/Active/SysMachine.h>        // for ACompMachines
+#include <osp/Active/SysVehicle.h>        // for ACompVehicle
+#include <osp/Active/ActiveScene.h>       // for ActiveScene
+#include <osp/Active/activetypes.h>       // for entt::basic_view, entt::basic_sparse_set
+#include <osp/Active/SysHierarchy.h>      // for osp::active::SysHierarchy
+#include <osp/logging.h>                  // for OSP_LOG_...
 
-#include <osp/OSPApplication.h>          // for OSPApplication
+#include <osp/Resource/PackageRegistry.h> // for PackageRegistry
 
-#include <Magnum/GL/Mesh.h>              // for Mesh
+#include <Magnum/GL/Mesh.h>               // for Mesh
 
-#include <entt/entity/entity.hpp>        // for entt::null_t, entt::null
+#include <entt/entity/entity.hpp>         // for entt::null_t, entt::null
 
 
-#include <string_view>                   // for string_view
+#include <string_view>                    // for string_view
 
 // IWYU pragma: no_include <vector>
 // IWYU pragma: no_include <string>

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -56,7 +56,7 @@ void ACompCamera::calculate_projection()
 }
 
 
-ActiveScene::ActiveScene(OSPApplication& rApp, Package& rContext)
+ActiveScene::ActiveScene(PackageRegistry& rApp, Package& rContext)
  : m_app(rApp)
  , m_context(rContext)
 {

--- a/src/osp/Active/ActiveScene.cpp
+++ b/src/osp/Active/ActiveScene.cpp
@@ -56,9 +56,9 @@ void ACompCamera::calculate_projection()
 }
 
 
-ActiveScene::ActiveScene(PackageRegistry& rApp, Package& rContext)
- : m_app(rApp)
- , m_context(rContext)
+ActiveScene::ActiveScene(PackageRegistry& rPkgs, Package& rContext)
+ : m_rPackages(rPkgs)
+ , m_rContext(rContext)
 {
     // Create the root entity
     m_root = m_registry.create();

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -148,7 +148,7 @@ public:
     constexpr PackageRegistry& get_packages() const { return m_rPackages; };
 
     constexpr Package& get_context_resources() { return m_rContext; }
-    constexpr Package& get_context_resources() const { return m_rContext; }
+    constexpr Package const& get_context_resources() const { return m_rContext; }
 
 private:
 

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -53,9 +53,7 @@ class ActiveScene
 
 public:
 
-    ActiveScene(PackageRegistry& rApp, Package& rContext);
-
-    PackageRegistry& get_application() { return m_app; };
+    ActiveScene(PackageRegistry& rPkgs, Package& rContext);
 
     /**
      * @return Root entity of the entire scene graph
@@ -135,18 +133,27 @@ public:
     }
 
     /**
-     * Calculate world transformations and draw to all render targets
+     * @brief Calculate world transformations and draw to all render targets
+     *
+     * @deprecated Move this to somewhere rendering/application related and
+     *             pass render targets as arguments or something
      */
     void draw();
 
     // TODO
     constexpr float get_time_delta_fixed() const { return 1.0f / 60.0f; }
 
-    Package& get_context_resources() { return m_context; }
+
+    constexpr PackageRegistry& get_packages() { return m_rPackages; };
+    constexpr PackageRegistry& get_packages() const { return m_rPackages; };
+
+    constexpr Package& get_context_resources() { return m_rContext; }
+    constexpr Package& get_context_resources() const { return m_rContext; }
+
 private:
 
-    PackageRegistry& m_app;
-    Package& m_context;
+    PackageRegistry &m_rPackages;
+    Package &m_rContext; // Resources specifically for GPU resources
 
     ActiveReg_t m_registry;
     ActiveEnt m_root;

--- a/src/osp/Active/ActiveScene.h
+++ b/src/osp/Active/ActiveScene.h
@@ -35,7 +35,7 @@
 // IWYU pragma: no_include <type_traits>
 
 namespace osp { class Package; }
-namespace osp { class OSPApplication; }
+namespace osp { class PackageRegistry; }
 
 namespace osp::active
 {
@@ -53,9 +53,9 @@ class ActiveScene
 
 public:
 
-    ActiveScene(OSPApplication& rApp, Package& rContext);
+    ActiveScene(PackageRegistry& rApp, Package& rContext);
 
-    OSPApplication& get_application() { return m_app; };
+    PackageRegistry& get_application() { return m_app; };
 
     /**
      * @return Root entity of the entire scene graph
@@ -145,7 +145,7 @@ public:
     Package& get_context_resources() { return m_context; }
 private:
 
-    OSPApplication& m_app;
+    PackageRegistry& m_app;
     Package& m_context;
 
     ActiveReg_t m_registry;

--- a/src/osp/Active/SysPhysics.cpp
+++ b/src/osp/Active/SysPhysics.cpp
@@ -1,10 +1,7 @@
 #include "SysPhysics.h"
 #include "ActiveScene.h"
 
-#include <osp/OSPApplication.h>
-
-#include <spdlog/spdlog.h>
-
+#include <osp/Resource/PackageRegistry.h>
 
 using osp::active::SysPhysics;
 using osp::active::ActiveEnt;

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -28,8 +28,8 @@
 #include "SysRender.h"
 #include "SysVehicle.h"
 #include "physics.h"
-#include <osp/OSPApplication.h>
 
+#include "../Resource/PackageRegistry.h"
 #include "../Resource/PrototypePart.h"
 #include "../Resource/AssetImporter.h"
 

--- a/src/osp/Active/SysVehicle.cpp
+++ b/src/osp/Active/SysVehicle.cpp
@@ -128,8 +128,6 @@ ActiveEnt SysVehicle::part_instantiate(
         using Magnum::GL::Texture2D;
         using Magnum::Trade::ImageData2D;
 
-        Package& package = rScene.get_application().debug_find_package("lzdb");
-
         Package& glResources = rScene.get_context_resources();
         DependRes<MeshData> meshData = pcompDrawable.m_mesh;
         DependRes<Mesh> meshRes = glResources.get<Mesh>(meshData.name());

--- a/src/osp/Resource/Package.cpp
+++ b/src/osp/Resource/Package.cpp
@@ -29,11 +29,6 @@
 namespace osp
 {
 
-Package::Package(std::string prefix, std::string packageName)
- : m_packageName(std::move(packageName))
- , m_prefix(std::move(prefix))
-{ }
-
 StrViewPair_t decompose_str(std::string_view path, const char delim)
 {
     std::size_t pos = path.find(delim);

--- a/src/osp/Resource/PackageRegistry.cpp
+++ b/src/osp/Resource/PackageRegistry.cpp
@@ -26,13 +26,15 @@
 
 using namespace osp;
 
-void PackageRegistry::debug_add_package(Package&& p)
+Package& PackageRegistry::create(ResPrefix_t const prefix)
 {
-    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
+    auto const& [it, success] = m_packages.try_emplace(std::move(prefix));
+
     assert(success);
+    return it->second;
 }
 
-Package& PackageRegistry::debug_find_package(std::string_view prefix)
+Package& PackageRegistry::find(std::string_view const prefix)
 {
     if (auto it = m_packages.find(prefix); it != m_packages.end())
     {

--- a/src/osp/Resource/PackageRegistry.cpp
+++ b/src/osp/Resource/PackageRegistry.cpp
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -22,45 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#pragma once
+#include "PackageRegistry.h"
 
-#include <map>
-#include <spdlog/spdlog.h>
+using namespace osp;
 
-#include "Universe.h"
-#include "Resource/Package.h"
-
-namespace osp
+void PackageRegistry::debug_add_package(Package&& p)
 {
-
-
-// TODO: Refactor to more permanent 'package list' or something
-class OSPApplication
-{
-public:
-
-    /**
-     * Add a resource package to the application
-     *
-     * The package should be populated externally, then passed via rvalue
-     * reference so the contents can be moved into the application resources
-     *
-     * @param p [in] The package to add
-     */
-    void debug_add_package(Package&& p);
-
-    /**
-     * Get a resource package by prefix name
-     *
-     * @param prefix [in] The short prefix name of the package
-     * @return The resource package
-     */
-    Package& debug_find_package(std::string_view prefix);
-
-    size_t debug_num_packages() const { return m_packages.size(); }
-
-private:
-    std::map<ResPrefix_t, Package, std::less<>> m_packages;
-
-};
+    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
+    assert(success);
 }
+
+Package& PackageRegistry::debug_find_package(std::string_view prefix)
+{
+    if (auto it = m_packages.find(prefix); it != m_packages.end())
+    {
+        return it->second;
+    }
+    throw std::out_of_range("Package not found");
+}
+

--- a/src/osp/Resource/PackageRegistry.cpp
+++ b/src/osp/Resource/PackageRegistry.cpp
@@ -24,6 +24,8 @@
  */
 #include "PackageRegistry.h"
 
+#include <stdexcept>
+
 using namespace osp;
 
 Package& PackageRegistry::create(ResPrefix_t const prefix)

--- a/src/osp/Resource/PackageRegistry.h
+++ b/src/osp/Resource/PackageRegistry.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -22,22 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "OSPApplication.h"
+#pragma once
 
-using namespace osp;
+#include "Package.h"
 
-void OSPApplication::debug_add_package(Package&& p)
+#include <map>
+
+namespace osp
 {
-    auto const& [it, success] = m_packages.emplace(p.get_prefix(), std::move(p));
-    assert(success);
-}
 
-Package& OSPApplication::debug_find_package(std::string_view prefix)
+
+// TODO: Refactor to more permanent 'package list' or something
+class PackageRegistry
 {
-    if (auto it = m_packages.find(prefix); it != m_packages.end())
-    {
-        return it->second;
-    }
-    throw std::out_of_range("Package not found");
-}
+public:
 
+    /**
+     * Add a resource package to the application
+     *
+     * The package should be populated externally, then passed via rvalue
+     * reference so the contents can be moved into the application resources
+     *
+     * @param p [in] The package to add
+     */
+    void debug_add_package(Package&& p);
+
+    /**
+     * Get a resource package by prefix name
+     *
+     * @param prefix [in] The short prefix name of the package
+     * @return The resource package
+     */
+    Package& debug_find_package(std::string_view prefix);
+
+    size_t debug_num_packages() const { return m_packages.size(); }
+
+private:
+    std::map<ResPrefix_t, Package, std::less<>> m_packages;
+
+};
+}

--- a/src/osp/Resource/PackageRegistry.h
+++ b/src/osp/Resource/PackageRegistry.h
@@ -31,34 +31,51 @@
 namespace osp
 {
 
+// Prefix for resource paths to indicate which package they're from
+// Ideally, this would be some kind of short string
+using ResPrefix_t = std::string;
 
-// TODO: Refactor to more permanent 'package list' or something
+/**
+ * @brief Stores Packages identifiable through a short prefix
+ *
+ * PackageRegistry is intended to store resources accessible throughout the
+ * entire application, organized by Package.
+ */
 class PackageRegistry
-{
+{    
 public:
 
-    /**
-     * Add a resource package to the application
-     *
-     * The package should be populated externally, then passed via rvalue
-     * reference so the contents can be moved into the application resources
-     *
-     * @param p [in] The package to add
-     */
-    void debug_add_package(Package&& p);
+    using Map_t = std::map<ResPrefix_t, Package, std::less<>>;
 
     /**
-     * Get a resource package by prefix name
+     * @brief Create a new resource package
+     *
+     * @param prefix [in] Prefix of package to add
+     *
+     * @return newly created Package
+     */
+    Package& create(ResPrefix_t const prefix);
+
+    /**
+     * @brief Get a resource package by prefix name
      *
      * @param prefix [in] The short prefix name of the package
      * @return The resource package
      */
-    Package& debug_find_package(std::string_view prefix);
+    Package& find(std::string_view const prefix);
 
-    size_t debug_num_packages() const { return m_packages.size(); }
+    /**
+     * @return Read-only internal map
+     */
+    constexpr Map_t const& get_map() const noexcept { return m_packages; };
+
+    /**
+     * @return Number of registered packages
+     */
+    size_t count() const noexcept { return m_packages.size(); }
 
 private:
-    std::map<ResPrefix_t, Package, std::less<>> m_packages;
+    Map_t m_packages;
 
 };
 }

--- a/src/osp/Satellites/SatActiveArea.h
+++ b/src/osp/Satellites/SatActiveArea.h
@@ -37,9 +37,6 @@
 namespace osp::universe
 {
 
-class OSPMagnum;
-class SatActiveArea;
-
 /**
  * @brief Tag for satellites that can be activated
  *

--- a/src/test_application/ActiveApplication.cpp
+++ b/src/test_application/ActiveApplication.cpp
@@ -48,13 +48,13 @@ using osp::input::EVarTrigger;
 using osp::input::EVarOperator;
 
 ActiveApplication::ActiveApplication(const Magnum::Platform::Application::Arguments& arguments,
-                     osp::PackageRegistry &rOspApp, on_draw_t onDraw) :
+                     osp::PackageRegistry &rPkgs, on_draw_t onDraw) :
         Magnum::Platform::Application{
             arguments,
             Configuration{}.setTitle("OSP-Magnum").setSize({1280, 720})},
         m_onDraw(onDraw),
         m_userInput(12),
-        m_rOspApp(rOspApp)
+        m_rPackages(rPkgs)
 {
     //.setWindowFlags(Configuration::WindowFlag::Hidden)
 
@@ -138,7 +138,7 @@ osp::active::ActiveScene& ActiveApplication::scene_create(std::string const& nam
 {
     auto const& [it, success] =
         m_scenes.try_emplace(
-            name, osp::active::ActiveScene{m_rOspApp, m_glResources}, upd);
+            name, osp::active::ActiveScene{m_rPackages, m_glResources}, upd);
     return it->second.first;
 }
 
@@ -147,16 +147,16 @@ osp::active::ActiveScene& ActiveApplication::scene_create(std::string && name, S
     auto const& [it, success] =
         m_scenes.try_emplace(
             std::move(name),
-            osp::active::ActiveScene{m_rOspApp, m_glResources}, upd);
+            osp::active::ActiveScene{m_rPackages, m_glResources}, upd);
     return it->second.first;
 }
 
-void testapp::config_controls(ActiveApplication& rOspApp)
+void testapp::config_controls(ActiveApplication& rPkgs)
 {
     // Configure Controls
     //Load toml
     auto data = toml::parse("settings.toml");
-    osp::input::UserInputHandler& rUserInput = rOspApp.get_input_handler();
+    osp::input::UserInputHandler& rUserInput = rPkgs.get_input_handler();
     for (const auto& [k, v] : data.as_table())
     {
         std::string const& primary = toml::find(v, "primary").as_string();

--- a/src/test_application/ActiveApplication.cpp
+++ b/src/test_application/ActiveApplication.cpp
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#include "OSPMagnum.h"
+#include "ActiveApplication.h"
 #include "osp/types.h"
 #include "osp/Active/SysHierarchy.h"
 
@@ -36,8 +36,8 @@
 
 using namespace testapp;
 
-using Key_t = OSPMagnum::KeyEvent::Key;
-using Mouse_t = OSPMagnum::MouseEvent::Button;
+using Key_t = ActiveApplication::KeyEvent::Key;
+using Mouse_t = ActiveApplication::MouseEvent::Button;
 
 using osp::input::sc_keyboard;
 using osp::input::sc_mouse;
@@ -47,7 +47,7 @@ using osp::input::ControlExprConfig_t;
 using osp::input::EVarTrigger;
 using osp::input::EVarOperator;
 
-OSPMagnum::OSPMagnum(const Magnum::Platform::Application::Arguments& arguments,
+ActiveApplication::ActiveApplication(const Magnum::Platform::Application::Arguments& arguments,
                      osp::OSPApplication &rOspApp, on_draw_t onDraw) :
         Magnum::Platform::Application{
             arguments,
@@ -61,13 +61,13 @@ OSPMagnum::OSPMagnum(const Magnum::Platform::Application::Arguments& arguments,
     m_timeline.start();
 }
 
-OSPMagnum::~OSPMagnum()
+ActiveApplication::~ActiveApplication()
 {
     // Clear scene data before GL resources are freed
     m_scenes.clear();
 }
 
-void OSPMagnum::drawEvent()
+void ActiveApplication::drawEvent()
 {
     m_userInput.update_controls();
 
@@ -80,7 +80,7 @@ void OSPMagnum::drawEvent()
     redraw();
 }
 
-void OSPMagnum::update_scenes()
+void ActiveApplication::update_scenes()
 {
     for (auto &[name, entry] : m_scenes)
     {
@@ -89,7 +89,7 @@ void OSPMagnum::update_scenes()
     }
 }
 
-void OSPMagnum::draw_scenes()
+void ActiveApplication::draw_scenes()
 {
     for (auto &[name, entry] : m_scenes)
     {
@@ -98,43 +98,43 @@ void OSPMagnum::draw_scenes()
     }
 }
 
-void OSPMagnum::keyPressEvent(KeyEvent& event)
+void ActiveApplication::keyPressEvent(KeyEvent& event)
 {
     if (event.isRepeated()) { return; }
     m_userInput.event_raw(osp::input::sc_keyboard, (int) event.key(),
                           osp::input::EButtonEvent::Pressed);
 }
 
-void OSPMagnum::keyReleaseEvent(KeyEvent& event)
+void ActiveApplication::keyReleaseEvent(KeyEvent& event)
 {
     if (event.isRepeated()) { return; }
     m_userInput.event_raw(osp::input::sc_keyboard, (int) event.key(),
                           osp::input::EButtonEvent::Released);
 }
 
-void OSPMagnum::mousePressEvent(MouseEvent& event)
+void ActiveApplication::mousePressEvent(MouseEvent& event)
 {
     m_userInput.event_raw(osp::input::sc_mouse, (int) event.button(),
                           osp::input::EButtonEvent::Pressed);
 }
 
-void OSPMagnum::mouseReleaseEvent(MouseEvent& event)
+void ActiveApplication::mouseReleaseEvent(MouseEvent& event)
 {
     m_userInput.event_raw(osp::input::sc_mouse, (int) event.button(),
                           osp::input::EButtonEvent::Released);
 }
 
-void OSPMagnum::mouseMoveEvent(MouseMoveEvent& event)
+void ActiveApplication::mouseMoveEvent(MouseMoveEvent& event)
 {
     m_userInput.mouse_delta(event.relativePosition());
 }
 
-void OSPMagnum::mouseScrollEvent(MouseScrollEvent & event)
+void ActiveApplication::mouseScrollEvent(MouseScrollEvent & event)
 {
     m_userInput.scroll_delta(static_cast<osp::Vector2i>(event.offset()));
 }
 
-osp::active::ActiveScene& OSPMagnum::scene_create(std::string const& name, SceneUpdate_t upd)
+osp::active::ActiveScene& ActiveApplication::scene_create(std::string const& name, SceneUpdate_t upd)
 {
     auto const& [it, success] =
         m_scenes.try_emplace(
@@ -142,7 +142,7 @@ osp::active::ActiveScene& OSPMagnum::scene_create(std::string const& name, Scene
     return it->second.first;
 }
 
-osp::active::ActiveScene& OSPMagnum::scene_create(std::string && name, SceneUpdate_t upd)
+osp::active::ActiveScene& ActiveApplication::scene_create(std::string && name, SceneUpdate_t upd)
 {
     auto const& [it, success] =
         m_scenes.try_emplace(
@@ -151,7 +151,7 @@ osp::active::ActiveScene& OSPMagnum::scene_create(std::string && name, SceneUpda
     return it->second.first;
 }
 
-void testapp::config_controls(OSPMagnum& rOspApp)
+void testapp::config_controls(ActiveApplication& rOspApp)
 {
     // Configure Controls
     //Load toml
@@ -257,9 +257,9 @@ const std::map<std::string_view, button_pair_t, std::less<>> gc_buttonMap = {
     {"F12", {sc_keyboard, (int)Key_t::F12  }},
 
     //Mouse
-    {"RMouse", {sc_mouse, (int)OSPMagnum::MouseEvent::Button::Right }},
-    {"LMouse", {sc_mouse, (int)OSPMagnum::MouseEvent::Button::Left }},
-    {"MMouse", {sc_mouse, (int)OSPMagnum::MouseEvent::Button::Middle }}
+    {"RMouse", {sc_mouse, (int)ActiveApplication::MouseEvent::Button::Right }},
+    {"LMouse", {sc_mouse, (int)ActiveApplication::MouseEvent::Button::Left }},
+    {"MMouse", {sc_mouse, (int)ActiveApplication::MouseEvent::Button::Middle }}
 };
 
 ControlExprConfig_t parse_control(std::string_view str) noexcept

--- a/src/test_application/ActiveApplication.cpp
+++ b/src/test_application/ActiveApplication.cpp
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -48,7 +48,7 @@ using osp::input::EVarTrigger;
 using osp::input::EVarOperator;
 
 ActiveApplication::ActiveApplication(const Magnum::Platform::Application::Arguments& arguments,
-                     osp::OSPApplication &rOspApp, on_draw_t onDraw) :
+                     osp::PackageRegistry &rOspApp, on_draw_t onDraw) :
         Magnum::Platform::Application{
             arguments,
             Configuration{}.setTitle("OSP-Magnum").setSize({1280, 720})},

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -24,15 +24,13 @@
  */
 #pragma once
 
-#include <osp/types.h>
-#include <osp/Resource/PackageRegistry.h>
-#include <osp/Universe.h>
-#include <osp/UserInputHandler.h>
-#include <osp/Satellites/SatActiveArea.h>
 #include <osp/Active/ActiveScene.h>
+#include <osp/Resource/PackageRegistry.h>
+
+#include <osp/types.h>
+#include <osp/UserInputHandler.h>
 
 #include <Magnum/Timeline.h>
-#include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/Buffer.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
@@ -52,6 +50,11 @@ using MapActiveScene_t = std::map<
         std::pair<osp::active::ActiveScene, SceneUpdate_t>,
         std::less<> >;
 
+/**
+ * @brief An interactive Magnum application made for running ActiveScenes
+ *
+ * These scenes can be a flight scene, map view, vehicle editor, or menu.
+ */
 class ActiveApplication : public Magnum::Platform::Application
 {
 
@@ -61,7 +64,7 @@ public:
 
     explicit ActiveApplication(
             const Magnum::Platform::Application::Arguments& arguments,
-            osp::PackageRegistry &rOspApp,
+            osp::PackageRegistry &rPkgs,
             on_draw_t onDraw);
 
     ~ActiveApplication();
@@ -95,14 +98,14 @@ private:
 
     MapActiveScene_t m_scenes;
 
-    osp::Package m_glResources{"gl", "gl-resources"};
+    osp::PackageRegistry &m_rPackages;
+
+    osp::Package m_glResources;
 
     Magnum::Timeline m_timeline;
-
-    osp::PackageRegistry& m_rOspApp;
 };
 
-void config_controls(ActiveApplication& rOspApp);
+void config_controls(ActiveApplication& rPkgs);
 
 }
 

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <osp/types.h>
-#include <osp/OSPApplication.h>
+#include <osp/Resource/PackageRegistry.h>
 #include <osp/Universe.h>
 #include <osp/UserInputHandler.h>
 #include <osp/Satellites/SatActiveArea.h>
@@ -61,7 +61,7 @@ public:
 
     explicit ActiveApplication(
             const Magnum::Platform::Application::Arguments& arguments,
-            osp::OSPApplication &rOspApp,
+            osp::PackageRegistry &rOspApp,
             on_draw_t onDraw);
 
     ~ActiveApplication();
@@ -99,7 +99,7 @@ private:
 
     Magnum::Timeline m_timeline;
 
-    osp::OSPApplication& m_rOspApp;
+    osp::PackageRegistry& m_rOspApp;
 };
 
 void config_controls(ActiveApplication& rOspApp);

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -35,6 +35,7 @@
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/Math/Color.h>
+#include <cstring> // workaround: memcpy needed by SDL2
 #include <Magnum/Platform/Sdl2Application.h>
 #include <Magnum/Shaders/VertexColorGL.h>
 

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -42,8 +42,6 @@
 
 #include <memory>
 
-#include "osp/UserInputHandler.h"
-
 namespace testapp
 {
 
@@ -54,19 +52,19 @@ using MapActiveScene_t = std::map<
         std::pair<osp::active::ActiveScene, SceneUpdate_t>,
         std::less<> >;
 
-class OSPMagnum : public Magnum::Platform::Application
+class ActiveApplication : public Magnum::Platform::Application
 {
 
 public:
 
-    using on_draw_t = std::function<void(OSPMagnum&)>;
+    using on_draw_t = std::function<void(ActiveApplication&)>;
 
-    explicit OSPMagnum(
+    explicit ActiveApplication(
             const Magnum::Platform::Application::Arguments& arguments,
             osp::OSPApplication &rOspApp,
             on_draw_t onDraw);
 
-    ~OSPMagnum();
+    ~ActiveApplication();
 
     void keyPressEvent(KeyEvent& event) override;
     void keyReleaseEvent(KeyEvent& event) override;
@@ -104,7 +102,7 @@ private:
     osp::OSPApplication& m_rOspApp;
 };
 
-void config_controls(OSPMagnum& rOspApp);
+void config_controls(ActiveApplication& rOspApp);
 
 }
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -119,14 +119,14 @@ void active_area_destroy(
         osp::OSPApplication& rOspApp, Universe &rUni, Satellite areaSat);
 
 void testapp::test_flight(
-        std::unique_ptr<OSPMagnum>& pMagnumApp, osp::OSPApplication& rOspApp,
-        Universe &rUni, universe_update_t& rUniUpd, OSPMagnum::Arguments args)
+        std::unique_ptr<ActiveApplication>& pMagnumApp, osp::OSPApplication& rOspApp,
+        Universe &rUni, universe_update_t& rUniUpd, ActiveApplication::Arguments args)
 {
 
     // Create the application, and its draw function
-    pMagnumApp = std::make_unique<OSPMagnum>(
+    pMagnumApp = std::make_unique<ActiveApplication>(
             args, rOspApp,
-            [&rUniUpd, &rUni] (OSPMagnum& rMagnumApp)
+            [&rUniUpd, &rUni] (ActiveApplication& rMagnumApp)
     {
         // Update the universe each frame
         // This likely wouldn't be here in the future
@@ -207,7 +207,7 @@ void testapp::test_flight(
     rScene.reg_emplace<ACompRenderer>(camera);
 
     // Starts the main loop. This function is blocking, and will only return
-    // once the window is closed. See OSPMagnum::drawEvent
+    // once the window is closed. See ActiveApplication::drawEvent
     pMagnumApp->exec();
 
     // Window has been closed

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -112,20 +112,20 @@ void update_scene(ActiveScene& rScene);
 void setup_wiring(ActiveScene& rScene);
 
 Satellite active_area_create(
-        osp::PackageRegistry& rOspApp, Universe &rUni,
+        osp::PackageRegistry& rPkgs, Universe &rUni,
         coordspace_index_t targetCoordspace);
 
 void active_area_destroy(
-        osp::PackageRegistry& rOspApp, Universe &rUni, Satellite areaSat);
+        osp::PackageRegistry& rPkgs, Universe &rUni, Satellite areaSat);
 
 void testapp::test_flight(
-        std::unique_ptr<ActiveApplication>& pMagnumApp, osp::PackageRegistry& rOspApp,
+        std::unique_ptr<ActiveApplication>& pMagnumApp, osp::PackageRegistry& rPkgs,
         Universe &rUni, universe_update_t& rUniUpd, ActiveApplication::Arguments args)
 {
 
     // Create the application, and its draw function
     pMagnumApp = std::make_unique<ActiveApplication>(
-            args, rOspApp,
+            args, rPkgs,
             [&rUniUpd, &rUni] (ActiveApplication& rMagnumApp)
     {
         // Update the universe each frame
@@ -149,7 +149,7 @@ void testapp::test_flight(
     setup_wiring(rScene);
 
     // create a Satellite with an ActiveArea, then link it to the scene
-    Satellite areaSat = active_area_create(rOspApp, rUni, 0);
+    Satellite areaSat = active_area_create(rPkgs, rUni, 0);
     rUniUpd(rUni);
     osp::active::SysAreaAssociate::connect(rScene, rUni, areaSat);
 
@@ -216,7 +216,7 @@ void testapp::test_flight(
 
     rUniUpd(rUni); // make sure universe is in a valid state
 
-    active_area_destroy(rOspApp, rUni, areaSat); // Disconnect ActiveArea
+    active_area_destroy(rPkgs, rUni, areaSat); // Disconnect ActiveArea
     rUniUpd(rUni);
 
     rUni.get_reg().destroy(areaSat);
@@ -331,7 +331,7 @@ void setup_wiring(ActiveScene& rScene)
 }
 
 Satellite active_area_create(
-        osp::PackageRegistry& rOspApp, Universe &rUni,
+        osp::PackageRegistry& rPkgs, Universe &rUni,
         coordspace_index_t targetIndex)
 {
     using namespace osp::universe;
@@ -384,7 +384,7 @@ Satellite active_area_create(
 }
 
 void active_area_destroy(
-        osp::PackageRegistry& rOspApp, Universe &rUni, Satellite areaSat)
+        osp::PackageRegistry& rPkgs, Universe &rUni, Satellite areaSat)
 {
     using namespace osp::universe;
 

--- a/src/test_application/flight.cpp
+++ b/src/test_application/flight.cpp
@@ -112,14 +112,14 @@ void update_scene(ActiveScene& rScene);
 void setup_wiring(ActiveScene& rScene);
 
 Satellite active_area_create(
-        osp::OSPApplication& rOspApp, Universe &rUni,
+        osp::PackageRegistry& rOspApp, Universe &rUni,
         coordspace_index_t targetCoordspace);
 
 void active_area_destroy(
-        osp::OSPApplication& rOspApp, Universe &rUni, Satellite areaSat);
+        osp::PackageRegistry& rOspApp, Universe &rUni, Satellite areaSat);
 
 void testapp::test_flight(
-        std::unique_ptr<ActiveApplication>& pMagnumApp, osp::OSPApplication& rOspApp,
+        std::unique_ptr<ActiveApplication>& pMagnumApp, osp::PackageRegistry& rOspApp,
         Universe &rUni, universe_update_t& rUniUpd, ActiveApplication::Arguments args)
 {
 
@@ -331,7 +331,7 @@ void setup_wiring(ActiveScene& rScene)
 }
 
 Satellite active_area_create(
-        osp::OSPApplication& rOspApp, Universe &rUni,
+        osp::PackageRegistry& rOspApp, Universe &rUni,
         coordspace_index_t targetIndex)
 {
     using namespace osp::universe;
@@ -384,7 +384,7 @@ Satellite active_area_create(
 }
 
 void active_area_destroy(
-        osp::OSPApplication& rOspApp, Universe &rUni, Satellite areaSat)
+        osp::PackageRegistry& rOspApp, Universe &rUni, Satellite areaSat)
 {
     using namespace osp::universe;
 

--- a/src/test_application/flight.h
+++ b/src/test_application/flight.h
@@ -41,13 +41,13 @@ namespace testapp
  *
  * @param pMagnumApp [out] Container for Magnum application to create for
  *                         external access
- * @param rOspApp    [ref] OSP Application containing needed resources
+ * @param rPkgs      [ref] Packages containing needed resources
  * @param rUni       [ref] Universe the flight scene will be connected to
  * @param rUniUpd    [ref] Universe update function to be called per frame
  * @param args       [in] Arguments to pass to Magnum
  */
 void test_flight(std::unique_ptr<ActiveApplication>& pMagnumApp,
-                 osp::PackageRegistry& rOspApp,
+                 osp::PackageRegistry& rPkgs,
                  osp::universe::Universe& rUni, universe_update_t& rUniUpd,
                  ActiveApplication::Arguments args);
 

--- a/src/test_application/flight.h
+++ b/src/test_application/flight.h
@@ -47,7 +47,7 @@ namespace testapp
  * @param args       [in] Arguments to pass to Magnum
  */
 void test_flight(std::unique_ptr<ActiveApplication>& pMagnumApp,
-                 osp::OSPApplication& rOspApp,
+                 osp::PackageRegistry& rOspApp,
                  osp::universe::Universe& rUni, universe_update_t& rUniUpd,
                  ActiveApplication::Arguments args);
 

--- a/src/test_application/flight.h
+++ b/src/test_application/flight.h
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-#include "OSPMagnum.h"
+#include "ActiveApplication.h"
 #include "universes/common.h"
 
 #include <thread>
@@ -46,9 +46,9 @@ namespace testapp
  * @param rUniUpd    [ref] Universe update function to be called per frame
  * @param args       [in] Arguments to pass to Magnum
  */
-void test_flight(std::unique_ptr<OSPMagnum>& pMagnumApp,
+void test_flight(std::unique_ptr<ActiveApplication>& pMagnumApp,
                  osp::OSPApplication& rOspApp,
                  osp::universe::Universe& rUni, universe_update_t& rUniUpd,
-                 OSPMagnum::Arguments args);
+                 ActiveApplication::Arguments args);
 
 }

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -87,7 +87,7 @@ void debug_print_hier();
 void debug_print_machines();
 
 // Stores loaded resources in packages.
-osp::OSPApplication g_osp;
+osp::PackageRegistry g_osp;
 
 // Test application stores 1 universe and its update function
 osp::universe::Universe g_universe;

--- a/src/test_application/universes/common.h
+++ b/src/test_application/universes/common.h
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include <osp/OSPApplication.h>
+#include <osp/Universe.h>
+#include <osp/Resource/PackageRegistry.h>
 
 namespace testapp
 {

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -38,6 +38,7 @@
 using namespace testapp;
 
 using osp::Package;
+using osp::PackageRegistry;
 
 using osp::universe::Satellite;
 using osp::universe::Universe;
@@ -57,7 +58,7 @@ using planeta::universe::UCompPlanet;
 using osp::universe::Vector3g;
 using osp::universe::spaceint_t;
 
-void moon::create(osp::OSPApplication& rOspApp,
+void moon::create(PackageRegistry& rOspApp,
                   Universe& rUni, universe_update_t &rUpdater)
 {
     Package &rPkg = rOspApp.debug_find_package("lzdb");

--- a/src/test_application/universes/planets.cpp
+++ b/src/test_application/universes/planets.cpp
@@ -58,10 +58,10 @@ using planeta::universe::UCompPlanet;
 using osp::universe::Vector3g;
 using osp::universe::spaceint_t;
 
-void moon::create(PackageRegistry& rOspApp,
+void moon::create(PackageRegistry& rPkgs,
                   Universe& rUni, universe_update_t &rUpdater)
 {
-    Package &rPkg = rOspApp.debug_find_package("lzdb");
+    Package &rPkg = rPkgs.find("lzdb");
 
     Satellite root = rUni.sat_create();
 

--- a/src/test_application/universes/planets.h
+++ b/src/test_application/universes/planets.h
@@ -37,7 +37,7 @@ namespace testapp::moon
  * @param rUni    [ref] Universe to setup; usually this is empty
  * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::OSPApplication& rOspApp,
+void create(osp::PackageRegistry& rOspApp,
             osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }

--- a/src/test_application/universes/planets.h
+++ b/src/test_application/universes/planets.h
@@ -33,11 +33,11 @@ namespace testapp::moon
 /**
  * @brief Create a universe featuring of a life-sized moon and vehicles
  *
- * @param rOspApp [ref] OSP Application with required resources
+ * @param rPkgs   [ref] Packages containing needed resources
  * @param rUni    [ref] Universe to setup; usually this is empty
  * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::PackageRegistry& rOspApp,
+void create(osp::PackageRegistry& rPkgs,
             osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -37,6 +37,7 @@
 using namespace testapp;
 
 using osp::Package;
+using osp::PackageRegistry;
 
 using osp::universe::Satellite;
 using osp::universe::Universe;
@@ -55,7 +56,7 @@ using planeta::universe::UCompPlanet;
 
 using osp::universe::Vector3g;
 
-void simplesolarsystem::create(osp::OSPApplication& rOspApp,
+void simplesolarsystem::create(PackageRegistry& rOspApp,
                                Universe& rUni, universe_update_t& rUpdater)
 {
     Package &rPkg = rOspApp.debug_find_package("lzdb");

--- a/src/test_application/universes/simple.cpp
+++ b/src/test_application/universes/simple.cpp
@@ -56,10 +56,10 @@ using planeta::universe::UCompPlanet;
 
 using osp::universe::Vector3g;
 
-void simplesolarsystem::create(PackageRegistry& rOspApp,
+void simplesolarsystem::create(PackageRegistry& rPkgs,
                                Universe& rUni, universe_update_t& rUpdater)
 {
-    Package &rPkg = rOspApp.debug_find_package("lzdb");
+    Package &rPkg = rPkgs.find("lzdb");
 
     Satellite root = rUni.sat_create();
 

--- a/src/test_application/universes/simple.h
+++ b/src/test_application/universes/simple.h
@@ -38,7 +38,7 @@ namespace testapp::simplesolarsystem
  * @param rUni    [ref] Universe to setup; usually this is empty
  * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::OSPApplication& rOspApp,
+void create(osp::PackageRegistry& rOspApp,
             osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }

--- a/src/test_application/universes/simple.h
+++ b/src/test_application/universes/simple.h
@@ -34,11 +34,11 @@ namespace testapp::simplesolarsystem
  * @brief Create a universe with a few unrealistically small planets and some
  *        vehicles
  *
- * @param rOspApp [ref] OSP Application with required resources
+ * @param rPkgs   [ref] Packages containing needed resources
  * @param rUni    [ref] Universe to setup; usually this is empty
  * @param rUniUpd [out] Associated universe update function to set
  */
-void create(osp::PackageRegistry& rOspApp,
+void create(osp::PackageRegistry& rPkgs,
             osp::universe::Universe& rUni, universe_update_t &rUniUpd);
 
 }


### PR DESCRIPTION
Depends on #153

Final step to removing OSPApplication.

* OSPApplication only stores packages, so it's renamed to PackageRegistry and moved to `src/osp/Resource`.
* OSPMagnum is renamed to ActiveApplication. This better hints at its purpose in the program along with relevant docs.
* Packages don't need to store their own name prefix; these members were removed. the `group_get()` function was made const-friendly.
* Variable names and docs in many other places were changed accordingly

Important changes in files:
* `src/test_application/ActiveApplication.cpp`
* `src/osp/Resource/PackageRegistry.cpp`
* `src/osp/Resource/Package.h`