### PR TITLE
Separate renderer entirely and Improve documentation

### DIFF
--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -68,7 +68,7 @@ using namespace adera::shader;
 
 void PlumeShader::draw_plume(
         ActiveEnt ent,
-        ACompCamera const& camera,
+        ViewProjMatrix const& viewProj,
         EntityToDraw::UserData_t userData) noexcept
 {
     using Magnum::GL::Renderer;
@@ -82,7 +82,7 @@ void PlumeShader::draw_plume(
     PlumeEffectData const &effect       = *comp.m_effect;
     Magnum::GL::Mesh &rMesh             = *rData.m_pMesh->get(ent).m_mesh;
 
-    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
+    Magnum::Matrix4 entRelative = viewProj.m_view * drawTf.m_transformWorld;
 
     rData.m_shader
         .bindNozzleNoiseTexture     (*rData.m_tmpTex)
@@ -93,7 +93,7 @@ void PlumeShader::draw_plume(
         .updateTime                 (comp.m_time)
         .setPower                   (comp.m_powerLevel)
         .setTransformationMatrix    (entRelative)
-        .setProjectionMatrix        (camera.m_projection)
+        .setProjectionMatrix        (viewProj.m_proj)
         .setNormalMatrix            (entRelative.normalMatrix());
 
     // Draw back face

--- a/src/adera/Shaders/PlumeShader.h
+++ b/src/adera/Shaders/PlumeShader.h
@@ -65,7 +65,7 @@ public:
 
     static void draw_plume(
             osp::active::ActiveEnt ent,
-            osp::active::ACompCamera const& camera,
+            osp::active::ViewProjMatrix const& viewProj,
             osp::active::EntityToDraw::UserData_t userData) noexcept;
 
     static void assign_plumes(

--- a/src/osp/Active/SysRender.cpp
+++ b/src/osp/Active/SysRender.cpp
@@ -28,7 +28,7 @@ using osp::active::SysRender;
 
 void SysRender::update_draw_transforms(
         acomp_storage_t<ACompHierarchy> const& hier,
-        acomp_view_t<ACompTransform> const& viewTf,
+        acomp_storage_t<ACompTransform> const& transform,
         acomp_storage_t<ACompDrawTransform>& rDrawTf)
 {
 
@@ -38,22 +38,32 @@ void SysRender::update_draw_transforms(
 
     for(ActiveEnt const entity : viewDrawTf)
     {
-        ACompHierarchy const &entHier = hier.get(entity);
-        auto const &entTf = viewTf.get<ACompTransform>(entity);
-        auto &entDrawTf = viewDrawTf.get<ACompDrawTransform>(entity);
+        ACompHierarchy const &entHier   = hier.get(entity);
+        ACompTransform const &entTf     = transform.get(entity);
+        ACompDrawTransform &rEntDrawTf  = rDrawTf.get(entity);
 
         if (entHier.m_level == 1)
         {
             // top level object, parent is root
-            entDrawTf.m_transformWorld = entTf.m_transform;
+            rEntDrawTf.m_transformWorld = entTf.m_transform;
         }
         else
         {
             ACompDrawTransform const& parentDrawTf = rDrawTf.get(entHier.m_parent);
 
             // set transform relative to parent
-            entDrawTf.m_transformWorld = parentDrawTf.m_transformWorld
-                                       * entTf.m_transform;
+            rEntDrawTf.m_transformWorld = parentDrawTf.m_transformWorld
+                                        * entTf.m_transform;
         }
     }
 }
+
+void SysRender::clear_dirty_materials(std::vector<MaterialData> &rMaterials)
+{
+    for (MaterialData &rMat : rMaterials)
+    {
+        rMat.m_added.clear();
+        rMat.m_removed.clear();
+    }
+}
+

--- a/src/osp/Active/basic.h
+++ b/src/osp/Active/basic.h
@@ -97,16 +97,18 @@ struct ACompCamera
 {
     float m_near;
     float m_far;
+    float m_aspectRatio;
     Deg m_fov;
-    Vector2 m_viewport;
 
-    Matrix4 m_projection;
-    Matrix4 m_inverse;
-
-    void calculate_projection() noexcept
+    constexpr void set_aspect_ratio(Vector2 const viewport) noexcept
     {
-        m_projection = osp::Matrix4::perspectiveProjection(
-                m_fov, m_viewport.x() / m_viewport.y(),
+        m_aspectRatio = viewport.x() / viewport.y();
+    }
+
+    Matrix4 calculate_projection() const noexcept
+    {
+        return osp::Matrix4::perspectiveProjection(
+                m_fov, m_aspectRatio,
                 m_near, m_far);
     }
 };

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -107,7 +107,6 @@ struct ACtxDrawing
     acomp_storage_t<ACompOpaque>            m_opaque;
     acomp_storage_t<ACompTransparent>       m_transparent;
     acomp_storage_t<ACompVisible>           m_visible;
-    acomp_storage_t<ACompDrawTransform>     m_drawTransform;
     acomp_storage_t<ACompColor>             m_color;
 
     acomp_storage_t<ACompMesh>              m_mesh;

--- a/src/osp/Active/opengl/SysRenderGL.cpp
+++ b/src/osp/Active/opengl/SysRenderGL.cpp
@@ -116,11 +116,11 @@ DependRes<Mesh> try_compile_mesh(
 
 void SysRenderGL::compile_meshes(
         acomp_storage_t<ACompMesh> const& meshes,
-        std::vector<ActiveEnt>& rDirty,
+        std::vector<ActiveEnt> const& dirty,
         acomp_storage_t<ACompMeshGL>& rMeshGl,
         osp::Package& rGlResources)
 {
-    for (ActiveEnt ent : std::exchange(rDirty, {}))
+    for (ActiveEnt ent : dirty)
     {
         if (meshes.contains(ent))
         {
@@ -189,11 +189,11 @@ DependRes<Texture2D> try_compile_texture(
 
 void SysRenderGL::compile_textures(
         acomp_storage_t<ACompTexture> const& textures,
-        std::vector<ActiveEnt>& rDirty,
+        std::vector<ActiveEnt> const& dirty,
         acomp_storage_t<ACompTextureGL>& rTexGl,
         osp::Package& rGlResources)
 {
-    for (ActiveEnt ent : std::exchange(rDirty, {}))
+    for (ActiveEnt ent : dirty)
     {
         if (textures.contains(ent))
         {
@@ -257,7 +257,7 @@ void SysRenderGL::display_texture(
 void SysRenderGL::render_opaque(
         RenderGroup const& group,
         acomp_storage_t<ACompVisible> const& visible,
-        ACompCamera const& camera)
+        ViewProjMatrix const& viewProj)
 {
     using Magnum::GL::Renderer;
 
@@ -266,13 +266,13 @@ void SysRenderGL::render_opaque(
     Renderer::disable(Renderer::Feature::Blending);
     Renderer::setDepthMask(true);
 
-    draw_group(group, visible, camera);
+    draw_group(group, visible, viewProj);
 }
 
 void SysRenderGL::render_transparent(
         RenderGroup const& group,
         acomp_storage_t<ACompVisible> const& visible,
-        ACompCamera const& camera)
+        ViewProjMatrix const& viewProj)
 {
     using Magnum::GL::Renderer;
 
@@ -287,19 +287,19 @@ void SysRenderGL::render_transparent(
     //            can mess up other transparent objects once added
     //Renderer::setDepthMask(false);
 
-    draw_group(group, visible, camera);
+    draw_group(group, visible, viewProj);
 }
 
 void SysRenderGL::draw_group(
         RenderGroup const& group,
         acomp_storage_t<ACompVisible> const& visible,
-        ACompCamera const& camera)
+        ViewProjMatrix const& viewProj)
 {
     for (auto const& [ent, toDraw] : group.view().each())
     {
         if (visible.contains(ent))
         {
-            toDraw(ent, camera);
+            toDraw(ent, viewProj);
         }
     }
 }

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -56,8 +56,9 @@ struct ACompTextureGL
  */
 struct ACtxRenderGL
 {
-    acomp_storage_t<ACompMeshGL>    m_meshGl;
-    acomp_storage_t<ACompTextureGL> m_diffuseTexGl;
+    acomp_storage_t<ACompMeshGL>            m_meshGl;
+    acomp_storage_t<ACompTextureGL>         m_diffuseTexGl;
+    acomp_storage_t<ACompDrawTransform>     m_drawTransform;
 };
 
 /**
@@ -93,14 +94,13 @@ public:
      * Entities with an ACompMesh will be synchronized with an ACompMeshGL
      *
      * @param meshes        [in] Storage for generic mesh components
-     * @param rDirty        [ref] Vector of entities that have updated meshes,
-     *                            this will be cleared.
+     * @param dirty         [in] Vector of entities that have updated meshes
      * @param rMeshGl       [ref] Storage for GL mesh components
      * @param rGlResources  [out] Package to store newly compiled meshes
      */
     static void compile_meshes(
             acomp_storage_t<ACompMesh> const& meshes,
-            std::vector<ActiveEnt>& rDirty,
+            std::vector<ActiveEnt> const& dirty,
             acomp_storage_t<ACompMeshGL>& rMeshGl,
             osp::Package& rGlResources);
 
@@ -109,48 +109,60 @@ public:
      *        texture data components
      *
      * @param textures      [in] Storage for generic texture data components
-     * @param rDirty        [ref] Vector of entities that have updated meshes,
-     *                            this will be cleared.
+     * @param dirty         [in] Vector of entities that have updated textures
      * @param rDiffTexGl    [ref] Storage for GL texture components
      * @param rGlResources  [out] Package to store newly compiled textures
      */
     static void compile_textures(
             acomp_storage_t<ACompTexture> const& textures,
-            std::vector<ActiveEnt>& rDirty,
+            std::vector<ActiveEnt> const& dirty,
             acomp_storage_t<ACompTextureGL>& rDiffTexGl,
             osp::Package& rGlResources);
 
     /**
      * @brief Call draw functions of a RenderGroup of opaque objects
      *
-     * @param group         [in] RenderGroup to draw
-     * @param visible       [in] Storage for visible components
-     * @param camera        [in] Camera to render from
+     * @param group     [in] RenderGroup to draw
+     * @param visible   [in] Storage for visible components
+     * @param viewProj  [in] View and projection matrix
      */
     static void render_opaque(
             RenderGroup const& group,
             acomp_storage_t<ACompVisible> const& visible,
-            ACompCamera const& camera);
+            ViewProjMatrix const& viewProj);
 
     /**
      * @brief Call draw functions of a RenderGroup of transparent objects
      *
      * Consider sorting the render group for correct transparency
      *
-     * @param group         [in] RenderGroup to draw
-     * @param visible       [in] Storage for visible components
-     * @param camera        [in] Camera to render from
+     * @param group     [in] RenderGroup to draw
+     * @param visible   [in] Storage for visible components
+     * @param viewProj  [in] View and projection matrix
      */
     static void render_transparent(
             RenderGroup const& group,
             acomp_storage_t<ACompVisible> const& visible,
-            ACompCamera const& camera);
+            ViewProjMatrix const& viewProj);
 
     static void draw_group(
             RenderGroup const& group,
             acomp_storage_t<ACompVisible> const& visible,
-            ACompCamera const& camera);
+            ViewProjMatrix const& viewProj);
+
+    template<typename IT_T>
+    static void update_delete(
+            ACtxRenderGL &rCtxRenderGl, IT_T first, IT_T last);
 };
+
+template<typename IT_T>
+void SysRenderGL::update_delete(
+        ACtxRenderGL &rCtxRenderGl, IT_T first, IT_T last)
+{
+    rCtxRenderGl.m_meshGl           .remove(first, last);
+    rCtxRenderGl.m_diffuseTexGl     .remove(first, last);
+    rCtxRenderGl.m_drawTransform    .remove(first, last);
+}
 
 
 

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -36,7 +36,7 @@ using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_flat(
-        ActiveEnt ent, ACompCamera const& camera,
+        ActiveEnt ent, ViewProjMatrix const& viewProj,
         EntityToDraw::UserData_t userData) noexcept
 {
     using Flag = Flat::Flag;
@@ -46,8 +46,6 @@ void shader::draw_ent_flat(
 
     // Collect uniform information
     ACompDrawTransform const &drawTf = rData.m_pDrawTf->get(ent);
-
-    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
 
     if (rShader.flags() & Flag::Textured)
     {
@@ -62,7 +60,7 @@ void shader::draw_ent_flat(
     }
 
     rShader
-        .setTransformationProjectionMatrix(camera.m_projection*entRelative)
+        .setTransformationProjectionMatrix(viewProj.m_viewProj * drawTf.m_transformWorld)
         .draw(*rData.m_pMeshGl->get(ent).m_mesh);
 }
 

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -50,7 +50,7 @@ struct ACtxDrawFlat
 
 void draw_ent_flat(
         active::ActiveEnt ent,
-        active::ACompCamera const& camera,
+        active::ViewProjMatrix const& viewProj,
         active::EntityToDraw::UserData_t userData) noexcept;
 
 /**

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -39,7 +39,7 @@ using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_visualizer(
-        ActiveEnt ent, const ACompCamera &camera,
+        ActiveEnt ent, const ViewProjMatrix &viewProj,
         EntityToDraw::UserData_t userData) noexcept
 {
     using Magnum::Shaders::MeshVisualizerGL3D;
@@ -49,8 +49,7 @@ void shader::draw_ent_visualizer(
     ACompMeshGL &rMesh = rData.m_pMeshGl->get(ent);
     ACompDrawTransform const& drawTf = rData.m_pDrawTf->get(ent);
 
-    Matrix4 const entRelative = camera.m_inverse * drawTf.m_transformWorld;
-
+    Matrix4 const entRelative = viewProj.m_view * drawTf.m_transformWorld;
 
     MeshVisualizer &rShader = *rData.m_shader;
 
@@ -69,7 +68,7 @@ void shader::draw_ent_visualizer(
     rShader
         .setViewportSize(Vector2{Magnum::GL::defaultFramebuffer.viewport().size()})
         .setTransformationMatrix(entRelative)
-        .setProjectionMatrix(camera.m_projection)
+        .setProjectionMatrix(viewProj.m_proj)
         .draw(*rMesh.m_mesh);
 
     if (rData.m_wireframeOnly)

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -42,11 +42,17 @@ struct ACtxDrawMeshVisualizer
     active::acomp_storage_t< active::ACompMeshGL >         *m_pMeshGl{nullptr};
 
     bool m_wireframeOnly{false};
+
+    constexpr void assign_pointers(active::ACtxRenderGL& rCtxRenderGl) noexcept
+    {
+        m_pDrawTf   = &rCtxRenderGl.m_drawTransform;
+        m_pMeshGl   = &rCtxRenderGl.m_meshGl;
+    }
 };
 
 void draw_ent_visualizer(
         active::ActiveEnt ent,
-        active::ACompCamera const& camera,
+        active::ViewProjMatrix const& viewProj,
         active::EntityToDraw::UserData_t userData) noexcept;
 
 

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -36,7 +36,7 @@ using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_phong(
-        ActiveEnt ent, ACompCamera const& camera,
+        ActiveEnt ent, ViewProjMatrix const& viewProj,
         EntityToDraw::UserData_t userData) noexcept
 {
     using Flag = Phong::Flag;
@@ -47,7 +47,7 @@ void shader::draw_ent_phong(
     // Collect uniform information
     ACompDrawTransform const &drawTf = rData.m_pDrawTf->get(ent);
 
-    Magnum::Matrix4 entRelative = camera.m_inverse * drawTf.m_transformWorld;
+    Magnum::Matrix4 entRelative = viewProj.m_view * drawTf.m_transformWorld;
 
     /* 4th component indicates light type. A value of 0.0f indicates that the
      * light is a direction light coming from the specified direction relative
@@ -79,14 +79,14 @@ void shader::draw_ent_phong(
         .setLightPositions({Vector4{Vector3{0.2f, 0.6f, 0.5f}.normalized(), 0.0f},
                            Vector4{-Vector3{0.2f, 0.6f, 0.5f}.normalized(), 0.0f}})
         .setTransformationMatrix(entRelative)
-        .setProjectionMatrix(camera.m_projection)
+        .setProjectionMatrix(viewProj.m_proj)
         .setNormalMatrix(Matrix3{drawTf.m_transformWorld})
         .draw(*rData.m_pMeshGl->get(ent).m_mesh);
 }
 
 
 void shader::assign_phong(
-        RenderGroup::ArrayView_t entities,
+        RenderGroup::ArrayView_t const entities,
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
         acomp_storage_t<ACompOpaque> const& opaque,

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -48,13 +48,19 @@ struct ACtxDrawPhong
     active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
     active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
     active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl{nullptr};
-
     active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl{nullptr};
+
+    constexpr void assign_pointers(active::ACtxRenderGL& rCtxRenderGl) noexcept
+    {
+        m_pDrawTf       = &rCtxRenderGl.m_drawTransform;
+        m_pDiffuseTexGl = &rCtxRenderGl.m_diffuseTexGl;
+        m_pMeshGl       = &rCtxRenderGl.m_meshGl;
+    }
 };
 
 void draw_ent_phong(
         active::ActiveEnt ent,
-        active::ACompCamera const& camera,
+        active::ViewProjMatrix const& viewProj,
         active::EntityToDraw::UserData_t userData) noexcept;
 
 /**

--- a/src/test_application/activescenes/CameraController.h
+++ b/src/test_application/activescenes/CameraController.h
@@ -53,9 +53,9 @@ struct ACtxCameraController
      , m_btnMovDn(      m_controls.button_subscribe("cam_dn"))
     { }
 
-    osp::Vector3 m_up{};
+    osp::Vector3 m_up{0.0f, 1.0f, 0.0f};
 
-    std::optional<osp::Vector3> m_target;
+    std::optional<osp::Vector3> m_target{osp::Vector3{}};
     float m_orbitDistance{20.0f};
 
     float m_moveSpeed{1.0f};

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -55,7 +55,7 @@ entt::any setup_scene();
  *
  * @return
  */
-on_draw_t gen_draw(FlightScene& rScene, ActiveApplication& rApp);
+on_draw_t generate_draw_func(FlightScene& rScene, ActiveApplication& rApp);
 
 } // namespace flight
 
@@ -94,7 +94,7 @@ void load_gl_resources(ActiveApplication& rApp);
  *
  * @return ActiveApplication draw function
  */
-on_draw_t gen_draw(EngineTestScene& rScene, ActiveApplication& rApp);
+on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp);
 
 } // namespace enginetest
 
@@ -133,7 +133,7 @@ void load_gl_resources(ActiveApplication& rApp);
  *
  * @return ActiveApplication draw function
  */
-on_draw_t gen_draw(PhysicsTestScene& rScene, ActiveApplication& rApp);
+on_draw_t generate_draw_func(PhysicsTestScene& rScene, ActiveApplication& rApp);
 
 } // namespace physicstest
 

--- a/src/test_application/activescenes/scenarios_flight.cpp
+++ b/src/test_application/activescenes/scenarios_flight.cpp
@@ -39,7 +39,7 @@ entt::any setup_scene()
     return std::move(sceneAny);
 }
 
-on_draw_t gen_draw(FlightScene& rScene, ActiveApplication& rApp)
+on_draw_t generate_draw_func(FlightScene& rScene, ActiveApplication& rApp)
 {
     return [] (ActiveApplication& rApp, float delta) {};
 }

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -128,7 +128,7 @@ std::unordered_map<std::string_view, Option> const g_scenes
         {
             EngineTestScene& rScene
                     = entt::any_cast<EngineTestScene&>(g_activeScene);
-            rApp.set_on_draw(gen_draw(rScene, rApp));
+            rApp.set_on_draw(generate_draw_func(rScene, rApp));
             load_gl_resources(*g_activeApplication);
         };
     }}},
@@ -141,7 +141,7 @@ std::unordered_map<std::string_view, Option> const g_scenes
         {
             PhysicsTestScene& rScene
                     = entt::any_cast<PhysicsTestScene&>(g_activeScene);
-            rApp.set_on_draw(gen_draw(rScene, rApp));
+            rApp.set_on_draw(generate_draw_func(rScene, rApp));
             load_gl_resources(*g_activeApplication);
         };
     }}}


### PR DESCRIPTION
As the titles says, this pull request achieves 'complete' separation between the rendering and engine code. Take a look at the `render_test_scene()` function in `scenarios_enginetest.cpp` and `scenarios_physicstest.cpp`; the entire scene structs are now passed in as const :)

Changes:
* Move draw transform component (ACompDrawTransform) to the renderer. Moved from the ACtxDrawing struct to ACtxRenderGL struct.
* Add missing deleter system functions for ACtxRenderGL, somehow this didn't lead to any bugs from before.
* Separate rendering-related matrices from camera component (ACompCamera). This is turned into the ViewProjMatrix struct, which stores the view and projection matrix. ViewProjMatrix is now passed to drawing functions instead of ACompCamera.
* Rename "gen_draw" functions to "generate_draw_func" for better clarity
* Rearrange code in `scenarios_physicstest.cpp`, related to aborts caused by entities created and deleted on the same update. Entity creation now happens near the end of the frame.

In the future, the renderer is intended to handle interpolation between frames, hence frames rendered between physics updates. This adds some sense to separating draw transforms.