### PR TITLE
Port physics & Newton Dynamics to new architecture, Add physics test, Add delete systems

### DIFF
--- a/bin/settings.toml
+++ b/bin/settings.toml
@@ -103,8 +103,38 @@ primary = "Right"
 secondary = "None"
 holdable = true
 
-[ui_rmb]
+[cam_orbit]
 primary = "RMouse"
+secondary = "None"
+holdable = true
+
+[cam_fd]
+primary = "W"
+secondary = "None"
+holdable = true
+
+[cam_bk]
+primary = "S"
+secondary = "None"
+holdable = true
+
+[cam_lf]
+primary = "A"
+secondary = "None"
+holdable = true
+
+[cam_rt]
+primary = "D"
+secondary = "None"
+holdable = true
+
+[cam_up]
+primary = "Q"
+secondary = "None"
+holdable = true
+
+[cam_dn]
+primary = "E"
 secondary = "None"
 holdable = true
 

--- a/bin/settings.toml
+++ b/bin/settings.toml
@@ -138,6 +138,11 @@ primary = "E"
 secondary = "None"
 holdable = true
 
+[debug_throw]
+primary = "Space"
+secondary = "None"
+holdable = true
+
 [debug_planet_update]
 primary = "LCtrl+1"
 secondary = "None"

--- a/src/newtondynamics_physics/SysNewton.cpp
+++ b/src/newtondynamics_physics/SysNewton.cpp
@@ -68,7 +68,6 @@ using osp::active::SysPhysics;
 
 using osp::active::ACompHierarchy;
 using osp::active::ACompShape;
-using osp::active::ACompSolidCollider;
 using osp::active::ACompTransform;
 using osp::active::ACompTransformControlled;
 using osp::active::ACompTransformMutable;
