### PR TITLE
Renderer Improvements

### DIFF
--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -77,10 +77,10 @@ void PlumeShader::draw_plume(
     ACtxPlumeData &rData = *reinterpret_cast<ACtxPlumeData*>(userData[0]);
 
     // Collect uniform data
-    auto const &drawTf  = rData.m_viewDrawTf.get<ACompDrawTransform>(ent);
-    auto const &comp    = rData.m_viewExaustPlumes.get<ACompExhaustPlume>(ent);
-    auto const &effect  = *comp.m_effect;
-    auto &rMesh         = *rData.m_mesh.get<ACompMeshGL>(ent).m_mesh;
+    ACompDrawTransform const &drawTf    = rData.m_pDrawTf->get(ent);
+    ACompExhaustPlume const &comp       = rData.m_pExaustPlumes->get(ent);
+    PlumeEffectData const &effect       = *comp.m_effect;
+    Magnum::GL::Mesh &rMesh             = *rData.m_pMesh->get(ent).m_mesh;
 
     Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 

--- a/src/adera/Shaders/PlumeShader.h
+++ b/src/adera/Shaders/PlumeShader.h
@@ -124,16 +124,19 @@ private:
  */
 struct ACtxPlumeData
 {
-    template<typename... COMP_T>
-    using acomp_view_t = typename osp::active::acomp_view_t<COMP_T...>;
+    template<typename COMP_T>
+    using acomp_storage_t       = typename osp::active::acomp_storage_t<COMP_T>;
+    using ACompDrawTransform    = osp::active::ACompDrawTransform;
+    using ACompMeshGL           = osp::active::ACompMeshGL;
+    using ACompExhaustPlume     = adera::active::ACompExhaustPlume;
 
     PlumeShader m_shader;
 
     osp::DependRes<Magnum::GL::Texture2D> m_tmpTex;
 
-    acomp_view_t< osp::active::ACompDrawTransform >     m_viewDrawTf;
-    acomp_view_t< adera::active::ACompExhaustPlume >    m_viewExaustPlumes;
-    acomp_view_t< osp::active::ACompMeshGL >            m_mesh;
+    acomp_storage_t<ACompDrawTransform> *m_pDrawTf{nullptr};
+    acomp_storage_t<ACompExhaustPlume>  *m_pExaustPlumes{nullptr};
+    acomp_storage_t<ACompMeshGL>        *m_pMesh{nullptr};
 };
 
 } // namespace adera::shader

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -33,6 +33,8 @@
 #include <Corrade/Containers/ArrayView.h>
 #include <entt/core/family.hpp>
 
+#include <Magnum/Math/Color.h>
+
 // MSVC freaks out if these are forward declared
 #include <Magnum/Trade/ImageData.h>
 #include <Magnum/Trade/MeshData.h>
@@ -88,6 +90,8 @@ struct ACompTexture
     osp::DependRes<Magnum::Trade::ImageData2D> m_texture;
 };
 
+struct ACompColor : Magnum::Color4 {};
+
 struct MaterialData
 {
     active_sparse_set_t     m_comp;
@@ -104,6 +108,7 @@ struct ACtxDrawing
     acomp_storage_t<ACompTransparent>       m_transparent;
     acomp_storage_t<ACompVisible>           m_visible;
     acomp_storage_t<ACompDrawTransform>     m_drawTransform;
+    acomp_storage_t<ACompColor>             m_color;
 
     acomp_storage_t<ACompMesh>              m_mesh;
     std::vector<osp::active::ActiveEnt>     m_meshDirty;

--- a/src/osp/Active/opengl/SysRenderGL.cpp
+++ b/src/osp/Active/opengl/SysRenderGL.cpp
@@ -254,11 +254,9 @@ void SysRenderGL::display_texture(
     shader->display_texure(*surface, rTex);
 }
 
-// TODO: problem got simpler, maybe generalize these two somehow
-
 void SysRenderGL::render_opaque(
-        RenderGroup const& rGroup,
-        acomp_view_t<const ACompVisible> viewVisible,
+        RenderGroup const& group,
+        acomp_storage_t<ACompVisible> const& visible,
         ACompCamera const& camera)
 {
     using Magnum::GL::Renderer;
@@ -268,18 +266,12 @@ void SysRenderGL::render_opaque(
     Renderer::disable(Renderer::Feature::Blending);
     Renderer::setDepthMask(true);
 
-    for (auto const& [ent, toDraw] : rGroup.view().each())
-    {
-        if (viewVisible.contains(ent))
-        {
-            toDraw(ent, camera);
-        }
-    }
+    draw_group(group, visible, camera);
 }
 
 void SysRenderGL::render_transparent(
         RenderGroup const& group,
-        acomp_view_t<const ACompVisible> viewVisible,
+        acomp_storage_t<ACompVisible> const& visible,
         ACompCamera const& camera)
 {
     using Magnum::GL::Renderer;
@@ -295,23 +287,17 @@ void SysRenderGL::render_transparent(
     //            can mess up other transparent objects once added
     //Renderer::setDepthMask(false);
 
-    for (auto const& [ent, toDraw] : group.view().each())
-    {
-        if (viewVisible.contains(ent))
-        {
-            toDraw(ent, camera);
-        }
-    }
+    draw_group(group, visible, camera);
 }
 
 void SysRenderGL::draw_group(
-        RenderGroup const& rGroup,
-        acomp_view_t<const ACompVisible> viewVisible,
+        RenderGroup const& group,
+        acomp_storage_t<ACompVisible> const& visible,
         ACompCamera const& camera)
 {
-    for (auto const& [ent, toDraw] : rGroup.view().each())
+    for (auto const& [ent, toDraw] : group.view().each())
     {
-        if (viewVisible.contains(ent))
+        if (visible.contains(ent))
         {
             toDraw(ent, camera);
         }

--- a/src/osp/Active/opengl/SysRenderGL.cpp
+++ b/src/osp/Active/opengl/SysRenderGL.cpp
@@ -115,16 +115,16 @@ DependRes<Mesh> try_compile_mesh(
 }
 
 void SysRenderGL::compile_meshes(
-        acomp_view_t<ACompMesh const> viewMeshs,
+        acomp_storage_t<ACompMesh> const& meshes,
         std::vector<ActiveEnt>& rDirty,
         acomp_storage_t<ACompMeshGL>& rMeshGl,
         osp::Package& rGlResources)
 {
     for (ActiveEnt ent : std::exchange(rDirty, {}))
     {
-        if (viewMeshs.contains(ent))
+        if (meshes.contains(ent))
         {
-            auto const &rEntMesh = viewMeshs.get<ACompMesh const>(ent);
+            ACompMesh const &rEntMesh = meshes.get(ent);
 
             if (rMeshGl.contains(ent))
             {
@@ -188,16 +188,16 @@ DependRes<Texture2D> try_compile_texture(
 }
 
 void SysRenderGL::compile_textures(
-        acomp_view_t<const ACompTexture> viewTex,
+        acomp_storage_t<ACompTexture> const& textures,
         std::vector<ActiveEnt>& rDirty,
         acomp_storage_t<ACompTextureGL>& rTexGl,
         osp::Package& rGlResources)
 {
     for (ActiveEnt ent : std::exchange(rDirty, {}))
     {
-        if (viewTex.contains(ent))
+        if (textures.contains(ent))
         {
-            auto const &rEntTex = viewTex.get<ACompTexture const>(ent);
+            ACompTexture const &rEntTex = textures.get(ent);
 
             if (rTexGl.contains(ent))
             {

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -142,6 +142,11 @@ public:
             RenderGroup const& group,
             acomp_view_t<const ACompVisible> viewVisible,
             ACompCamera const& camera);
+
+    static void draw_group(
+            RenderGroup const& rGroup,
+            acomp_view_t<const ACompVisible> viewVisible,
+            ACompCamera const& camera);
 };
 
 

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -87,32 +87,35 @@ public:
                                 Magnum::GL::Texture2D& rTex);
 
     /**
-     * @brief Compile entities with loaded meshes into GPU resources
+     * @brief Compile and assign GPU mesh components to entities with mesh
+     *        data components
      *
      * Entities with an ACompMesh will be synchronized with an ACompMeshGL
      *
-     * @param viewMeshs     [in] View for generic mesh components
+     * @param meshes        [in] Storage for generic mesh components
      * @param rDirty        [ref] Vector of entities that have updated meshes,
      *                            this will be cleared.
      * @param rMeshGl       [ref] Storage for GL mesh components
      * @param rGlResources  [out] Package to store newly compiled meshes
      */
     static void compile_meshes(
-            acomp_view_t<ACompMesh const> viewMeshs,
+            acomp_storage_t<ACompMesh> const& meshes,
             std::vector<ActiveEnt>& rDirty,
             acomp_storage_t<ACompMeshGL>& rMeshGl,
             osp::Package& rGlResources);
 
     /**
-     * @brief TODO
+     * @brief Compile and assign GPU texture components to entities with
+     *        texture data components
      *
-     * @param viewDiffTex
-     * @param rDirty
-     * @param rDiffTexGl
-     * @param rGlResources
+     * @param textures      [in] Storage for generic texture data components
+     * @param rDirty        [ref] Vector of entities that have updated meshes,
+     *                            this will be cleared.
+     * @param rDiffTexGl    [ref] Storage for GL texture components
+     * @param rGlResources  [out] Package to store newly compiled textures
      */
     static void compile_textures(
-            acomp_view_t<ACompTexture const> viewDiffTex,
+            acomp_storage_t<ACompTexture> const& textures,
             std::vector<ActiveEnt>& rDirty,
             acomp_storage_t<ACompTextureGL>& rDiffTexGl,
             osp::Package& rGlResources);

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -120,13 +120,13 @@ public:
     /**
      * @brief Call draw functions of a RenderGroup of opaque objects
      *
-     * @param rGroup        [in] RenderGroup to draw
-     * @param viewVisible   [in] View for visible components
+     * @param group         [in] RenderGroup to draw
+     * @param visible       [in] Storage for visible components
      * @param camera        [in] Camera to render from
      */
     static void render_opaque(
             RenderGroup const& group,
-            acomp_view_t<const ACompVisible> viewVisible,
+            acomp_storage_t<ACompVisible> const& visible,
             ACompCamera const& camera);
 
     /**
@@ -134,18 +134,18 @@ public:
      *
      * Consider sorting the render group for correct transparency
      *
-     * @param rGroup        [in] RenderGroup to draw
-     * @param viewVisible   [in] View for visible components
+     * @param group         [in] RenderGroup to draw
+     * @param visible       [in] Storage for visible components
      * @param camera        [in] Camera to render from
      */
     static void render_transparent(
             RenderGroup const& group,
-            acomp_view_t<const ACompVisible> viewVisible,
+            acomp_storage_t<ACompVisible> const& visible,
             ACompCamera const& camera);
 
     static void draw_group(
-            RenderGroup const& rGroup,
-            acomp_view_t<const ACompVisible> viewVisible,
+            RenderGroup const& group,
+            acomp_storage_t<ACompVisible> const& visible,
             ACompCamera const& camera);
 };
 

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -49,12 +49,6 @@ void shader::draw_ent_flat(
 
     Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 
-    /* 4th component indicates light type. A value of 0.0f indicates that the
-     * light is a direction light coming from the specified direction relative
-     * to the camera.
-     */
-    //Vector4 light = ;
-
     if (rShader.flags() & Flag::Textured)
     {
         rShader.bindTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
@@ -77,21 +71,21 @@ void shader::assign_flat(
         RenderGroup::ArrayView_t entities,
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
-        acomp_view_t<ACompOpaque const> viewOpaque,
-        acomp_view_t<ACompTextureGL const> viewDiffuse,
+        acomp_storage_t<active::ACompOpaque> const& opaque,
+        acomp_storage_t<ACompTextureGL> const& diffuse,
         ACtxDrawFlat &rData)
 {
 
     for (ActiveEnt ent : entities)
     {
-        if (viewOpaque.contains(ent))
+        if (opaque.contains(ent))
         {
             if (pStorageOpaque == nullptr)
             {
                 continue;
             }
 
-            if (viewDiffuse.contains(ent))
+            if (diffuse.contains(ent))
             {
                 pStorageOpaque->emplace(
                         ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });
@@ -110,7 +104,7 @@ void shader::assign_flat(
                 continue;
             }
 
-            if (viewDiffuse.contains(ent))
+            if (diffuse.contains(ent))
             {
                 pStorageTransparent->emplace(
                         ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -1,0 +1,123 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "Flat.h"
+
+#include <osp/Active/SysRender.h>
+
+#include <Magnum/Math/Color.h>
+
+// for the 0xrrggbb_rgbf and angle literals
+using namespace Magnum::Math::Literals;
+
+using namespace osp;
+using namespace osp::active;
+using namespace osp::shader;
+
+void shader::draw_ent_flat(
+        ActiveEnt ent, ACompCamera const& camera,
+        EntityToDraw::UserData_t userData) noexcept
+{
+    using Flag = Flat::Flag;
+
+    auto &rData = *reinterpret_cast<ACtxDrawFlat*>(userData[0]);
+    auto &rShader = *reinterpret_cast<Flat*>(userData[1]);
+
+    // Collect uniform information
+    ACompDrawTransform const &drawTf = rData.m_pDrawTf->get(ent);
+
+    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
+
+    /* 4th component indicates light type. A value of 0.0f indicates that the
+     * light is a direction light coming from the specified direction relative
+     * to the camera.
+     */
+    //Vector4 light = ;
+
+    if (rShader.flags() & Flag::Textured)
+    {
+        rShader.bindTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
+    }
+
+    rShader
+        .setColor(0xffffff00_rgbaf)
+        .setTransformationProjectionMatrix(camera.m_projection*entRelative)
+        .draw(*rData.m_pMeshGl->get(ent).m_mesh);
+}
+
+
+void shader::assign_flat(
+        RenderGroup::ArrayView_t entities,
+        RenderGroup::Storage_t *pStorageOpaque,
+        RenderGroup::Storage_t *pStorageTransparent,
+        acomp_view_t<ACompOpaque const> viewOpaque,
+        acomp_view_t<ACompTextureGL const> viewDiffuse,
+        ACtxDrawFlat &rData)
+{
+
+    for (ActiveEnt ent : entities)
+    {
+        if (viewOpaque.contains(ent))
+        {
+            if (pStorageOpaque == nullptr)
+            {
+                continue;
+            }
+
+            if (viewDiffuse.contains(ent))
+            {
+                pStorageOpaque->emplace(
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });
+            }
+            else
+            {
+                pStorageOpaque->emplace(
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderUntextured)} });
+            }
+        }
+        else
+        {
+
+            if (pStorageTransparent == nullptr)
+            {
+                continue;
+            }
+
+            if (viewDiffuse.contains(ent))
+            {
+                pStorageTransparent->emplace(
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });
+            }
+            else
+            {
+                pStorageTransparent->emplace(
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderUntextured)} });
+            }
+
+        }
+
+
+    }
+}
+

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -60,8 +60,14 @@ void shader::draw_ent_flat(
         rShader.bindTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
     }
 
+    if (rData.m_pColor != nullptr)
+    {
+        rShader.setColor(rData.m_pColor->contains(ent)
+                         ? rData.m_pColor->get(ent)
+                         : 0xffffffff_rgbaf);
+    }
+
     rShader
-        .setColor(0xffffff00_rgbaf)
         .setTransformationProjectionMatrix(camera.m_projection*entRelative)
         .draw(*rData.m_pMeshGl->get(ent).m_mesh);
 }

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -60,16 +60,16 @@ void draw_ent_flat(
  * @param entities              [in] Entities to consider
  * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
  * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
- * @param viewOpaque            [in] View for opaque component
- * @param viewDiffuse           [in] View for diffuse texture component
+ * @param opaque                [in] View for opaque component
+ * @param diffuse               [in] View for diffuse texture component
  * @param rData                 [in] Phong shader data, stable memory required
  */
 void assign_flat(
         active::RenderGroup::ArrayView_t entities,
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
-        active::acomp_view_t<active::ACompOpaque const> viewOpaque,
-        active::acomp_view_t<active::ACompTextureGL const> viewDiffuse,
+        active::acomp_storage_t<active::ACompOpaque> const& opaque,
+        active::acomp_storage_t<active::ACompTextureGL> const& diffuse,
         ACtxDrawFlat &rData);
 
 

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -42,9 +42,10 @@ struct ACtxDrawFlat
     DependRes<Flat> m_shaderUntextured;
     DependRes<Flat> m_shaderDiffuse;
 
-    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf;
-    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl;
-    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl;
+    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
+    active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl{nullptr};
+    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl{nullptr};
 };
 
 void draw_ent_flat(

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -1,0 +1,75 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2021 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+
+#include <osp/Active/opengl/SysRenderGL.h>
+#include <osp/Resource/Resource.h>
+
+#include <Magnum/Shaders/FlatGL.h>
+
+namespace osp::shader
+{
+
+using Flat = Magnum::Shaders::FlatGL3D;
+
+
+struct ACtxDrawFlat
+{
+
+    DependRes<Flat> m_shaderUntextured;
+    DependRes<Flat> m_shaderDiffuse;
+
+    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf;
+    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl;
+    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl;
+};
+
+void draw_ent_flat(
+        active::ActiveEnt ent,
+        active::ACompCamera const& camera,
+        active::EntityToDraw::UserData_t userData) noexcept;
+
+/**
+ * @brief Assign a Flat shader to a set of entities, and write results to
+ *        a RenderGroup
+ *
+ * @param entities              [in] Entities to consider
+ * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
+ * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
+ * @param viewOpaque            [in] View for opaque component
+ * @param viewDiffuse           [in] View for diffuse texture component
+ * @param rData                 [in] Phong shader data, stable memory required
+ */
+void assign_flat(
+        active::RenderGroup::ArrayView_t entities,
+        active::RenderGroup::Storage_t *pStorageOpaque,
+        active::RenderGroup::Storage_t *pStorageTransparent,
+        active::acomp_view_t<active::ACompOpaque const> viewOpaque,
+        active::acomp_view_t<active::ACompTextureGL const> viewDiffuse,
+        ACtxDrawFlat &rData);
+
+
+} // namespace osp::shader

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -38,8 +38,8 @@ struct ACtxDrawMeshVisualizer
 {
     DependRes<MeshVisualizer> m_shader;
 
-    active::acomp_storage_t< osp::active::ACompDrawTransform >  *m_pDrawTf;
-    active::acomp_storage_t< osp::active::ACompMeshGL >         *m_pMeshGl;
+    active::acomp_storage_t< active::ACompDrawTransform >  *m_pDrawTf{nullptr};
+    active::acomp_storage_t< active::ACompMeshGL >         *m_pMeshGl{nullptr};
 
     bool m_wireframeOnly{false};
 };

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -32,34 +32,27 @@
 namespace osp::shader
 {
 
-struct ACtxMeshVisualizerData;
+using MeshVisualizer = Magnum::Shaders::MeshVisualizerGL3D;
 
-class MeshVisualizer : protected Magnum::Shaders::MeshVisualizerGL3D
-{
-    using RenderGroup = osp::active::RenderGroup;
-
-public:
-
-    using Magnum::Shaders::MeshVisualizerGL3D::MeshVisualizerGL3D;
-    using Flag = Magnum::Shaders::MeshVisualizerGL3D::Flag;
-
-    static void draw_entity(
-            active::ActiveEnt ent,
-            active::ACompCamera const& camera,
-            active::EntityToDraw::UserData_t userData) noexcept;
-
-    static void assign(
-            RenderGroup::ArrayView_t entities,
-            RenderGroup::Storage_t& rStorage,
-            ACtxMeshVisualizerData &rData);
-};
-
-struct ACtxMeshVisualizerData
+struct ACtxDrawMeshVisualizer
 {
     DependRes<MeshVisualizer> m_shader;
 
     active::acomp_storage_t< osp::active::ACompDrawTransform >  *m_pDrawTf;
     active::acomp_storage_t< osp::active::ACompMeshGL >         *m_pMeshGl;
+
+    bool m_wireframeOnly{false};
 };
+
+void draw_ent_visualizer(
+        active::ActiveEnt ent,
+        active::ACompCamera const& camera,
+        active::EntityToDraw::UserData_t userData) noexcept;
+
+
+void assign_visualizer(
+        active::RenderGroup::ArrayView_t entities,
+        active::RenderGroup::Storage_t& rStorage,
+        ACtxDrawMeshVisualizer &rData);
 
 } // namespace osp::shader

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -65,9 +65,15 @@ void shader::draw_ent_phong(
         rShader.bindAmbientTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
     }
 
+    if (rData.m_pColor != nullptr)
+    {
+        rShader.setDiffuseColor(rData.m_pColor->contains(ent)
+                                ? rData.m_pColor->get(ent)
+                                : 0xffffffff_rgbaf);
+    }
+
     rShader
         .setAmbientColor(0x000000ff_rgbaf)
-        .setDiffuseColor(0xffffff00_rgbaf)
         .setSpecularColor(0xffffff00_rgbaf)
         .setLightColors({0xfff5ec_rgbf, 0xe4e8ff_rgbf})
         .setLightPositions({Vector4{Vector3{0.2f, 0.6f, 0.5f}.normalized(), 0.0f},

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -89,21 +89,21 @@ void shader::assign_phong(
         RenderGroup::ArrayView_t entities,
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
-        acomp_view_t<ACompOpaque const> viewOpaque,
-        acomp_view_t<ACompTextureGL const> viewDiffuse,
+        acomp_storage_t<ACompOpaque> const& opaque,
+        acomp_storage_t<ACompTextureGL> const& diffuse,
         ACtxDrawPhong &rData)
 {
 
     for (ActiveEnt ent : entities)
     {
-        if (viewOpaque.contains(ent))
+        if (opaque.contains(ent))
         {
             if (pStorageOpaque == nullptr)
             {
                 continue;
             }
 
-            if (viewDiffuse.contains(ent))
+            if (diffuse.contains(ent))
             {
                 pStorageOpaque->emplace(
                         ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderDiffuse)} });
@@ -122,7 +122,7 @@ void shader::assign_phong(
                 continue;
             }
 
-            if (viewDiffuse.contains(ent))
+            if (diffuse.contains(ent))
             {
                 pStorageTransparent->emplace(
                         ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderDiffuse)} });

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -29,60 +29,50 @@
 #include <osp/Resource/Resource.h>
 
 #include <Magnum/Shaders/PhongGL.h>
-#include <Magnum/Math/Color.h>
 
-#include <string_view>
-#include <vector>
 
 namespace osp::shader
 {
 
-struct ACtxPhongData;
-
-class Phong : protected Magnum::Shaders::PhongGL
-{
-    using RenderGroup = osp::active::RenderGroup;
-
-public:
-
-    using Magnum::Shaders::PhongGL::PhongGL;
-    using Flag = Magnum::Shaders::PhongGL::Flag;
-
-    static void draw_entity(
-            osp::active::ActiveEnt ent,
-            osp::active::ACompCamera const& camera,
-            osp::active::EntityToDraw::UserData_t userData) noexcept;
-
-    /**
-     * @brief Assign a Phong shader to a set of entities, and write results to
-     *        a RenderGroup
-     *
-     * @param entities      [in] Entities to consider
-     * @param rStorage      [out] RenderGroup storage
-     * @param viewOpaque    [in] View for opaque component
-     * @param viewDiffuse   [in] View for diffuse texture component
-     * @param rData         [in] Phong shader data, stable memory required
-     */
-    static void assign_phong_opaque(
-            RenderGroup::ArrayView_t entities,
-            RenderGroup::Storage_t& rStorage,
-            osp::active::acomp_view_t<osp::active::ACompOpaque const> viewOpaque,
-            osp::active::acomp_view_t<osp::active::ACompTextureGL const> viewDiffuse,
-            ACtxPhongData &rData);
-};
+using Phong = Magnum::Shaders::PhongGL;
 
 /**
  * @brief Stores per-scene data needed for Phong shaders to draw
  */
-struct ACtxPhongData
+struct ACtxDrawPhong
 {
 
     DependRes<Phong> m_shaderUntextured;
     DependRes<Phong> m_shaderDiffuse;
 
-    active::acomp_storage_t< osp::active::ACompDrawTransform > *m_pDrawTf;
-    active::acomp_storage_t< osp::active::ACompTextureGL >     *m_pDiffuseTexGl;
-    active::acomp_storage_t< osp::active::ACompMeshGL >        *m_pMeshGl;
+    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf;
+    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl;
+    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl;
 };
+
+void draw_ent_phong(
+        active::ActiveEnt ent,
+        active::ACompCamera const& camera,
+        active::EntityToDraw::UserData_t userData) noexcept;
+
+/**
+ * @brief Assign a Phong shader to a set of entities, and write results to
+ *        a RenderGroup
+ *
+ * @param entities              [in] Entities to consider
+ * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
+ * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
+ * @param viewOpaque            [in] View for opaque component
+ * @param viewDiffuse           [in] View for diffuse texture component
+ * @param rData                 [in] Phong shader data, stable memory required
+ */
+void assign_phong(
+        active::RenderGroup::ArrayView_t entities,
+        active::RenderGroup::Storage_t *pStorageOpaque,
+        active::RenderGroup::Storage_t *pStorageTransparent,
+        active::acomp_view_t<active::ACompOpaque const> viewOpaque,
+        active::acomp_view_t<active::ACompTextureGL const> viewDiffuse,
+        ACtxDrawPhong &rData);
+
 
 } // namespace osp::shader

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -64,16 +64,16 @@ void draw_ent_phong(
  * @param entities              [in] Entities to consider
  * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
  * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
- * @param viewOpaque            [in] View for opaque component
- * @param viewDiffuse           [in] View for diffuse texture component
+ * @param opaque            [in] Storage for opaque component
+ * @param diffuse           [in] Storage for diffuse texture component
  * @param rData                 [in] Phong shader data, stable memory required
  */
 void assign_phong(
         active::RenderGroup::ArrayView_t entities,
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
-        active::acomp_view_t<active::ACompOpaque const> viewOpaque,
-        active::acomp_view_t<active::ACompTextureGL const> viewDiffuse,
+        active::acomp_storage_t<active::ACompOpaque> const& opaque,
+        active::acomp_storage_t<active::ACompTextureGL> const& diffuse,
         ACtxDrawPhong &rData);
 
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -45,9 +45,11 @@ struct ACtxDrawPhong
     DependRes<Phong> m_shaderUntextured;
     DependRes<Phong> m_shaderDiffuse;
 
-    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf;
-    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl;
-    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl;
+    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
+    active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl{nullptr};
+
+    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl{nullptr};
 };
 
 void draw_ent_phong(


### PR DESCRIPTION
A handful of changes related to rendering:

* Add Texture support
* Tweak hard-coded lights in the Phong shader to look slightly nicer
* Refactor to use Magnum Shaders directly instead of inherited classes
* Add Magnum Flat Shader

TODO: Proper lights for the Phong shader, still need to decide how to do lights in the first place.

The flat shader and textures aren't used anywhere yet. Fun fact: these changes originate from my repo of turning osp-magnum into a minecraft redstone simulator.

### Meshes (and textures) rundown

How meshes and textures are added to entities and used by the renderer (from scenarios_enginetest.cpp):

1. Non-GPU code adds ACompMesh components to an entity, and also pushes it to the 'mesh dirty' vector
```cpp
// rScene.m_cube is an ActiveEnt

// Add cube mesh to cube
rScene.m_drawing.m_mesh.emplace(
        rScene.m_cube, ACompMesh{ rPkg.get<MeshData>("cube") });
rScene.m_drawing.m_meshDirty.push_back(rScene.m_cube);
```

2. Renderer calls compile_meshes, which iterates the entities in the mesh dirty vector, reads their ACompMesh, and gives them an ACompMeshGL component which is a compiled GPU mesh. The entity now has a mesh that can be rendered by a shader.
```cpp
// Load any required meshes
SysRenderGL::compile_meshes(
        rScene.m_drawing.m_mesh, rScene.m_drawing.m_meshDirty,
        rRenderer.m_renderGl.m_meshGl, rApp.get_gl_resources());
```

Textures do the exact same thing, but with textures instead of meshes.

This synchronization effectively separates the renderer from all the other world logic, making it extremely easy to close the application, re-open it (there's a `reopen` command), run it in the background, or serialize it. 

### Shaders and materials rundown

1. During renderer setup, a ACtxDrawPhong is created, which stores pointers to needed components and shaders, so the Phong shader draw function can access them.
```cpp
// Acquire data needed to draw Phong materials
{
    ACtxDrawPhong &rPhong = pRenderer->m_phong;
    rPhong.m_shaderUntextured
            = rGlResources.get_or_reserve<Phong>("notexture");
    rPhong.m_shaderDiffuse
            = rGlResources.get_or_reserve<Phong>("textured");
    rPhong.m_pDrawTf       = &rScene.m_drawing.m_drawTransform;
    rPhong.m_pDiffuseTexGl = &pRenderer->m_renderGl.m_diffuseTexGl;
    rPhong.m_pMeshGl       = &pRenderer->m_renderGl.m_meshGl;
}
```

2. To create renderable entities, give them a material, which is simply a category or group that acts as a hint at what shaders will be assigned to it. 
```cpp
// gc_mat_common is just an integer constant:
// constexpr int const gc_mat_common      = 0;

// Add common material to cube
MaterialData &rMatCommon = rScene.m_drawing.m_materials[gc_mat_common];
rMatCommon.m_comp.emplace(rScene.m_cube);
rMatCommon.m_added.push_back(rScene.m_cube);
```

MaterialData from drawing.h for reference. 
```cpp
struct MaterialData
{
    active_sparse_set_t     m_comp;
    std::vector<ActiveEnt>  m_added;
    std::vector<ActiveEnt>  m_removed;
};
```

3. Renderer calls assign_phong, see comment. A render group is simply a list of entities and their draw functions. Everything is now set to render the entity.
```cpp
// Assign Phong shader to entities with the gc_mat_common material, and put
// results into the fwd_opaque render group
RenderGroup &rGroupFwdOpaque
        = rRenderer.m_renderGroups.m_groups["fwd_opaque"];
MaterialData &rMatCommon = rScene.m_drawing.m_materials[gc_mat_common];
assign_phong(
        rMatCommon.m_added, &rGroupFwdOpaque.m_entities, nullptr,
        rScene.m_drawing.m_opaque, rRenderer.m_renderGl.m_diffuseTexGl,
        rRenderer.m_phong);
rMatCommon.m_added.clear();
```