@@ -170,11 +169,11 @@ void SysNewton::update_translate(ACtxPhysics& rCtxPhys, ACtxNwtWorld& rCtxWorld)
 
 void SysNewton::update_colliders(
         ACtxPhysics &rCtxPhys, ACtxNwtWorld &rCtxWorld,
-        std::vector<ActiveEnt> &rCollidersDirty)
+        std::vector<ActiveEnt> const &collidersDirty)
 {
     using osp::phys::EShape;
 
-    for (ActiveEnt ent : rCollidersDirty)
+    for (ActiveEnt ent : collidersDirty)
     {
         ACompShape const& shape = rCtxPhys.m_shape.get(ent);
 
@@ -313,6 +312,12 @@ void SysNewton::update_world(
     }
 }
 
+void SysNewton::remove_components(ACtxNwtWorld& rCtxWorld, ActiveEnt ent)
+{
+    rCtxWorld.m_nwtBodies.remove(ent);
+    rCtxWorld.m_nwtColliders.remove(ent);
+}
+
 void SysNewton::find_colliders_recurse(
         ACtxPhysics& rCtxPhys, ACtxNwtWorld& rCtxWorld,
         acomp_storage_t<ACompHierarchy> const& rHier,
@@ -321,7 +326,7 @@ void SysNewton::find_colliders_recurse(
         Matrix4 const& transform, NewtonCollision* pCompound)
 {
     // Add newton collider if exists
-    if (rCtxPhys.m_solidCollider.contains(ent)
+    if (rCtxPhys.m_solid.contains(ent)
         && rCtxWorld.m_nwtColliders.contains(ent))
     {
         NewtonCollision const *pCollision

--- a/src/newtondynamics_physics/SysNewton.cpp
+++ b/src/newtondynamics_physics/SysNewton.cpp
@@ -190,7 +190,7 @@ void SysNewton::update_colliders(
             pNwtCollider = NewtonCreateSphere(pNwtWorld, 1.0f, 0, nullptr);
             break;
         case EShape::Box:
-            pNwtCollider = NewtonCreateBox(pNwtWorld, 1, 1, 1, 0, nullptr);
+            pNwtCollider = NewtonCreateBox(pNwtWorld, 2, 2, 2, 0, nullptr);
             break;
         case EShape::Capsule:
             // TODO
@@ -329,7 +329,7 @@ void SysNewton::find_colliders_recurse(
 
         // Set transform relative to root body
 
-        Matrix4 const normScale = Matrix4::from(transform.rotationNormalized(),
+        Matrix4 const normScale = Matrix4::from(transform.rotation(),
                                                 transform.translation());
 
         NewtonCollisionSetMatrix(pCollision, normScale.data());
@@ -468,7 +468,7 @@ void SysNewton::create_body(
     NewtonBodySetLinearDamping(pBody, 0.0f);
 
     // Make it easier to rotate
-    NewtonBodySetAngularDamping(pBody, Vector3(1.0f, 1.0f, 1.0f).data());
+    //NewtonBodySetAngularDamping(pBody, Vector3(1.0f, 1.0f, 1.0f).data());
 
     // Set callback for applying force and setting transforms
     NewtonBodySetForceAndTorqueCallback(pBody, &cb_force_torque);

--- a/src/newtondynamics_physics/SysNewton.h
+++ b/src/newtondynamics_physics/SysNewton.h
@@ -77,7 +77,7 @@ public:
     static void update_colliders(
             osp::active::ACtxPhysics& rCtxPhys,
             ACtxNwtWorld& rCtxWorld,
-            std::vector<osp::active::ActiveEnt>& rCollidersDirty);
+            std::vector<osp::active::ActiveEnt> const& collidersDirty);
 
     /**
      * @brief update_world
@@ -98,6 +98,20 @@ public:
             osp::active::acomp_storage_t<osp::active::ACompTransform>& rTf,
             osp::active::acomp_storage_t<osp::active::ACompTransformControlled>& rTfControlled,
             osp::active::acomp_storage_t<osp::active::ACompTransformMutable>& rTfMutable);
+
+    static void remove_components(
+            ACtxNwtWorld& rCtxWorld, osp::active::ActiveEnt ent);
+
+    template<typename IT_T>
+    static void update_delete(
+            ACtxNwtWorld &rCtxWorld, IT_T first, IT_T last)
+    {
+        while (first != last)
+        {
+            remove_components(rCtxWorld, *first);
+            ++first;
+        }
+    }
 
 private:
 

--- a/src/newtondynamics_physics/SysNewton.h
+++ b/src/newtondynamics_physics/SysNewton.h
@@ -50,17 +50,46 @@ class SysNewton
 
 public:
 
+    /**
+     * @brief destroy
+     *
+     * @param rCtxWorld
+     */
     static void destroy(ACtxNwtWorld &rCtxWorld);
 
+    /**
+     * @brief update_translate
+     *
+     * @param rCtxPhys
+     * @param rCtxWorld
+     */
     static void update_translate(
             osp::active::ACtxPhysics& rCtxPhys,
             ACtxNwtWorld& rCtxWorld);
 
+    /**
+     * @brief update_colliders
+     *
+     * @param rCtxPhys
+     * @param rCtxWorld
+     * @param rCollidersDirty
+     */
     static void update_colliders(
             osp::active::ACtxPhysics& rCtxPhys,
             ACtxNwtWorld& rCtxWorld,
             std::vector<osp::active::ActiveEnt>& rCollidersDirty);
 
+    /**
+     * @brief update_world
+     *
+     * @param rCtxPhys
+     * @param rCtxWorld
+     * @param inputs
+     * @param rHier
+     * @param rTf
+     * @param rTfControlled
+     * @param rTfMutable
+     */
     static void update_world(
             osp::active::ACtxPhysics& rCtxPhys,
             ACtxNwtWorld& rCtxWorld,
@@ -70,20 +99,20 @@ public:
             osp::active::acomp_storage_t<osp::active::ACompTransformControlled>& rTfControlled,
             osp::active::acomp_storage_t<osp::active::ACompTransformMutable>& rTfMutable);
 
-    static NewtonWorld const* debug_get_world();
-
 private:
 
     /**
-     * Search descendents for collider components and add NewtonCollisions to a
-     * vector. Make sure NewtonCompoundCollisionBeginAddRemove(rCompound) is
-     * called first.
+     * @brief Find colliders in an entity and its hierarchy, and add them to
+     *        a Newton Compound Collision
      *
-     * @param rScene    [in] ActiveScene containing entity and physics world
-     * @param ent       [in] Entity containing colliders, and recurse into children
-     * @param transform [in] Total transform from Hierarchy
-     * @param nwtWorld  [in] Newton world from scene
-     * @param rCompound [out] Compound collision to add new colliders to
+     * @param rCtxPhys
+     * @param rCtxWorld
+     * @param rHier
+     * @param rTf
+     * @param ent
+     * @param firstChild
+     * @param transform
+     * @param pCompound
      */
     static void find_colliders_recurse(
             osp::active::ACtxPhysics& rCtxPhys,

--- a/src/newtondynamics_physics/ospnewton.h
+++ b/src/newtondynamics_physics/ospnewton.h
@@ -78,6 +78,9 @@ struct ACtxNwtWorld
 
     std::unique_ptr<NewtonWorld, Deleter> m_nwtWorld;
 
+    // note: important that m_nwtBodies and m_nwtColliders are destructed
+    //       before m_nwtWorld
+
     osp::active::acomp_storage_t<ACompNwtBody_t> m_nwtBodies;
     osp::active::acomp_storage_t<ACompNwtCollider_t> m_nwtColliders;
 
@@ -87,6 +90,8 @@ struct ACtxNwtWorld
         osp::active::acomp_storage_t<osp::active::ACompPhysNetTorque> m_torque;
     };
 
+    // Forces and torques swapped in during SysNewton::update_world to be read
+    // by multiple Newton threads during cb_force_torque
     std::vector<ForceTorqueIn> m_forceTorqueIn;
 
     std::vector<PerThread> m_perThread;

--- a/src/osp/Active/SysHierarchy.cpp
+++ b/src/osp/Active/SysHierarchy.cpp
@@ -110,25 +110,3 @@ void SysHierarchy::sort(acomp_storage_t<ACompHierarchy>& rHier)
         return rHier.get(lhs).m_level < rHier.get(lhs).m_level;
     }, entt::insertion_sort());
 }
-
-void SysHierarchy::update_delete_descendents(
-        acomp_view_t<ACompHierarchy> viewHier,
-        acomp_storage_t<ACompDelete>& rDelete)
-{
-    auto view = viewHier | entt::basic_view{rDelete};
-
-    // copy entities to delete into a buffer
-    std::vector<ActiveEnt> toDelete;
-    toDelete.reserve(view.size_hint());
-    toDelete.assign(std::begin(view), std::end(view));
-
-    // Add delete components to descendents of all entities to delete
-    for (ActiveEnt ent : toDelete)
-    {
-        traverse(viewHier, ent, [&rDelete] (ActiveEnt descendent) {
-            rDelete.emplace(descendent);
-            return EHierarchyTraverseStatus::Continue;
-        });
-    }
-}
-

--- a/src/osp/Active/SysHierarchy.cpp
+++ b/src/osp/Active/SysHierarchy.cpp
@@ -30,22 +30,24 @@ using osp::active::ActiveEnt;
 
 
 void SysHierarchy::add_child(
-        acomp_storage_t<ACompHierarchy>& rHier,
+        acomp_storage_t<ACompHierarchy>& rHierarchy,
         ActiveEnt parent, ActiveEnt child)
 {
-    rHier.emplace(child);
-    set_parent_child(rHier, parent, child);
+    rHierarchy.emplace(child);
+    set_parent_child(rHierarchy, parent, child);
 }
 
-void SysHierarchy::set_parent_child(acomp_view_t<ACompHierarchy> viewHier, ActiveEnt parent, ActiveEnt child)
+void SysHierarchy::set_parent_child(
+        acomp_storage_t<ACompHierarchy>& rHierarchy,
+        ActiveEnt parent, ActiveEnt child)
 {
-    ACompHierarchy &rChildHier  = viewHier.get<ACompHierarchy>(child);
-    ACompHierarchy &rParentHier = viewHier.get<ACompHierarchy>(parent);
+    ACompHierarchy &rChildHier  = rHierarchy.get(child);
+    ACompHierarchy &rParentHier = rHierarchy.get(parent);
 
     // if child has an existing parent, cut first
     if (rChildHier.m_parent != entt::null)
     {
-        cut(viewHier, child);
+        cut(rHierarchy, child);
     }
 
     // set new child's parent
@@ -56,7 +58,7 @@ void SysHierarchy::set_parent_child(acomp_view_t<ACompHierarchy> viewHier, Activ
     if(0 != rParentHier.m_childCount)
     {
         ActiveEnt sibling = rParentHier.m_childFirst;
-        auto &rSiblingHier = viewHier.get<ACompHierarchy>(sibling);
+        auto &rSiblingHier = rHierarchy.get(sibling);
 
         // Set new child and former first child as siblings
         rSiblingHier.m_siblingPrev = child;
@@ -68,9 +70,10 @@ void SysHierarchy::set_parent_child(acomp_view_t<ACompHierarchy> viewHier, Activ
     rParentHier.m_childCount ++; // increase child count
 }
 
-void SysHierarchy::cut(acomp_view_t<ACompHierarchy> viewHier, ActiveEnt ent)
+void SysHierarchy::cut(
+        acomp_storage_t<ACompHierarchy>& rHierarchy, ActiveEnt ent)
 {
-    auto &rEntHier = viewHier.get<ACompHierarchy>(ent);
+    ACompHierarchy &rEntHier = rHierarchy.get(ent);
 
     // TODO: deal with m_depth
 
@@ -78,19 +81,19 @@ void SysHierarchy::cut(acomp_view_t<ACompHierarchy> viewHier, ActiveEnt ent)
 
     if (rEntHier.m_siblingNext != entt::null)
     {
-        viewHier.get<ACompHierarchy>(rEntHier.m_siblingNext).m_siblingPrev
+        rHierarchy.get(rEntHier.m_siblingNext).m_siblingPrev
                 = rEntHier.m_siblingPrev;
     }
 
     if (rEntHier.m_siblingPrev != entt::null)
     {
-        viewHier.get<ACompHierarchy>(rEntHier.m_siblingPrev).m_siblingNext
+        rHierarchy.get(rEntHier.m_siblingPrev).m_siblingNext
                 = rEntHier.m_siblingNext;
     }
 
     // Unlink parent
 
-    auto &rParentHier = viewHier.get<ACompHierarchy>(rEntHier.m_parent);
+    ACompHierarchy &rParentHier = rHierarchy.get(rEntHier.m_parent);
     rParentHier.m_childCount --;
 
     if (rParentHier.m_childFirst == ent)
@@ -103,10 +106,10 @@ void SysHierarchy::cut(acomp_view_t<ACompHierarchy> viewHier, ActiveEnt ent)
                       = entt::null;
 }
 
-void SysHierarchy::sort(acomp_storage_t<ACompHierarchy>& rHier)
+void SysHierarchy::sort(acomp_storage_t<ACompHierarchy>& rHierarchy)
 {
-    rHier.sort( [&rHier](ActiveEnt lhs, ActiveEnt rhs)
+    rHierarchy.sort( [&rHierarchy](ActiveEnt lhs, ActiveEnt rhs)
     {
-        return rHier.get(lhs).m_level < rHier.get(lhs).m_level;
+        return rHierarchy.get(lhs).m_level < rHierarchy.get(lhs).m_level;
     }, entt::insertion_sort());
 }

--- a/src/osp/Active/SysHierarchy.h
+++ b/src/osp/Active/SysHierarchy.h
@@ -93,12 +93,30 @@ public:
     static void sort(acomp_storage_t<ACompHierarchy>& rHier);
 
     /**
+     * @brief Cut entities to delete out of the hierarchy
+     */
+    template<typename IT_T>
+    static void update_delete_cut(
+            acomp_storage_t<ACompHierarchy>& rHier, IT_T first, IT_T last);
+
+    /**
      * @brief Mark descendents of deleted hierarchy entities as deleted too
      */
     template<typename IT_T, typename FUNC_T>
     static void update_delete_descendents(
             acomp_storage_t<ACompHierarchy> const& hier, IT_T first, IT_T last, FUNC_T&& deleteEnt);
 };
+
+template<typename IT_T>
+void SysHierarchy::update_delete_cut(
+        acomp_storage_t<ACompHierarchy>& rHier, IT_T first, IT_T last)
+{
+    while (first != last)
+    {
+        cut(rHier, *first);
+        ++first;
+    }
+}
 
 template<typename IT_T, typename FUNC_T>
 void SysHierarchy::update_delete_descendents(

--- a/src/osp/Active/SysHierarchy.h
+++ b/src/osp/Active/SysHierarchy.h
@@ -50,27 +50,28 @@ public:
      * @param child     [in] Child entity to add ACompHierarchy to
      */
     static void add_child(
-            acomp_storage_t<ACompHierarchy>& rHier,
+            acomp_storage_t<ACompHierarchy>& rHierarchy,
             ActiveEnt parent, ActiveEnt child);
 
     /**
      * @brief Set parent-child relationship between two entities with
      *        ACompHierarchy
      *
-     * @param viewHier  [ref] View for hierarchy components
+     * @param hierarchy [ref] Storage for hierarchy components
      * @param parent    [in] Parent entity
      * @param child     [in] Child entity
      */
-    static void set_parent_child(acomp_view_t<ACompHierarchy> viewHier,
-                                 ActiveEnt parent, ActiveEnt child);
+    static void set_parent_child(
+            acomp_storage_t<ACompHierarchy>& rHierarchy,
+            ActiveEnt parent, ActiveEnt child);
 
     /**
      * @brief Cut an entity out of the hierarchy.
      *
-     * @param viewHier  [ref] View for hierarchy components
+     * @param hierarchy [ref] Storage for hierarchy components
      * @param ent       [in] Entity to remove from hierarchy
      */
-    static void cut(acomp_view_t<ACompHierarchy> viewHier, ActiveEnt ent);
+    static void cut(acomp_storage_t<ACompHierarchy>& hierarchy, ActiveEnt ent);
 
     /**
      * @brief Traverse the scene hierarchy
@@ -90,7 +91,7 @@ public:
      *
      * @param rHier     [ref] Storage for hierarchy components
      */
-    static void sort(acomp_storage_t<ACompHierarchy>& rHier);
+    static void sort(acomp_storage_t<ACompHierarchy>& rHierarchy);
 
     /**
      * @brief Cut entities to delete out of the hierarchy

--- a/src/osp/Active/SysPhysics.cpp
+++ b/src/osp/Active/SysPhysics.cpp
@@ -12,265 +12,55 @@ using osp::Matrix3;
 using osp::Vector4;
 
 ActiveEnt SysPhysics::find_rigidbody_ancestor(
-        acomp_view_t<ACompHierarchy> viewHier,
+        acomp_storage_t<ACompHierarchy> const& hierarchy,
         ActiveEnt ent)
 {
     ActiveEnt prevEnt;
     ActiveEnt currEnt = ent;
-    ACompHierarchy *pCurrHier = nullptr;
+    ACompHierarchy const *pCurrHier = nullptr;
 
     do
     {
-        if( ! viewHier.contains(currEnt) )
+        if( ! hierarchy.contains(currEnt) )
         {
             return entt::null;
         }
 
-        pCurrHier = &viewHier.get<ACompHierarchy>(currEnt);
+        pCurrHier = &hierarchy.get(currEnt);
 
         prevEnt = std::exchange(currEnt, pCurrHier->m_parent);
     }
     while (pCurrHier->m_level != gc_heir_physics_level);
 
-//    if ( ! rCtxPhys.m_physBody.contains(prevEnt))
-//    {
-//        return entt::null; // no Physics body!
-//    }
-
     return prevEnt;
 }
 
-Matrix4 SysPhysics::find_transform_rel_rigidbody_ancestor(
-        acomp_view_t<ACompHierarchy> viewHier,
-        acomp_view_t<ACompTransform> viewTf,
+Matrix4 SysPhysics::calc_transform_rel_rigidbody_ancestor(
+        acomp_storage_t<ACompHierarchy> const& hierarchy,
+        acomp_storage_t<ACompTransform> const& transforms,
         ActiveEnt ent)
 {
     ActiveEnt prevEnt;
     ActiveEnt currEnt = ent;
-    ACompHierarchy *pCurrHier = nullptr;
-    Matrix4 transform;
+    ACompHierarchy const *pCurrHier = nullptr;
+    Matrix4 transformOut;
 
     do
     {
-        pCurrHier = &viewHier.get<ACompHierarchy>(currEnt);
+        pCurrHier = &hierarchy.get(currEnt);
 
         // Record the local transformation of the current node relative to its parent
         if (pCurrHier->m_level > gc_heir_physics_level)
         {
-            if (viewTf.contains(currEnt))
+            if (transforms.contains(currEnt))
             {
-                transform = viewTf.get<ACompTransform>(currEnt).m_transform * transform;
+                transformOut = transforms.get(currEnt).m_transform * transformOut;
             }
         }
 
         prevEnt = std::exchange(currEnt, pCurrHier->m_parent);
-    } while (pCurrHier->m_level != gc_heir_physics_level);
-
-    // Fail if a rigidbody ancestor is not found
-    //assert(rCtxPhys.m_physBody.contains(prevEnt));
-
-    return transform;
-}
-
-
-osp::active::ACompRigidbodyAncestor* SysPhysics::try_get_or_find_rigidbody_ancestor(
-        acomp_view_t<ACompHierarchy> viewHier,
-        acomp_view_t<ACompTransform> viewTf,
-        acomp_storage_t<ACompRigidbodyAncestor>& rRbAncestor,
-        ActiveEnt ent)
-{
-    ACompRigidbodyAncestor *pEntRbAncestor;
-
-    // Perform first-time initialization of rigidbody ancestor component
-    if ( ! rRbAncestor.contains(ent))
-    {
-        find_rigidbody_ancestor(viewHier, ent);
-
-        pEntRbAncestor = &rRbAncestor.emplace(ent);
     }
-    else
-    {
-        pEntRbAncestor = &rRbAncestor.get(ent);
-    }
-    // childEntity now has an ACompRigidbodyAncestor
+    while (pCurrHier->m_level != gc_heir_physics_level);
 
-    ActiveEnt& rAncestor = pEntRbAncestor->m_ancestor;
-
-    // Ancestor entity already valid
-    if (rAncestor != entt::null)
-    {
-        return pEntRbAncestor;
-    }
-
-    // Rigidbody ancestor not set yet
-    ActiveEnt bodyEnt = find_rigidbody_ancestor(viewHier, ent);
-
-    // Initialize ACompRigidbodyAncestor
-    rAncestor = bodyEnt;
-    pEntRbAncestor->m_relTransform = find_transform_rel_rigidbody_ancestor(
-                viewHier, viewTf, ent);
-    //TODO: this transformation may change and need recalculating
-
-    return pEntRbAncestor;
-}
-
-/* Since masses are usually stored in the rigidbody's children instead of the
- * rigidbody root, the function provides the option to ignore the root entity's
- * mass (this is the default). Otherwise, the root of each call will be double
- * counted since it will also be included in both the loop and the root of the
- * next call. This makes it possible for a rigidbody to have a convenient
- * root-level mass component set by some external system without interfering
- * with physics calculations that depend on mass components to determine the
- * mechanical behaviors of the rigidbody.
- */
-template <SysPhysics::EIncludeRootMass INCLUDE_ROOT_MASS>
-Vector4 SysPhysics::compute_hier_CoM(
-        acomp_view_t<ACompHierarchy> const viewHier,
-        acomp_view_t<ACompTransform> const viewTf,
-        acomp_view_t<ACompMass> const viewMass, ActiveEnt root)
-{
-    Vector3 localCoM{0.0f};
-    float localMass = 0.0f;
-
-    /* Include the root entity's mass. Skipped by default to avoid
-     * double-counting in recursion, and because some subhierarchies
-     * may have a total mass stored at their root for easy external access
-     */
-    if constexpr (INCLUDE_ROOT_MASS)
-    {
-        if (viewMass.contains(root))
-        {
-            localMass += viewMass.get<ACompMass>(root).m_mass;
-        }
-    }
-
-    for (ActiveEnt nextChild = viewHier.get<ACompHierarchy>(root).m_childFirst;
-        nextChild != entt::null;)
-    {
-        auto const &childHier = viewHier.get<ACompHierarchy>(nextChild);
-        Matrix4 childMatrix{Magnum::Math::IdentityInit};
-
-        if (viewTf.contains(nextChild))
-        {
-            childMatrix = viewTf.get<ACompTransform>(nextChild).m_transform;
-        }
-        // Else, assume identity transformation relative to parent
-
-        if (viewMass.contains(nextChild))
-        {
-            float childMass = viewMass.get<ACompMass>(root).m_mass;
-
-            Vector3 offset = childMatrix.translation();
-
-            localCoM += childMass * offset;
-            localMass += childMass;
-        }
-
-        // Recursively call this function to include grandchild masses
-        Vector4 subCoM = compute_hier_CoM(viewHier, viewTf, viewMass, nextChild);
-        Vector3 childCoMOffset = childMatrix.translation() + subCoM.xyz();
-        localCoM += subCoM.w() * childCoMOffset;
-        localMass += subCoM.w();
-
-        nextChild = childHier.m_siblingNext;
-    }
-
-    if (!(localMass > 0.0f))
-    {
-        // Massless subhierarchy, return zero contribution
-        return Vector4{0.0f};
-    }
-
-    // Weighted sum of positions is divided by total mass to arrive at final CoM
-    return {localCoM / localMass, localMass};
-}
-
-std::pair<Matrix3, Vector4> SysPhysics::compute_hier_inertia(
-        acomp_view_t<ACompHierarchy> const viewHier,
-        acomp_view_t<ACompTransform> const viewTf,
-        acomp_view_t<ACompMass> const viewMass,
-        acomp_view_t<ACompShape> const viewShape,
-        ActiveEnt entity)
-{
-    Matrix3 I{0.0f};
-    Vector4 centerOfMass = compute_hier_CoM<EIncludeRootMass::Include>(viewHier, viewTf, viewMass, entity);
-
-    // Sum inertias of children
-    for (ActiveEnt nextChild = viewHier.get<ACompHierarchy>(entity).m_childFirst;
-        nextChild != entt::null;)
-    {
-        // Use child transformation to transform child inertia and add to sum
-        bool childHasTf = viewTf.contains(nextChild);
-
-        Matrix4 const childTransformMat = childHasTf
-                ? viewTf.get<ACompTransform>(nextChild).m_transform
-                : Matrix4{Magnum::Math::IdentityInit};
-
-        /* Special case:
-         * Ordinarily, a child without a transformation means that branch of the
-         * hierarchy doesn't have any physics-related data and can be skipped.
-         * However, to minimize the number of transformations needed for
-         * entities like machines which are associated with an immediate parent
-         * and would have an identity transformation, the ACompTransform may be
-         * omitted. A child that has no transformation but still has a mass will
-         * be assumed to have an identity transformation relative to its parent
-         * and processed as usual.
-         */
-        if (childHasTf || viewMass.contains(nextChild))
-        {
-            // Compute the inertia of the child subhierarchy
-            auto const& [childInertia, childCoM] = compute_hier_inertia(
-                    viewHier, viewTf, viewMass, viewShape, nextChild);
-
-            Matrix3 const rotation = childTransformMat.rotation();
-            // Offset is the vector between the ship center of mass and the child CoM
-            Vector3 const offset = (childTransformMat.translation() + childCoM.xyz()) - centerOfMass.xyz();
-
-            I += phys::transform_inertia_tensor(
-                childInertia, childCoM.w(), offset, rotation);
-        }
-        nextChild = viewHier.get<ACompHierarchy>(nextChild).m_siblingNext;
-    }
-
-    // Include entity's own inertia, if it has a mass and volume from which to compute it
-    if (viewMass.contains(entity) && viewShape.contains(entity))
-    {
-        auto const &mass = viewMass.get<ACompMass>(entity);
-        auto const &shape = viewShape.get<ACompShape>(entity);
-        //auto const &compTransform = reg.try_get<ACompTransform>(entity);
-
-        Vector3 principalAxes;
-        if (viewTf.contains(entity))
-        {
-            // Transform used for scale; identity translation between root and itself
-            const Matrix4& transform = viewTf.get<ACompTransform>(entity).m_transform;
-            principalAxes = phys::collider_inertia_tensor(
-                    shape.m_shape, transform.scaling(), mass.m_mass);
-        }
-        else
-        {
-            /* If entity has both a mass and shape but no transform, it can be
-             * assumed to be a leaf which has an identity transform relative to
-             * its immediate parent. Thus, the parent's transformation is used
-             * to calculate the leaf's scale.
-             */
-            ActiveEnt parent = viewHier.get<ACompHierarchy>(entity).m_parent;
-            Matrix4 const& parentTransform = viewTf.get<ACompTransform>(parent).m_transform;
-            principalAxes = phys::collider_inertia_tensor(
-                shape.m_shape, parentTransform.scaling(), mass.m_mass);
-        }
-
-        /* We assume that all primitive shapes have diagonal inertia tensors in
-         * their default orientation. The moments of inertia about these
-         * principal axes thus form the eigenvalues of the inertia tensor.
-         */
-        Matrix3 localInertiaTensor{};
-        localInertiaTensor[0][0] = principalAxes.x();
-        localInertiaTensor[1][1] = principalAxes.y();
-        localInertiaTensor[2][2] = principalAxes.z();
-
-        I += localInertiaTensor;
-    }
-
-    return {I, centerOfMass};
+    return transformOut;
 }

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -139,8 +139,67 @@ public:
             acomp_view_t<ACompShape> const viewShape,
             ActiveEnt entity);
 
+    template<typename IT_T>
+    static void update_delete_phys(
+            ACtxPhysics &rCtxPhys, IT_T first, IT_T last);
+
+    template<typename IT_T>
+    static void update_delete_shapes(
+            ACtxPhysics &rCtxPhys, IT_T first, IT_T last);
+
+    template<typename IT_T>
+    static void update_delete_hier_body(
+            ACtxHierBody &rCtxHierBody, IT_T first, IT_T last);
 
 };
+
+template<typename IT_T>
+void SysPhysics::update_delete_phys(
+        ACtxPhysics &rCtxPhys, IT_T first, IT_T last)
+{
+    while (first != last)
+    {
+        ActiveEnt const ent = *first;
+
+        if (rCtxPhys.m_physBody.contains(ent))
+        {
+            rCtxPhys.m_physBody         .remove(ent);
+            rCtxPhys.m_physDynamic      .remove(ent);
+            rCtxPhys.m_physLinearVel    .remove(ent);
+            rCtxPhys.m_physAngularVel   .remove(ent);
+        }
+
+        ++first;
+    }
+}
+
+template<typename IT_T>
+void SysPhysics::update_delete_shapes(
+        ACtxPhysics &rCtxPhys, IT_T first, IT_T last)
+{
+    rCtxPhys.m_hasColliders.remove(first, last);
+
+    while (first != last)
+    {
+        ActiveEnt const ent = *first;
+
+        if (rCtxPhys.m_shape.contains(ent))
+        {
+            rCtxPhys.m_shape.remove(ent);
+            rCtxPhys.m_solid.remove(ent);
+        }
+
+        ++first;
+    }
+}
+
+template<typename IT_T>
+void SysPhysics::update_delete_hier_body(
+        ACtxHierBody &rCtxHierBody, IT_T first, IT_T last)
+{
+    rCtxHierBody.m_ownDyn.remove(first, last);
+    rCtxHierBody.m_totalDyn.remove(first, last);
+}
 
 
 }

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -35,109 +35,43 @@ struct ACompTransform;
 class SysPhysics
 {
 public:
+
     /**
-     * Used to find which rigid body an entity belongs to. This will keep
-     * looking up the tree of parents until it finds a rigid body.
+     * @brief Find which rigid body an entity belongs to
      *
-     * @param rScene     [in] ActiveScene containing ent
-     * @param ent        [in] ActiveEnt with ACompHierarchy and rigidbody ancestor
+     * This function will follow an entity's chain parents until it reaches
+     * the hierarchy level at which rigid bodies exist.
      *
-     * @return Pair of {level-1 entity, pointer to ACompNwtBody found}. If
-     *         hierarchy error, then {entt:null, nullptr}. If no ACompNwtBody
-     *         component is found, then {level-1 entity, nullptr}
+     * @param hierarchy [in] Hierarchy component storage
+     * @param ent       [in] Entity to find rigid body transform of
+     *
+     * @return Entity at rigid body hierarchy level
      */
     static ActiveEnt find_rigidbody_ancestor(
-            acomp_view_t<ACompHierarchy> viewHier,
+            acomp_storage_t<ACompHierarchy> const& hier,
             ActiveEnt ent);
 
     /**
-     * Finds the transformation of an entity relative to its rigidbody ancestor
+     * @brief Calculates the transformation of an entity relative to its
+     *        rigidbody ancestor
      *
      * Identical to find_rigidbody_ancestor(), except returns the transformation
      * between rigidbody ancestor and the specified entity.
      *
-     * @param rScene  [in] ActiveScene containing ent
-     * @param ent     [in] ActiveEnt with ACompHierarchy and rigidbody ancestor
+     * @param hierarchy     [in] Hierarchy component storage
+     * @param transforms    [in] Transform component storage
+     * @param ent           [in] Entity to calculate
      *
      * @return A Matrix4 representing the transformation
      */
-    static Matrix4 find_transform_rel_rigidbody_ancestor(
-            acomp_view_t<ACompHierarchy> viewHier,
-            acomp_view_t<ACompTransform> viewTf,
-            ActiveEnt ent);
-
-
-    /**
-     * Helper function for a SysMachine to access a parent rigidbody
-     *
-     * Used by machines which influence the rigidbody to which they're attached.
-     * This function takes a child entity and attempts to retrieve the rigidbody
-     * ancestor of the machine. The function makes use of the
-     * ACompRigidbodyAncestor component; if the specified entity lacks this
-     * component, one is added to it. The component is then used to store the
-     * result of find_rigidbody_ancestor() (the entity which owns the rigidbody)
-     * so that it can be easily accessed later.
-     *
-     * @param rScene          [in] The scene to search
-     * @param childEntity     [in] An entity whose rigidbody ancestor is sought
-     *
-     * @return Pair of {pointer to found ACompNwtBody, pointer to ACompTransform
-     *         of the ACompNwtBody entity}. If either component can't be found,
-     *         returns {nullptr, nullptr}
-     */
-    static ACompRigidbodyAncestor* try_get_or_find_rigidbody_ancestor(
-            acomp_view_t<ACompHierarchy> viewHier,
-            acomp_view_t<ACompTransform> viewTf,
-            acomp_storage_t<ACompRigidbodyAncestor>& rRbAncestor,
+    static Matrix4 calc_transform_rel_rigidbody_ancestor(
+            acomp_storage_t<ACompHierarchy> const& hierarchy,
+            acomp_storage_t<ACompTransform> const& transform,
             ActiveEnt ent);
 
     enum EIncludeRootMass { Ignore, Include };
-    /**
-    * Recursively compute the center of mass of a hierarchy subtree
-    *
-    * Takes in a root entity and recurses through its children. Entities which
-    * possess an ACompMass component are used to compute a center of mass for
-    * the entire subtree, treating it as a system of point masses. By default,
-    * the root entity's mass is not included; to include it, the optional
-    * includeRootMass argument can be set to 'true'.
-    *
-    * @template CHECK_ROOT_MASS Include or exclude the mass of the root entity
-    * being passed to the function
-    *
-    * @param rScene           [in] ActiveScene containing relevant scene data
-    * @param root             [in] Entity at the root of the hierarchy subtree
-    * @param includeRootMass  [in] Set to true if the root entity's mass should
-    *                              be included in the calculation
-    *
-    * @return A 4-vector containing xyz=CoM, w=total mass
-    */
-    template <EIncludeRootMass INCLUDE_ROOT_MASS=EIncludeRootMass::Ignore>
-    static Vector4 compute_hier_CoM(
-            acomp_view_t<ACompHierarchy> const viewHier,
-            acomp_view_t<ACompTransform> const viewTf,
-            acomp_view_t<ACompMass> const viewMass,
-            ActiveEnt root);
 
-    /**
-     * Compute the moment of inertia of a rigid body
-     *
-     * Searches the child nodes of the root and computes the total moment of
-     * inertia of the body. To contribute to the inertia of the rigidbody, child
-     * entities must posses both an ACompMass and ACompShape component, so that
-     * the mass distribution of the entity may be calculated.
-     *
-     * @param rScene       [in] ActiveScene containing relevant scene data
-     * @param root         [in] The root entity of the rigid body
-     *
-     * @return The inertia tensor of the rigid body about its center of mass, and
-     *         a 4-vector containing xyz=CoM, w=total mass
-     */
-    static std::pair<Matrix3, Vector4> compute_hier_inertia(
-            acomp_view_t<ACompHierarchy> const viewHier,
-            acomp_view_t<ACompTransform> const viewTf,
-            acomp_view_t<ACompMass> const viewMass,
-            acomp_view_t<ACompShape> const viewShape,
-            ActiveEnt entity);
+    // TODO: rewrite hierarchy inertia calculations for new mass/inertia system
 
     template<typename IT_T>
     static void update_delete_phys(

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -120,6 +120,46 @@ public:
             acomp_view_t<ACompTransform> const& viewTf,
             acomp_storage_t<ACompDrawTransform>& rDrawTf);
 
+    template<typename IT_T>
+    static void update_delete_drawing(
+            ACtxDrawing &rCtxDraw, IT_T first, IT_T last);
+
+    template<typename IT_T>
+    static void update_delete_groups(
+            ACtxRenderGroups &rCtxGroups, IT_T first, IT_T last);
+
 }; // class SysRender
+
+
+template<typename IT_T>
+void SysRender::update_delete_drawing(
+        ACtxDrawing &rCtxDraw, IT_T first, IT_T last)
+{
+    rCtxDraw.m_opaque           .remove(first, last);
+    rCtxDraw.m_transparent      .remove(first, last);
+    rCtxDraw.m_visible          .remove(first, last);
+    rCtxDraw.m_drawTransform    .remove(first, last);
+    rCtxDraw.m_mesh             .remove(first, last);
+    rCtxDraw.m_diffuseTex       .remove(first, last);
+
+    for (MaterialData& rMat : rCtxDraw.m_materials)
+    {
+        rMat.m_comp.remove(first, last);
+    }
+}
+
+template<typename IT_T>
+void SysRender::update_delete_groups(
+        ACtxRenderGroups &rCtxGroups, IT_T first, IT_T last)
+{
+    if (first == last)
+    {
+        return;
+    }
+    for (auto& [_, rGroup] : rCtxGroups.m_groups)
+    {
+        rGroup.m_entities.remove(first, last);
+    }
+}
 
 } // namespace osp::active

--- a/src/osp/Active/basic.h
+++ b/src/osp/Active/basic.h
@@ -74,11 +74,6 @@ struct ACompName
 };
 
 /**
- * @brief Marks an entity for deletion
- */
-struct ACompDelete { };
-
-/**
  * @brief Places an entity in a hierarchy
  *
  * Stores entity IDs for parent, both siblings, and first child if present
@@ -129,5 +124,29 @@ struct ACtxBasic
     acomp_storage_t<ACompHierarchy>             m_hierarchy;
     acomp_storage_t<ACompCamera>                m_camera;
 };
+
+template<typename IT_T>
+void update_delete_basic(ACtxBasic &rCtxBasic, IT_T first, IT_T last)
+{
+    rCtxBasic.m_floatingOrigin  .remove(first, last);
+    rCtxBasic.m_name            .remove(first, last);
+    rCtxBasic.m_hierarchy       .remove(first, last);
+    rCtxBasic.m_camera          .remove(first, last);
+
+    while (first != last)
+    {
+        ActiveEnt const ent = *first;
+
+        if (rCtxBasic.m_transform.contains(ent))
+        {
+            rCtxBasic.m_transform           .remove(ent);
+            rCtxBasic.m_transformControlled .remove(ent);
+            rCtxBasic.m_transformMutable    .remove(ent);
+
+        }
+
+        ++first;
+    }
+}
 
 } // namespace osp::active

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -89,13 +89,6 @@ struct ACompShape
  */
 struct ACompMass { float m_mass; };
 
-/**
- * @brief Tells the physics system that entity will be used as a collider.
- *
- * Relies on ACompShape
- */
-struct ACompSolidCollider { };
-
 struct ACompSubBody
 {
     Vector3 m_inertia;
@@ -115,7 +108,7 @@ struct ACtxPhysics
     acomp_storage_t<ACompPhysAngularVel>    m_physAngularVel;
 
     acomp_storage_t<ACompShape>             m_shape;
-    acomp_storage_t<ACompSolidCollider>     m_solidCollider;
+    active_sparse_set_t                     m_solid;
     active_sparse_set_t                     m_hasColliders;
 
 }; // struct ACtxPhysics

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -85,10 +85,8 @@ struct ACompShape
 };
 
 /**
- * @brief Stores the mass of entities
+ * @brief Generic Mass and inertia intended for entities
  */
-struct ACompMass { float m_mass; };
-
 struct ACompSubBody
 {
     Vector3 m_inertia;

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -32,6 +32,8 @@
 namespace osp::shader
 {
 
+struct ACtxMeshVisualizerData;
+
 class MeshVisualizer : protected Magnum::Shaders::MeshVisualizerGL3D
 {
     using RenderGroup = osp::active::RenderGroup;
@@ -46,14 +48,18 @@ public:
             active::ACompCamera const& camera,
             active::EntityToDraw::UserData_t userData) noexcept;
 
+    static void assign(
+            RenderGroup::ArrayView_t entities,
+            RenderGroup::Storage_t& rStorage,
+            ACtxMeshVisualizerData &rData);
 };
 
 struct ACtxMeshVisualizerData
 {
-    MeshVisualizer m_shader;
+    DependRes<MeshVisualizer> m_shader;
 
-    active::acomp_view_t< osp::active::ACompDrawTransform >     m_viewDrawTf;
-    active::acomp_view_t< osp::active::ACompMeshGL >            m_mesh;
+    active::acomp_storage_t< osp::active::ACompDrawTransform >  *m_pDrawTf;
+    active::acomp_storage_t< osp::active::ACompMeshGL >         *m_pMeshGl;
 };
 
 } // namespace osp::shader

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -49,7 +49,7 @@ void Phong::draw_entity(
      * light is a direction light coming from the specified direction relative
      * to the camera.
      */
-    Vector4 light = Vector4{Vector3{0.2f, -1.0f, 0.5f}.normalized(), 0.0f};
+    Vector4 light = Vector4{Vector3{0.0f, 1.0f, 0.5f}.normalized(), 0.0f};
 
     if (rShader.flags() & Flag::DiffuseTexture)
     {

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -41,7 +41,7 @@ void Phong::draw_entity(
     auto &rShader = *reinterpret_cast<Phong*>(userData[1]);
 
     // Collect uniform information
-    auto const& drawTf = rData.m_views->m_drawTf.get<ACompDrawTransform>(ent);
+    ACompDrawTransform const &drawTf = rData.m_pDrawTf->get(ent);
 
     Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 
@@ -53,7 +53,7 @@ void Phong::draw_entity(
 
     if (rShader.flags() & Flag::DiffuseTexture)
     {
-        rShader.bindDiffuseTexture(*rData.m_views->m_diffuseTexGl.get<ACompTextureGL>(ent).m_tex);
+        rShader.bindDiffuseTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
     }
 
     rShader
@@ -63,7 +63,7 @@ void Phong::draw_entity(
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(camera.m_projection)
         .setNormalMatrix(Matrix3{drawTf.m_transformWorld})
-        .draw(*rData.m_views->m_meshGl.get<ACompMeshGL>(ent).m_mesh);
+        .draw(*rData.m_pMeshGl->get(ent).m_mesh);
 }
 
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -76,17 +76,13 @@ public:
  */
 struct ACtxPhongData
 {
-    struct Views
-    {
-        active::acomp_view_t< osp::active::ACompDrawTransform > m_drawTf;
-        active::acomp_view_t< osp::active::ACompTextureGL >     m_diffuseTexGl;
-        active::acomp_view_t< osp::active::ACompMeshGL >        m_meshGl;
-    };
 
     DependRes<Phong> m_shaderUntextured;
     DependRes<Phong> m_shaderDiffuse;
 
-    std::optional<Views> m_views;
+    active::acomp_storage_t< osp::active::ACompDrawTransform > *m_pDrawTf;
+    active::acomp_storage_t< osp::active::ACompTextureGL >     *m_pDiffuseTexGl;
+    active::acomp_storage_t< osp::active::ACompMeshGL >        *m_pMeshGl;
 };
 
 } // namespace osp::shader

--- a/src/test_application/ActiveApplication.cpp
+++ b/src/test_application/ActiveApplication.cpp
@@ -65,7 +65,7 @@ void ActiveApplication::drawEvent()
 
     if (m_onDraw.operator bool())
     {
-        m_onDraw(*this);
+        m_onDraw(*this, m_timeline.previousFrameDuration());
     }
 
     m_userInput.clear_events();

--- a/src/test_application/activescenes/CameraController.h
+++ b/src/test_application/activescenes/CameraController.h
@@ -1,6 +1,6 @@
 /**
  * Open Space Program
- * Copyright © 2019-2020 Open Space Program Project
+ * Copyright © 2019-2021 Open Space Program Project
  *
  * MIT License
  *
@@ -24,128 +24,75 @@
  */
 #pragma once
 
-#include <osp/Active/activetypes.h>
-#include <osp/Universe.h>
+#include <osp/Active/basic.h>
+
 #include <osp/UserInputHandler.h>
 #include <osp/types.h>
+
+#include <optional>
 
 namespace testapp
 {
 
-struct ACompCameraController
+struct ACtxCameraController
 {
     using EButtonControlIndex = osp::input::EButtonControlIndex;
 
-    ACompCameraController(osp::input::UserInputHandler &rInput)
+    ACtxCameraController(osp::input::UserInputHandler &rInput)
      : m_controls(&rInput)
-     , m_rmb(           m_controls.button_subscribe("ui_rmb"))
-     , m_up(            m_controls.button_subscribe("ui_up"))
-     , m_dn(            m_controls.button_subscribe("ui_dn"))
-     , m_lf(            m_controls.button_subscribe("ui_lf"))
-     , m_rt(            m_controls.button_subscribe("ui_rt"))
-     , m_switch(        m_controls.button_subscribe("game_switch"))
-     , m_throttleMax(   m_controls.button_subscribe("vehicle_thr_max"))
-     , m_throttleMin(   m_controls.button_subscribe("vehicle_thr_min"))
-     , m_throttleMore(  m_controls.button_subscribe("vehicle_thr_more"))
-     , m_throttleLess(  m_controls.button_subscribe("vehicle_thr_less"))
-     , m_selfDestruct(  m_controls.button_subscribe("vehicle_self_destruct"))
-     , m_pitchUp(       m_controls.button_subscribe("vehicle_pitch_up"))
-     , m_pitchDn(       m_controls.button_subscribe("vehicle_pitch_dn"))
-     , m_yawLf(         m_controls.button_subscribe("vehicle_yaw_lf"))
-     , m_yawRt(         m_controls.button_subscribe("vehicle_yaw_rt"))
-     , m_rollLf(        m_controls.button_subscribe("vehicle_roll_lf"))
-     , m_rollRt(        m_controls.button_subscribe("vehicle_roll_rt"))
+     , m_btnOrbit(      m_controls.button_subscribe("cam_orbit"))
+     , m_btnRotUp(      m_controls.button_subscribe("ui_up"))
+     , m_btnRotDn(      m_controls.button_subscribe("ui_dn"))
+     , m_btnRotLf(      m_controls.button_subscribe("ui_lf"))
+     , m_btnRotRt(      m_controls.button_subscribe("ui_rt"))
+     , m_btnMovFd(      m_controls.button_subscribe("cam_fd"))
+     , m_btnMovBk(      m_controls.button_subscribe("cam_bk"))
+     , m_btnMovLf(      m_controls.button_subscribe("cam_lf"))
+     , m_btnMovRt(      m_controls.button_subscribe("cam_rt"))
+     , m_btnMovUp(      m_controls.button_subscribe("cam_up"))
+     , m_btnMovDn(      m_controls.button_subscribe("cam_dn"))
     { }
 
-    osp::universe::Satellite m_selected{entt::null};
-    osp::Vector3 m_orbitPos{0.0f, 0.0f, 1.0f};
+    osp::Vector3 m_up{};
+
+    std::optional<osp::Vector3> m_target;
     float m_orbitDistance{20.0f};
 
-    // Max distance from the origin to trigger a floating origin translation
-    int m_originDistanceThreshold{256};
-
-    // When switching vehicle, Move 20% closer to the new vehicle each frame
-    float m_travelSpeed{0.2f};
-
-    // Throttle change per second for incremental throttle controls
-    float m_throttleRate{0.5f};
+    float m_moveSpeed{1.0f};
 
     osp::input::ControlSubscriber m_controls;
 
-    // Mouse inputs
-    EButtonControlIndex m_rmb;
+    // Camera rotation buttons
 
-    // Camera button controls
+    EButtonControlIndex m_btnOrbit;
+    EButtonControlIndex m_btnRotUp;
+    EButtonControlIndex m_btnRotDn;
+    EButtonControlIndex m_btnRotLf;
+    EButtonControlIndex m_btnRotRt;
 
-    EButtonControlIndex m_up;
-    EButtonControlIndex m_dn;
-    EButtonControlIndex m_lf;
-    EButtonControlIndex m_rt;
-    EButtonControlIndex m_switch;
+    // Camera movement buttons
 
-    // Vehicle button controls
+    EButtonControlIndex m_btnMovFd;
+    EButtonControlIndex m_btnMovBk;
+    EButtonControlIndex m_btnMovLf;
+    EButtonControlIndex m_btnMovRt;
+    EButtonControlIndex m_btnMovUp;
+    EButtonControlIndex m_btnMovDn;
 
-    EButtonControlIndex m_throttleMax;
-    EButtonControlIndex m_throttleMin;
-    EButtonControlIndex m_throttleMore;
-    EButtonControlIndex m_throttleLess;
+}; // struct ACtxCameraController
 
-    EButtonControlIndex m_selfDestruct;
-
-    EButtonControlIndex m_pitchUp;
-    EButtonControlIndex m_pitchDn;
-    EButtonControlIndex m_yawLf;
-    EButtonControlIndex m_yawRt;
-    EButtonControlIndex m_rollLf;
-    EButtonControlIndex m_rollRt;
-};
-
-#if 0
 
 class SysCameraController
 {
 public:
+    static void update_view(
+            ACtxCameraController &rCtrl, osp::active::ACompTransform &rCamTf,
+            float delta);
 
-    static std::pair<osp::active::ActiveEnt, ACompCameraController&>
-    get_camera_controller(osp::active::ActiveScene& rScene);
-
-    static bool try_switch_vehicle(osp::active::ActiveScene& rScene,
-                                   ACompCameraController& rCamCtrl);
-
-    /**
-     * @brief Update that deals with modifying the vehicle
-     *
-     * @param rScene [ref] Scene with root containing ACompCameraController
-     */
-    static void update_vehicle(osp::active::ActiveScene& rScene);
-
-    /**
-     * @brief Read user inputs, and write controls to MCompUserControl
-     *
-     * @param rScene [ref] Scene with root containing ACompCameraController
-     */
-    static void update_controls(osp::active::ActiveScene& rScene);
-
-    /**
-     * @brief Move the scene origin and ActiveArea to follow the target vehicle
-     *
-     * @param rScene [ref] Scene with root containing ACompCameraController
-     */
-    static void update_area(osp::active::ActiveScene& rScene);
-
-    /**
-     * @brief Deal with positioning and controlling the camera
-     *
-     * @param rScene [ref] Scene with root containing ACompCameraController
-     */
-    static void update_view(osp::active::ActiveScene& rScene);
-
-    static osp::active::ActiveEnt find_vehicle_from_sat(
-            osp::active::ActiveScene& rScene,
-            osp::universe::Satellite sat);
-
+    static void update_move(
+            ACtxCameraController &rCtrl, osp::active::ACompTransform &rCamTf,
+            float delta, bool moveTarget);
 };
 
-#endif
 
 }

--- a/src/test_application/activescenes/CameraController.h
+++ b/src/test_application/activescenes/CameraController.h
@@ -85,10 +85,28 @@ struct ACtxCameraController
 class SysCameraController
 {
 public:
+
+    /**
+     * @brief Read rotation controls and orientation around its target
+     *
+     * @param rCtrl     [in] Camera Controller state
+     * @param rCamTf    [out] Camera transform output
+     * @param delta     [in] Time used to calculate displacement
+     */
     static void update_view(
             ACtxCameraController &rCtrl, osp::active::ACompTransform &rCamTf,
             float delta);
 
+    /**
+     * @brief Read translation controls and move the camera accordingly
+     *
+     * @param rCtrl         [in] Camera Controller state
+     * @param rCamTf        [out] Camera transform output
+     * @param delta         [in] Time used to calculate displacement
+     * @param moveTarget    [in] Option to move the target position as well.
+     *                           Leave this as always true for now, as different
+     *                           camera modes are not yet finalized.
+     */
     static void update_move(
             ACtxCameraController &rCtrl, osp::active::ACompTransform &rCamTf,
             float delta, bool moveTarget);

--- a/src/test_application/activescenes/flight.h
+++ b/src/test_application/activescenes/flight.h
@@ -75,11 +75,6 @@ struct ACtxUniverseSync
     ACtxAreaLink        m_areaLink;
 };
 
-struct ACtxTestApp
-{
-    acomp_storage_t<ACompCameraController> m_cameraController;
-};
-
 } // namespace testapp::scenestate
 
 namespace testapp::flight

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -35,7 +35,7 @@ namespace testapp
 
 class ActiveApplication;
 
-using on_draw_t = std::function<void(ActiveApplication&)>;
+using on_draw_t = std::function<void(ActiveApplication&, float delta)>;
 
 
 namespace flight

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -172,7 +172,7 @@ struct EngineTestRenderer
 
     osp::active::ACtxRenderGL m_renderGl{};
 
-    osp::active::ActiveEnt m_camera{};
+    osp::active::ActiveEnt m_camera;
     ACtxCameraController m_camCtrl;
 
     osp::shader::ACtxPhongData m_phong{};
@@ -266,7 +266,6 @@ void load_gl_resources(ActiveApplication& rApp)
             "mesh_vis_shader",
             MeshVisualizer{ MeshVisualizer::Flag::Wireframe
                             | MeshVisualizer::Flag::NormalDirection});
-
 }
 
 on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
@@ -288,10 +287,9 @@ on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
     pRenderer->m_phong.m_shaderDiffuse
             = rGlResources.get_or_reserve<Phong>("textured");
 
-    pRenderer->m_phong.m_views.emplace(ACtxPhongData::Views{
-            rScene.m_drawing.m_drawTransform,
-            pRenderer->m_renderGl.m_diffuseTexGl,
-            pRenderer->m_renderGl.m_meshGl});
+    pRenderer->m_phong.m_pDrawTf       = &rScene.m_drawing.m_drawTransform;
+    pRenderer->m_phong.m_pDiffuseTexGl = &pRenderer->m_renderGl.m_diffuseTexGl;
+    pRenderer->m_phong.m_pMeshGl       = &pRenderer->m_renderGl.m_meshGl;
 
     // Select first camera for rendering
     pRenderer->m_camera = rScene.m_basic.m_camera.at(0);
@@ -321,6 +319,7 @@ on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
     {
 
         update_test_scene(rScene, delta);
+
         SysCameraController::update_view(
                 pRenderer->m_camCtrl,
                 rScene.m_basic.m_transform.get(pRenderer->m_camera), delta);

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -23,6 +23,7 @@
  * SOFTWARE.
  */
 #include "scenarios.h"
+#include "CameraController.h"
 
 #include "../ActiveApplication.h"
 
@@ -147,13 +148,13 @@ entt::any setup_scene(osp::Package &rPkg)
  *
  * @param rScene [ref] scene to update
  */
-void update_test_scene(EngineTestScene& rScene)
+void update_test_scene(EngineTestScene& rScene, float delta)
 {
     // Rotate the cube
     osp::Matrix4 &rCubeTf
             = rScene.m_basic.m_transform.get(rScene.m_cube).m_transform;
 
-    rCubeTf = Magnum::Matrix4::rotationY(360.0_degf / 60.0f) * rCubeTf;
+    rCubeTf = Magnum::Matrix4::rotationY(90.0_degf * delta) * rCubeTf;
 }
 
 //-----------------------------------------------------------------------------
@@ -163,13 +164,18 @@ void update_test_scene(EngineTestScene& rScene)
  */
 struct EngineTestRenderer
 {
-    osp::active::ACtxRenderGroups m_renderGroups;
+    EngineTestRenderer(ActiveApplication &rApp)
+     : m_camCtrl(rApp.get_input_handler())
+    { }
 
-    osp::active::ACtxRenderGL m_renderGl;
+    osp::active::ACtxRenderGroups m_renderGroups{};
 
-    osp::active::ActiveEnt m_camera;
+    osp::active::ACtxRenderGL m_renderGl{};
 
-    osp::shader::ACtxPhongData m_phong;
+    osp::active::ActiveEnt m_camera{};
+    ACtxCameraController m_camCtrl;
+
+    osp::shader::ACtxPhongData m_phong{};
 };
 
 /**
@@ -271,7 +277,7 @@ on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
     // Create renderer data. This uses a shared_ptr to allow being stored
     // inside an std::function, which require copyable types
     std::shared_ptr<EngineTestRenderer> pRenderer
-            = std::make_shared<EngineTestRenderer>();
+            = std::make_shared<EngineTestRenderer>(rApp);
 
     osp::Package &rGlResources = rApp.get_gl_resources();
 
@@ -290,6 +296,9 @@ on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
     // Select first camera for rendering
     pRenderer->m_camera = rScene.m_basic.m_camera.at(0);
 
+    pRenderer->m_camCtrl.m_target = osp::Vector3{};
+    pRenderer->m_camCtrl.m_up = osp::Vector3{0.0f, 1.0f, 0.0f};
+
     // Create render group for forward opaque pass
     pRenderer->m_renderGroups.m_groups.emplace("fwd_opaque", RenderGroup{});
 
@@ -307,9 +316,19 @@ on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp)
     auto &rDiffSet = static_cast<active_sparse_set_t&>(rScene.m_drawing.m_diffuseTex);
     rScene.m_drawing.m_diffuseDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
 
-    return [&rScene, pRenderer = std::move(pRenderer)] (ActiveApplication& rApp)
+    return [&rScene, pRenderer = std::move(pRenderer)] (
+            ActiveApplication& rApp, float delta)
     {
-        update_test_scene(rScene);
+
+        update_test_scene(rScene, delta);
+        SysCameraController::update_view(
+                pRenderer->m_camCtrl,
+                rScene.m_basic.m_transform.get(pRenderer->m_camera), delta);
+        SysCameraController::update_move(
+                pRenderer->m_camCtrl,
+                rScene.m_basic.m_transform.get(pRenderer->m_camera),
+                delta, true);
+
         render_test_scene(rApp, rScene, *pRenderer);
     };
 }

--- a/src/test_application/activescenes/scenarios_flight.cpp
+++ b/src/test_application/activescenes/scenarios_flight.cpp
@@ -41,7 +41,7 @@ entt::any setup_scene()
 
 on_draw_t gen_draw(FlightScene& rScene, ActiveApplication& rApp)
 {
-    return [] (ActiveApplication& rApp) {};
+    return [] (ActiveApplication& rApp, float delta) {};
 }
 
 } // namespace testapp::flight

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -73,8 +73,9 @@ namespace testapp::physicstest
 // generate IDs at runtime, and map them to named identifiers.
 constexpr int const gc_mat_common      = 0;
 constexpr int const gc_mat_visualizer  = 1;
-
 constexpr int const gc_maxMaterials = 2;
+
+constexpr float gc_physTimestep = 1.0 / 60.0f;
 
 /**
  * @brief State of the entire engine test scene
@@ -395,7 +396,8 @@ void update_test_scene(PhysicsTestScene& rScene, float delta)
 
     auto const physIn = ArrayView<ACtxPhysInputs>(&rScene.m_physIn, 1);
     SysNewton::update_world(
-            rScene.m_physics, *rScene.m_pNwtWorld, physIn, rScene.m_basic.m_hierarchy,
+            rScene.m_physics, *rScene.m_pNwtWorld, gc_physTimestep, physIn,
+            rScene.m_basic.m_hierarchy,
             rScene.m_basic.m_transform, rScene.m_basic.m_transformControlled,
             rScene.m_basic.m_transformMutable);
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -40,7 +40,10 @@
 #include <adera/ShipResources.h>
 #include <adera/Shaders/PlumeShader.h>
 
+#include <Magnum/Primitives/Cylinder.h>
 #include <Magnum/Primitives/Cube.h>
+#include <Magnum/Primitives/Grid.h>
+#include <Magnum/Primitives/Icosphere.h>
 #include <Corrade/Utility/Arguments.h>
 
 #include <iostream>
@@ -387,8 +390,13 @@ void load_a_bunch_of_stuff()
 
     rDebugPack.add<ShipResourceType>("fuel", std::move(fuel));
 
-    // Add a default cube
+    // Add a default primitives
     rDebugPack.add<Magnum::Trade::MeshData>("cube", Magnum::Primitives::cubeSolid());
+    rDebugPack.add<Magnum::Trade::MeshData>("cylinder", Magnum::Primitives::cylinderSolid(3, 24, 1.0f));
+    rDebugPack.add<Magnum::Trade::MeshData>("sphere", Magnum::Primitives::icosphereSolid(2));
+
+    // Add grids
+    rDebugPack.add<Magnum::Trade::MeshData>("grid64", Magnum::Primitives::grid3DSolid({64, 64}));
 
     OSP_LOG_INFO("Resource loading complete");
 }

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -40,6 +40,7 @@
 #include <adera/ShipResources.h>
 #include <adera/Shaders/PlumeShader.h>
 
+#include <Magnum/MeshTools/Transform.h>
 #include <Magnum/Primitives/Cylinder.h>
 #include <Magnum/Primitives/Cube.h>
 #include <Magnum/Primitives/Grid.h>
@@ -390,13 +391,18 @@ void load_a_bunch_of_stuff()
 
     rDebugPack.add<ShipResourceType>("fuel", std::move(fuel));
 
+    using namespace Magnum;
+    using Primitives::CylinderFlag;
+
     // Add a default primitives
-    rDebugPack.add<Magnum::Trade::MeshData>("cube", Magnum::Primitives::cubeSolid());
-    rDebugPack.add<Magnum::Trade::MeshData>("cylinder", Magnum::Primitives::cylinderSolid(3, 24, 1.0f));
-    rDebugPack.add<Magnum::Trade::MeshData>("sphere", Magnum::Primitives::icosphereSolid(2));
+    rDebugPack.add<Trade::MeshData>("cube", Primitives::cubeSolid());
+    rDebugPack.add<Trade::MeshData>("sphere", Primitives::icosphereSolid(2));
+    rDebugPack.add<Trade::MeshData>(
+            "cylinder",
+            Primitives::cylinderSolid(3, 16, 1.0f, CylinderFlag::CapEnds));
 
     // Add grids
-    rDebugPack.add<Magnum::Trade::MeshData>("grid64", Magnum::Primitives::grid3DSolid({64, 64}));
+    rDebugPack.add<Trade::MeshData>("grid64", Primitives::grid3DSolid({64, 64}));
 
     OSP_LOG_INFO("Resource loading complete");
 }


### PR DESCRIPTION
This PR ports SysNewton to the new architecture, adds a new self-contained physics test in `src/test_application/activescenes/scenarios_physicstest.cpp`, along with other changes to support them.

### Physics & Newton Dynamics

Not much has really changed besides no longer relying on the entt registry. All components are passed as function parameters, as well as improved multithreading considerations. Many of these changes were applied in the previous PR #157.

SysNewton is no longer responsible for calculating inertia. Inertia calculations don't rely on the physics engine, hence were separated out. Rigid bodies can now be assigned any inertia value.

The inertia calculations have been separated out into ACtxHierBody, generic physics components in `physics.h` that describes the mass and inertia of entities in the hierarchy. A future system can use these components to calculate values that can be passed to any physics engine.

### Camera Controller

The new camera controller actually only controls the camera and isn't a god class anymore. The camera orbits around an imaginary 'target' point, similar to blender and a few other programs.

Default controls, assignable in settings.toml:
* W/S - move camera forward and back
* A/D - move camera left and right
* Q/E - move camera up and down
* RMB - orbit around with mouse
* MouseWheel - Zoom in/out

Zooming out makes the camera move faster

### Physics test scene

The physics test consists of a 64x64 floor; a box and a cylinder are created every 2 seconds. The renderer uses the new Camera Controller and its controls. Pressing space throws a sphere.
![image](https://user-images.githubusercontent.com/14708882/146626380-97d028ba-c985-4f3e-9b89-497d70d875ba.png)

### Deleter systems

For the physics test scene, entities that are going to be deleted are added to vectors. Near the end of the update function, these vectors are passed to functions to delete their corresponding components. Once all the components are deleted, the entity ID can be deleted and reused. Since these functions use iterators, containers other than vectors can be used eventually, such as the Hierarchial bitset, which btw now have iterators in the new [Longeron++ library](https://github.com/Capital-Asterisk/longeronpp).

### Other changes:

* Fixed shaders
* Added Cube, Cylinder, Sphere, and Grid primitives added in main.cpp
* Added delta time to scene updates

Still no vehicles, flight, or anything too fancy.