### PR TITLE
Replace 'GL Resources' Package with RenderGL struct

### DIFF
--- a/src/adera/Plume.h
+++ b/src/adera/Plume.h
@@ -32,8 +32,6 @@
 namespace adera::active
 {
 
-struct MaterialPlume { };
-
 struct PlumeEffectData
 {
     float m_flowVelocity;

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -27,16 +27,10 @@
 #include <adera/Plume.h>                  // for PlumeEffectData
 #include <adera/SysExhaustPlume.h>        // for ACompExhaustPlume
 
-#include <osp/Resource/Package.h>         // for Package
-#include <osp/Resource/Resource.h>        // for DependRes
-#include <osp/Resource/AssetImporter.h>   // for AssetImporter
-
 #include <osp/Active/basic.h>             // for ACompCamera
 #include <osp/Active/drawing.h>           // for ACompDrawTransform
 #include <osp/Active/SysRender.h>         // for ACompMesh
 #include <osp/Active/activetypes.h>       // for basic_sparse_set, ActiveEnt
-
-#include <osp/Resource/PackageRegistry.h> // for PackageRegistry
 
 #include <Magnum/GL/Shader.h>             // for Shader, Shader::Type
 #include <Magnum/GL/Texture.h>            // for Texture2D
@@ -79,14 +73,16 @@ void PlumeShader::draw_plume(
     // Collect uniform data
     ACompDrawTransform const &drawTf    = rData.m_pDrawTf->get(ent);
     ACompExhaustPlume const &comp       = rData.m_pExaustPlumes->get(ent);
-    PlumeEffectData const &effect       = *comp.m_effect;
-    Magnum::GL::Mesh &rMesh             = rData.m_pMeshGl->get(rData.m_pMeshId->get(ent));
+    PlumeEffectData const &effect       = comp.m_effect;
+    MeshGlId const meshId               = rData.m_pMeshId->get(ent);
+    Magnum::GL::Mesh &rMesh             = rData.m_pMeshGl->get(meshId);
+    Magnum::GL::Texture2D &rTmpTex      = rData.m_pTexGl->get(rData.m_tmpTex);
 
     Magnum::Matrix4 entRelative = viewProj.m_view * drawTf.m_transformWorld;
 
     rData.m_shader
-        .bindNozzleNoiseTexture     (*rData.m_tmpTex)
-        .bindCombustionNoiseTexture (*rData.m_tmpTex)
+        .bindNozzleNoiseTexture     (rTmpTex)
+        .bindCombustionNoiseTexture (rTmpTex)
         .setMeshZBounds             (effect.m_zMax, effect.m_zMin)
         .setBaseColor               (effect.m_color)
         .setFlowVelocity            (effect.m_flowVelocity)

--- a/src/adera/Shaders/PlumeShader.cpp
+++ b/src/adera/Shaders/PlumeShader.cpp
@@ -80,7 +80,7 @@ void PlumeShader::draw_plume(
     ACompDrawTransform const &drawTf    = rData.m_pDrawTf->get(ent);
     ACompExhaustPlume const &comp       = rData.m_pExaustPlumes->get(ent);
     PlumeEffectData const &effect       = *comp.m_effect;
-    Magnum::GL::Mesh &rMesh             = *rData.m_pMesh->get(ent).m_mesh;
+    Magnum::GL::Mesh &rMesh             = rData.m_pMeshGl->get(rData.m_pMeshId->get(ent));
 
     Magnum::Matrix4 entRelative = viewProj.m_view * drawTf.m_transformWorld;
 

--- a/src/adera/Shaders/PlumeShader.h
+++ b/src/adera/Shaders/PlumeShader.h
@@ -129,15 +129,17 @@ struct ACtxPlumeData
     using ACompDrawTransform    = osp::active::ACompDrawTransform;
     using ACompExhaustPlume     = adera::active::ACompExhaustPlume;
     using MeshGlId              = osp::active::MeshGlId;
+    using TexGlId               = osp::active::TexGlId;
 
     PlumeShader m_shader;
 
-    osp::DependRes<Magnum::GL::Texture2D> m_tmpTex;
+    TexGlId m_tmpTex;
 
     acomp_storage_t<ACompDrawTransform> *m_pDrawTf{nullptr};
     acomp_storage_t<ACompExhaustPlume>  *m_pExaustPlumes{nullptr};
     acomp_storage_t<MeshGlId>           *m_pMeshId{nullptr};
     osp::active::MeshGlStorage_t        *m_pMeshGl{nullptr};
+    osp::active::TexGlStorage_t         *m_pTexGl{nullptr};
 };
 
 } // namespace adera::shader

--- a/src/adera/Shaders/PlumeShader.h
+++ b/src/adera/Shaders/PlumeShader.h
@@ -127,8 +127,8 @@ struct ACtxPlumeData
     template<typename COMP_T>
     using acomp_storage_t       = typename osp::active::acomp_storage_t<COMP_T>;
     using ACompDrawTransform    = osp::active::ACompDrawTransform;
-    using ACompMeshGL           = osp::active::ACompMeshGL;
     using ACompExhaustPlume     = adera::active::ACompExhaustPlume;
+    using MeshGlId              = osp::active::MeshGlId;
 
     PlumeShader m_shader;
 
@@ -136,7 +136,8 @@ struct ACtxPlumeData
 
     acomp_storage_t<ACompDrawTransform> *m_pDrawTf{nullptr};
     acomp_storage_t<ACompExhaustPlume>  *m_pExaustPlumes{nullptr};
-    acomp_storage_t<ACompMeshGL>        *m_pMesh{nullptr};
+    acomp_storage_t<MeshGlId>           *m_pMeshId{nullptr};
+    osp::active::MeshGlStorage_t        *m_pMeshGl{nullptr};
 };
 
 } // namespace adera::shader

--- a/src/adera/SysExhaustPlume.h
+++ b/src/adera/SysExhaustPlume.h
@@ -27,8 +27,6 @@
 
 #include <osp/Active/activetypes.h>  // for ActiveEnt
 
-#include <osp/Resource/Resource.h>   // for DependRes
-
 #include <entt/entity/entity.hpp>    // for null, null_t
 
 namespace osp { namespace active { class ActiveScene; } }
@@ -39,7 +37,7 @@ namespace adera::active
 struct ACompExhaustPlume
 {
     osp::active::ActiveEnt m_parentMCompRocket{entt::null};
-    osp::DependRes<PlumeEffectData> m_effect;
+    PlumeEffectData m_effect;
 
     float m_time{0.0f};
     float m_powerLevel{0.0f};

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -124,11 +124,11 @@ public:
             acomp_storage_t<ACompDrawTransform>& rDrawTf,
             ActiveEnt ent);
 
-    template<typename IT_T>
+    template<typename ITA_T, typename ITB_T>
     static void assure_draw_transforms(
             acomp_storage_t<ACompHierarchy> const& hier,
             acomp_storage_t<ACompDrawTransform>& rDrawTf,
-            IT_T first, IT_T last);
+            ITA_T first, ITB_T last);
 
     /**
      * @brief Update draw ACompDrawTransform according to the hierarchy of
@@ -189,11 +189,11 @@ void SysRender::add_draw_transforms_recurse(
     add_draw_transforms_recurse(hier, rDrawTf, currHier.m_parent);
 }
 
-template<typename IT_T>
+template<typename ITA_T, typename ITB_T>
 void SysRender::assure_draw_transforms(
         acomp_storage_t<ACompHierarchy> const& hier,
         acomp_storage_t<ACompDrawTransform>& rDrawTf,
-        IT_T first, IT_T last)
+        ITA_T first, ITB_T last)
 {
     while (first != last)
     {

--- a/src/osp/Active/opengl/SysRenderGL.cpp
+++ b/src/osp/Active/opengl/SysRenderGL.cpp
@@ -50,14 +50,16 @@ using Magnum::GL::Mesh;
 using Magnum::GL::Texture2D;
 
 using osp::DependRes;
-using osp::Package;
-using osp::active::SysRenderGL;
 
-void SysRenderGL::setup_context(Package& rGlResources)
+using osp::active::SysRenderGL;
+using osp::active::RenderGL;
+
+using osp::active::TexIdGL;
+using osp::active::MeshIdGL;
+
+void SysRenderGL::setup_context(RenderGL& rCtxGl)
 {
     using namespace Magnum;
-
-    rGlResources.add<FullscreenTriShader>("fullscreen_tri_shader");
 
     /* Generate fullscreen tri for texture rendering */
     {
@@ -72,53 +74,51 @@ void SysRenderGL::setup_context(Package& rGlResources)
         };
 
         GL::Buffer surface(surfData, GL::BufferUsage::StaticDraw);
-        GL::Mesh surfaceMesh;
-        surfaceMesh
+        rCtxGl.m_fullscreenTri = rCtxGl.create_mesh();
+
+        rCtxGl.get_mesh(rCtxGl.m_fullscreenTri)
             .setPrimitive(Magnum::MeshPrimitive::Triangles)
             .setCount(3)
             .addVertexBuffer(std::move(surface), 0,
                 FullscreenTriShader::Position{},
                 FullscreenTriShader::TextureCoordinates{});
-        rGlResources.add<GL::Mesh>("fullscreen_tri", std::move(surfaceMesh));
     }
 
     /* Add an offscreen framebuffer */
     {
-        Vector2i viewSize = GL::defaultFramebuffer.viewport().size();
+        Vector2i const viewSize = GL::defaultFramebuffer.viewport().size();
 
-        DependRes<GL::Texture2D> color = rGlResources.add<GL::Texture2D>("offscreen_fbo_color");
-        color->setStorage(1, GL::TextureFormat::RGB8, viewSize);
-
-        DependRes<GL::Renderbuffer> depthStencil
-                = rGlResources.add<GL::Renderbuffer>("offscreen_fbo_depthStencil");
-        depthStencil->setStorage(GL::RenderbufferFormat::Depth24Stencil8, viewSize);
-
-        DependRes<GL::Framebuffer> fbo
-                = rGlResources.add<GL::Framebuffer>("offscreen_fbo", Range2Di{{0, 0}, viewSize});
-        fbo->attachTexture(GL::Framebuffer::ColorAttachment{0}, *color, 0);
-        fbo->attachRenderbuffer(GL::Framebuffer::BufferAttachment::DepthStencil, *depthStencil);
+        rCtxGl.m_fboColor = rCtxGl.create_tex();
+        GL::Texture2D &rFboColor = rCtxGl.get_tex(rCtxGl.m_fboColor);
+        rFboColor.setStorage(1, GL::TextureFormat::RGB8, viewSize);
+        rCtxGl.m_fboDepthStencil.setStorage(GL::RenderbufferFormat::Depth24Stencil8, viewSize);
+        rCtxGl.m_fbo.attachTexture(GL::Framebuffer::ColorAttachment{0}, rFboColor, 0);
+        rCtxGl.m_fbo.attachRenderbuffer(GL::Framebuffer::BufferAttachment::DepthStencil, rCtxGl.m_fboDepthStencil);
     }
 }
 
-DependRes<Mesh> try_compile_mesh(
-        osp::Package& rGlResources, DependRes<MeshData> const& meshData)
+MeshIdGL try_compile_mesh(
+        RenderGL& rRenderGl, DependRes<MeshData> const& meshData)
 {
-    DependRes<Mesh> rMeshGlRes = rGlResources.get_or_reserve<Mesh>(meshData.name());
+    auto foundIt = rRenderGl.m_oldResToMesh.find(meshData.name());
 
-    if (rMeshGlRes.reserve_empty())
+    if (foundIt == rRenderGl.m_oldResToMesh.end())
     {
         // Mesh isn't compiled yet, compile it
-        rMeshGlRes.reserve_emplace(Magnum::MeshTools::compile(*meshData));
+        MeshIdGL newId = rRenderGl.create_mesh();
+        rRenderGl.get_mesh(newId) = Magnum::MeshTools::compile(*meshData);
+        rRenderGl.m_oldResToMesh.emplace(meshData.name(), newId);
+        return newId;
     }
 
-    return rMeshGlRes;
+    return foundIt->second;
 }
 
 void SysRenderGL::compile_meshes(
         acomp_storage_t<ACompMesh> const& meshes,
         std::vector<ActiveEnt> const& dirty,
-        acomp_storage_t<ACompMeshGL>& rMeshGl,
-        osp::Package& rGlResources)
+        acomp_storage_t<MeshIdGL>& rMeshGl,
+        RenderGL& rRenderGl)
 {
     for (ActiveEnt ent : dirty)
     {
@@ -129,19 +129,19 @@ void SysRenderGL::compile_meshes(
             if (rMeshGl.contains(ent))
             {
                 // Check if ACompMesh changed
-                ACompMeshGL &rEntMeshGl = rMeshGl.get(ent);
+                MeshIdGL &rEntMeshGl = rMeshGl.get(ent);
 
-                if (rEntMeshGl.m_mesh.name() != rEntMesh.m_mesh.name())
+                if (rRenderGl.m_oldResToMesh.at(rEntMesh.m_mesh.name()) != rEntMeshGl)
                 {
                     // get new mesh
-                    rEntMeshGl.m_mesh = try_compile_mesh(rGlResources, rEntMesh.m_mesh);
+                    rEntMeshGl = try_compile_mesh(rRenderGl, rEntMesh.m_mesh);
                 }
             }
             else
             {
                 // ACompMeshGL component needed
                 rMeshGl.emplace(
-                        ent, ACompMeshGL{try_compile_mesh(rGlResources, rEntMesh.m_mesh)});
+                        ent, try_compile_mesh(rRenderGl, rEntMesh.m_mesh));
             }
         }
         else
@@ -159,17 +159,19 @@ void SysRenderGL::compile_meshes(
     }
 }
 
-DependRes<Texture2D> try_compile_texture(
-        osp::Package& rGlResources, DependRes<ImageData2D> const& texData)
+TexIdGL try_compile_texture(
+        RenderGL& rRenderGl, DependRes<ImageData2D> const& texData)
 {
-    DependRes<Texture2D> rTexGlRes
-            = rGlResources.get_or_reserve<Texture2D>(texData.name());
+    auto foundIt = rRenderGl.m_oldResToTex.find(texData.name());
 
-    if (rTexGlRes.reserve_empty())
+    if (foundIt == rRenderGl.m_oldResToTex.end())
     {
         // Texture isn't compiled yet, compile it
-        Texture2D &rTexGl = rTexGlRes.reserve_emplace();
+        TexIdGL newId = rRenderGl.create_tex();
 
+        Texture2D &rTexGl = rRenderGl.get_tex(newId);
+        rTexGl = Texture2D{};
+        
         using Magnum::GL::SamplerWrapping;
         using Magnum::GL::SamplerFilter;
         using Magnum::GL::textureFormat;
@@ -182,16 +184,18 @@ DependRes<Texture2D> try_compile_texture(
             .setStorage(1, textureFormat((*texData).format()), (*texData).size())
             .setSubImage(0, {}, view);
 
+        return newId;
+
     }
 
-    return rTexGlRes;
+    return foundIt->second;
 }
 
 void SysRenderGL::compile_textures(
         acomp_storage_t<ACompTexture> const& textures,
         std::vector<ActiveEnt> const& dirty,
-        acomp_storage_t<ACompTextureGL>& rTexGl,
-        osp::Package& rGlResources)
+        acomp_storage_t<TexIdGL>& rTexGl,
+        RenderGL& rRenderGl)
 {
     for (ActiveEnt ent : dirty)
     {
@@ -202,19 +206,19 @@ void SysRenderGL::compile_textures(
             if (rTexGl.contains(ent))
             {
                 // Check if ACompTexture changed
-                ACompTextureGL &rEntTexGl = rTexGl.get(ent);
+                TexIdGL &rEntTexGl = rTexGl.get(ent);
 
-                if (rEntTexGl.m_tex.name() != rEntTexGl.m_tex.name())
+                if (rRenderGl.m_oldResToTex.at(rEntTex.m_texture.name()) != rEntTexGl)
                 {
                     // get new mesh
-                    rEntTexGl.m_tex = try_compile_texture(rGlResources, rEntTex.m_texture);
+                    rEntTexGl = try_compile_texture(rRenderGl, rEntTex.m_texture);
                 }
             }
             else
             {
                 // ACompMeshGL component needed
-                ACompTextureGL &rEntTexGl = rTexGl.emplace(
-                        ent, ACompTextureGL{try_compile_texture(rGlResources, rEntTex.m_texture)});
+                rTexGl.emplace(
+                        ent, try_compile_texture(rRenderGl, rEntTex.m_texture));
             }
         }
         else
@@ -233,16 +237,12 @@ void SysRenderGL::compile_textures(
 }
 
 void SysRenderGL::display_texture(
-        Package& rGlResources, Magnum::GL::Texture2D& rTex)
+        RenderGL& rRenderGl, Magnum::GL::Texture2D& rTex)
 {
     using Magnum::GL::Renderer;
     using Magnum::GL::Framebuffer;
     using Magnum::GL::FramebufferClear;
     using Magnum::GL::Mesh;
-
-    DependRes<FullscreenTriShader> shader
-            = rGlResources.get<FullscreenTriShader>("fullscreen_tri_shader");
-    DependRes<Mesh> surface = rGlResources.get<Mesh>("fullscreen_tri");
 
     Magnum::GL::defaultFramebuffer.bind();
 
@@ -251,7 +251,9 @@ void SysRenderGL::display_texture(
     Renderer::disable(Renderer::Feature::Blending);
     Renderer::setDepthMask(true);
 
-    shader->display_texure(*surface, rTex);
+    rRenderGl.m_fullscreenTriShader.display_texure(
+            rRenderGl.get_mesh(rRenderGl.m_fullscreenTri),
+            rRenderGl.get_tex(rRenderGl.m_fboColor));
 }
 
 void SysRenderGL::render_opaque(

--- a/src/osp/Active/opengl/SysRenderGL.cpp
+++ b/src/osp/Active/opengl/SysRenderGL.cpp
@@ -188,7 +188,6 @@ TexGlId try_compile_texture(
             .setSubImage(0, {}, view);
 
         return newId;
-
     }
 
     return foundIt->second;

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -37,8 +37,11 @@
 namespace osp::active
 {
 
-enum class TexIdGL : uint32_t { };
-enum class MeshIdGL : uint32_t { };
+enum class TexGlId : uint32_t { };
+enum class MeshGlId : uint32_t { };
+
+using TexGlStorage_t    = entt::basic_storage<TexGlId, Magnum::GL::Texture2D>;
+using MeshGlStorage_t   = entt::basic_storage<MeshGlId, Magnum::GL::Mesh>;
 
 /**
  * @brief Essential GL resources
@@ -48,55 +51,29 @@ enum class MeshIdGL : uint32_t { };
 struct RenderGL
 {
     // Fullscreen Triangle
-    MeshIdGL            m_fullscreenTri;
+    MeshGlId            m_fullscreenTri;
     FullscreenTriShader m_fullscreenTriShader;
 
     // Offscreen Framebuffer
-    TexIdGL                     m_fboColor;
+    TexGlId                     m_fboColor;
     Magnum::GL::Renderbuffer    m_fboDepthStencil{Corrade::NoCreate};
     Magnum::GL::Framebuffer     m_fbo{Corrade::NoCreate};
 
     // Addressable Textures
-    lgrn::IdRegistry<TexIdGL>           m_texIds;
-    std::vector<Magnum::GL::Texture2D>  m_texGl;
+    lgrn::IdRegistry<TexGlId>   m_texIds;
+    TexGlStorage_t              m_texGl;
 
     // Addressable Meshes
-    lgrn::IdRegistry<MeshIdGL>          m_meshIds;
-    std::vector<Magnum::GL::Mesh>       m_meshGl;
+    lgrn::IdRegistry<MeshGlId>  m_meshIds;
+    MeshGlStorage_t             m_meshGl;
 
     // Meshes and textures associated with new Resources (in other PR)
-    //std::unordered_map<ResId, TexIdGL>  m_resToTex;
-    //std::unordered_map<ResId, MeshIdGL> m_resToMesh;
+    //std::unordered_map<ResId, TexGlId>  m_resToTex;
+    //std::unordered_map<ResId, MeshGlId> m_resToMesh;
 
     // TEMPORARY!!!  Meshes and textures associated with Packages
-    std::unordered_map<std::string, TexIdGL>  m_oldResToTex;
-    std::unordered_map<std::string, MeshIdGL> m_oldResToMesh;
-
-    inline TexIdGL create_tex()
-    {
-        TexIdGL const texId = m_texIds.create();
-        m_texGl.resize(
-                m_texIds.capacity(), Magnum::GL::Texture2D(Corrade::NoCreate));
-        return texId;
-    }
-
-    inline Magnum::GL::Texture2D& get_tex(TexIdGL texId) noexcept
-    {
-        return m_texGl[std::size_t(texId)];
-    }
-
-    inline MeshIdGL create_mesh()
-    {
-        MeshIdGL const meshId = m_meshIds.create();
-        m_meshGl.resize(
-                m_meshIds.capacity(), Magnum::GL::Mesh(Corrade::NoCreate));
-        return meshId;
-    }
-
-    inline Magnum::GL::Mesh& get_mesh(MeshIdGL meshId) noexcept
-    {
-        return m_meshGl[std::size_t(meshId)];
-    }
+    std::unordered_map<std::string, TexGlId>  m_oldResToTex;
+    std::unordered_map<std::string, MeshGlId> m_oldResToMesh;
 };
 
 /**
@@ -104,8 +81,8 @@ struct RenderGL
  */
 struct ACtxSceneRenderGL
 {
-    acomp_storage_t<MeshIdGL>               m_meshGl;
-    acomp_storage_t<TexIdGL>                m_diffuseTexGl;
+    acomp_storage_t<MeshGlId>               m_meshId;
+    acomp_storage_t<TexGlId>                m_diffuseTexId;
     acomp_storage_t<ACompDrawTransform>     m_drawTransform;
 };
 
@@ -149,7 +126,7 @@ public:
     static void compile_meshes(
             acomp_storage_t<ACompMesh> const& meshes,
             std::vector<ActiveEnt> const& dirty,
-            acomp_storage_t<MeshIdGL>& rMeshGl,
+            acomp_storage_t<MeshGlId>& rMeshGl,
             RenderGL& rRenderGl);
 
     /**
@@ -164,7 +141,7 @@ public:
     static void compile_textures(
             acomp_storage_t<ACompTexture> const& textures,
             std::vector<ActiveEnt> const& dirty,
-            acomp_storage_t<TexIdGL>& rTexGl,
+            acomp_storage_t<TexGlId>& rTexGl,
             RenderGL& rRenderGl);
 
     /**
@@ -207,8 +184,8 @@ template<typename IT_T>
 void SysRenderGL::update_delete(
         ACtxSceneRenderGL &rCtxRenderGl, IT_T first, IT_T last)
 {
-    rCtxRenderGl.m_meshGl           .remove(first, last);
-    rCtxRenderGl.m_diffuseTexGl     .remove(first, last);
+    rCtxRenderGl.m_meshId           .remove(first, last);
+    rCtxRenderGl.m_diffuseTexId     .remove(first, last);
     rCtxRenderGl.m_drawTransform    .remove(first, last);
 }
 

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -24,40 +24,88 @@
  */
 #pragma once
 
-#include "osp/Resource/Package.h"
 #include "../SysRender.h"
+#include "../../Shaders/FullscreenTriShader.h"
 
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
 #include <Magnum/GL/Framebuffer.h>
 #include <Magnum/GL/Renderbuffer.h>
 
+#include <longeron/id_management/registry.hpp>
+
 namespace osp::active
 {
 
+enum class TexIdGL : uint32_t { };
+enum class MeshIdGL : uint32_t { };
+
 /**
- * @brief Stores a mesh to be drawn by the renderer
+ * @brief Essential GL resources
+ *
+ * This may be shared between scenes
  */
-struct ACompMeshGL
+struct RenderGL
 {
-    osp::DependRes<Magnum::GL::Mesh> m_mesh;
+    // Fullscreen Triangle
+    MeshIdGL            m_fullscreenTri;
+    FullscreenTriShader m_fullscreenTriShader;
+
+    // Offscreen Framebuffer
+    TexIdGL                     m_fboColor;
+    Magnum::GL::Renderbuffer    m_fboDepthStencil{Corrade::NoCreate};
+    Magnum::GL::Framebuffer     m_fbo{Corrade::NoCreate};
+
+    // Addressable Textures
+    lgrn::IdRegistry<TexIdGL>           m_texIds;
+    std::vector<Magnum::GL::Texture2D>  m_texGl;
+
+    // Addressable Meshes
+    lgrn::IdRegistry<MeshIdGL>          m_meshIds;
+    std::vector<Magnum::GL::Mesh>       m_meshGl;
+
+    // Meshes and textures associated with new Resources (in other PR)
+    //std::unordered_map<ResId, TexIdGL>  m_resToTex;
+    //std::unordered_map<ResId, MeshIdGL> m_resToMesh;
+
+    // TEMPORARY!!!  Meshes and textures associated with Packages
+    std::unordered_map<std::string, TexIdGL>  m_oldResToTex;
+    std::unordered_map<std::string, MeshIdGL> m_oldResToMesh;
+
+    inline TexIdGL create_tex()
+    {
+        TexIdGL const texId = m_texIds.create();
+        m_texGl.resize(
+                m_texIds.capacity(), Magnum::GL::Texture2D(Corrade::NoCreate));
+        return texId;
+    }
+
+    inline Magnum::GL::Texture2D& get_tex(TexIdGL texId) noexcept
+    {
+        return m_texGl[std::size_t(texId)];
+    }
+
+    inline MeshIdGL create_mesh()
+    {
+        MeshIdGL const meshId = m_meshIds.create();
+        m_meshGl.resize(
+                m_meshIds.capacity(), Magnum::GL::Mesh(Corrade::NoCreate));
+        return meshId;
+    }
+
+    inline Magnum::GL::Mesh& get_mesh(MeshIdGL meshId) noexcept
+    {
+        return m_meshGl[std::size_t(meshId)];
+    }
 };
 
 /**
- * @brief Diffuse texture component
+ * @brief OpenGL specific rendering components for rendering a scene
  */
-struct ACompTextureGL
+struct ACtxSceneRenderGL
 {
-    osp::DependRes<Magnum::GL::Texture2D> m_tex;
-};
-
-/**
- * @brief OpenGL specific rendering components
- */
-struct ACtxRenderGL
-{
-    acomp_storage_t<ACompMeshGL>            m_meshGl;
-    acomp_storage_t<ACompTextureGL>         m_diffuseTexGl;
+    acomp_storage_t<MeshIdGL>               m_meshGl;
+    acomp_storage_t<TexIdGL>                m_diffuseTexGl;
     acomp_storage_t<ACompDrawTransform>     m_drawTransform;
 };
 
@@ -74,9 +122,9 @@ public:
      *
      * This sets up an offscreen framebuffer and a fullscreen triangle
      *
-     * @param rGlResources [ref] Context resources Package
+     * @param rRenderGl [ref]
      */
-    static void setup_context(Package& rGlResources);
+    static void setup_context(RenderGL& rRenderGl);
 
     /**
      * @brief Display a fullscreen texture to the default framebuffer
@@ -84,8 +132,8 @@ public:
      * @param rGlResources  [ref] GL resources containing fullscreen triangle
      * @param rTex          [in] Texture to display
      */
-    static void display_texture(Package& rGlResources,
-                                Magnum::GL::Texture2D& rTex);
+    static void display_texture(
+            RenderGL& rRenderGl, Magnum::GL::Texture2D& rTex);
 
     /**
      * @brief Compile and assign GPU mesh components to entities with mesh
@@ -101,8 +149,8 @@ public:
     static void compile_meshes(
             acomp_storage_t<ACompMesh> const& meshes,
             std::vector<ActiveEnt> const& dirty,
-            acomp_storage_t<ACompMeshGL>& rMeshGl,
-            osp::Package& rGlResources);
+            acomp_storage_t<MeshIdGL>& rMeshGl,
+            RenderGL& rRenderGl);
 
     /**
      * @brief Compile and assign GPU texture components to entities with
@@ -110,14 +158,14 @@ public:
      *
      * @param textures      [in] Storage for generic texture data components
      * @param dirty         [in] Vector of entities that have updated textures
-     * @param rDiffTexGl    [ref] Storage for GL texture components
+     * @param rTexGl        [ref] Storage for GL texture components
      * @param rGlResources  [out] Package to store newly compiled textures
      */
     static void compile_textures(
             acomp_storage_t<ACompTexture> const& textures,
             std::vector<ActiveEnt> const& dirty,
-            acomp_storage_t<ACompTextureGL>& rDiffTexGl,
-            osp::Package& rGlResources);
+            acomp_storage_t<TexIdGL>& rTexGl,
+            RenderGL& rRenderGl);
 
     /**
      * @brief Call draw functions of a RenderGroup of opaque objects
@@ -152,12 +200,12 @@ public:
 
     template<typename IT_T>
     static void update_delete(
-            ACtxRenderGL &rCtxRenderGl, IT_T first, IT_T last);
+            ACtxSceneRenderGL &rCtxRenderGl, IT_T first, IT_T last);
 };
 
 template<typename IT_T>
 void SysRenderGL::update_delete(
-        ACtxRenderGL &rCtxRenderGl, IT_T first, IT_T last)
+        ACtxSceneRenderGL &rCtxRenderGl, IT_T first, IT_T last)
 {
     rCtxRenderGl.m_meshGl           .remove(first, last);
     rCtxRenderGl.m_diffuseTexGl     .remove(first, last);

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -59,9 +59,12 @@ void shader::draw_ent_flat(
                          : 0xffffffff_rgbaf);
     }
 
+    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
+
     rShader
         .setTransformationProjectionMatrix(viewProj.m_viewProj * drawTf.m_transformWorld)
-        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
+        .draw(rMesh);
 }
 
 

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -49,7 +49,7 @@ void shader::draw_ent_flat(
 
     if (rShader.flags() & Flag::Textured)
     {
-        rShader.bindTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
+        rShader.bindTexture(rData.m_pTexGl->get(rData.m_pDiffuseTexId->get(ent)));
     }
 
     if (rData.m_pColor != nullptr)
@@ -61,7 +61,7 @@ void shader::draw_ent_flat(
 
     rShader
         .setTransformationProjectionMatrix(viewProj.m_viewProj * drawTf.m_transformWorld)
-        .draw(*rData.m_pMeshGl->get(ent).m_mesh);
+        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
 }
 
 
@@ -70,7 +70,7 @@ void shader::assign_flat(
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
         acomp_storage_t<active::ACompOpaque> const& opaque,
-        acomp_storage_t<ACompTextureGL> const& diffuse,
+        acomp_storage_t<active::TexGlId> const& diffuse,
         ACtxDrawFlat &rData)
 {
 

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -44,8 +44,12 @@ struct ACtxDrawFlat
 
     active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
     active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
-    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl{nullptr};
-    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl{nullptr};
+
+    osp::active::acomp_storage_t<osp::active::TexGlId>  *m_pDiffuseTexId{nullptr};
+    osp::active::TexGlStorage_t                         *m_pTexGl{nullptr};
+
+    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
+    osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
 };
 
 void draw_ent_flat(
@@ -69,7 +73,7 @@ void assign_flat(
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
         active::acomp_storage_t<active::ACompOpaque> const& opaque,
-        active::acomp_storage_t<active::ACompTextureGL> const& diffuse,
+        active::acomp_storage_t<active::TexGlId> const& diffuse,
         ACtxDrawFlat &rData);
 
 

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -46,12 +46,11 @@ void shader::draw_ent_visualizer(
 
     auto &rData = *reinterpret_cast<ACtxDrawMeshVisualizer*>(userData[0]);
 
-    ACompMeshGL &rMesh = rData.m_pMeshGl->get(ent);
     ACompDrawTransform const& drawTf = rData.m_pDrawTf->get(ent);
 
     Matrix4 const entRelative = viewProj.m_view * drawTf.m_transformWorld;
 
-    MeshVisualizer &rShader = *rData.m_shader;
+    MeshVisualizer &rShader = rData.m_shader;
 
     if (rShader.flags() & MeshVisualizer::Flag::NormalDirection)
     {
@@ -69,7 +68,7 @@ void shader::draw_ent_visualizer(
         .setViewportSize(Vector2{Magnum::GL::defaultFramebuffer.viewport().size()})
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(viewProj.m_proj)
-        .draw(*rMesh.m_mesh);
+        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
 
     if (rData.m_wireframeOnly)
     {

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -64,11 +64,14 @@ void shader::draw_ent_visualizer(
         Magnum::GL::Renderer::setDepthMask(false);
     }
 
+    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
+
     rShader
         .setViewportSize(Vector2{Magnum::GL::defaultFramebuffer.viewport().size()})
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(viewProj.m_proj)
-        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
+        .draw(rMesh);
 
     if (rData.m_wireframeOnly)
     {

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -36,17 +36,20 @@ using MeshVisualizer = Magnum::Shaders::MeshVisualizerGL3D;
 
 struct ACtxDrawMeshVisualizer
 {
-    DependRes<MeshVisualizer> m_shader;
+    MeshVisualizer m_shader{Corrade::NoCreate};
 
-    active::acomp_storage_t< active::ACompDrawTransform >  *m_pDrawTf{nullptr};
-    active::acomp_storage_t< active::ACompMeshGL >         *m_pMeshGl{nullptr};
+    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
+    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
+    osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
 
     bool m_wireframeOnly{false};
 
-    constexpr void assign_pointers(active::ACtxRenderGL& rCtxRenderGl) noexcept
+    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
+                                   active::RenderGL& rRenderGl) noexcept
     {
-        m_pDrawTf   = &rCtxRenderGl.m_drawTransform;
-        m_pMeshGl   = &rCtxRenderGl.m_meshGl;
+        m_pDrawTf   = &rCtxScnGl.m_drawTransform;
+        m_pMeshId   = &rCtxScnGl.m_meshId;
+        m_pMeshGl   = &rRenderGl.m_meshGl;
     }
 };
 

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -57,13 +57,16 @@ void shader::draw_ent_phong(
 
     if (rShader.flags() & Flag::DiffuseTexture)
     {
-        rShader.bindDiffuseTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
+        Magnum::GL::Texture2D &rTexture = rData.m_pTexGl->get(rData.m_pDiffuseTexId->get(ent));
+        rShader.bindDiffuseTexture(rTexture);
+
+        if (rShader.flags() & (Flag::AmbientTexture | Flag::AlphaMask))
+        {
+            rShader.bindAmbientTexture(rTexture);
+        }
+
     }
 
-    if (rShader.flags() & (Flag::DiffuseTexture | Flag::AmbientTexture | Flag::AlphaMask))
-    {
-        rShader.bindAmbientTexture(*rData.m_pDiffuseTexGl->get(ent).m_tex);
-    }
 
     if (rData.m_pColor != nullptr)
     {
@@ -81,7 +84,7 @@ void shader::draw_ent_phong(
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(viewProj.m_proj)
         .setNormalMatrix(Matrix3{drawTf.m_transformWorld})
-        .draw(*rData.m_pMeshGl->get(ent).m_mesh);
+        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
 }
 
 
@@ -90,7 +93,7 @@ void shader::assign_phong(
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
         acomp_storage_t<ACompOpaque> const& opaque,
-        acomp_storage_t<ACompTextureGL> const& diffuse,
+        acomp_storage_t<active::TexGlId> const& diffuse,
         ACtxDrawPhong &rData)
 {
 
@@ -106,12 +109,12 @@ void shader::assign_phong(
             if (diffuse.contains(ent))
             {
                 pStorageOpaque->emplace(
-                        ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderDiffuse)} });
+                        ent, EntityToDraw{&draw_ent_phong, {&rData, &rData.m_shaderDiffuse} });
             }
             else
             {
                 pStorageOpaque->emplace(
-                        ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderUntextured)} });
+                        ent, EntityToDraw{&draw_ent_phong, {&rData, &rData.m_shaderUntextured} });
             }
         }
         else
@@ -125,12 +128,12 @@ void shader::assign_phong(
             if (diffuse.contains(ent))
             {
                 pStorageTransparent->emplace(
-                        ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderDiffuse)} });
+                        ent, EntityToDraw{&draw_ent_phong, {&rData, &rData.m_shaderDiffuse} });
             }
             else
             {
                 pStorageTransparent->emplace(
-                        ent, EntityToDraw{&draw_ent_phong, {&rData, &(*rData.m_shaderUntextured)} });
+                        ent, EntityToDraw{&draw_ent_phong, {&rData, &rData.m_shaderUntextured} });
             }
 
         }

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -64,9 +64,7 @@ void shader::draw_ent_phong(
         {
             rShader.bindAmbientTexture(rTexture);
         }
-
     }
-
 
     if (rData.m_pColor != nullptr)
     {
@@ -74,6 +72,9 @@ void shader::draw_ent_phong(
                                 ? rData.m_pColor->get(ent)
                                 : 0xffffffff_rgbaf);
     }
+
+    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
 
     rShader
         .setAmbientColor(0x000000ff_rgbaf)
@@ -84,7 +85,7 @@ void shader::draw_ent_phong(
         .setTransformationMatrix(entRelative)
         .setProjectionMatrix(viewProj.m_proj)
         .setNormalMatrix(Matrix3{drawTf.m_transformWorld})
-        .draw(rData.m_pMeshGl->get(rData.m_pMeshId->get(ent)));
+        .draw(rMesh);
 }
 
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -42,19 +42,29 @@ using Phong = Magnum::Shaders::PhongGL;
 struct ACtxDrawPhong
 {
 
-    DependRes<Phong> m_shaderUntextured;
-    DependRes<Phong> m_shaderDiffuse;
+    Phong m_shaderUntextured{Corrade::NoCreate};
+    Phong m_shaderDiffuse{Corrade::NoCreate};
 
     active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
     active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
-    active::acomp_storage_t<active::ACompTextureGL>     *m_pDiffuseTexGl{nullptr};
-    active::acomp_storage_t<active::ACompMeshGL>        *m_pMeshGl{nullptr};
 
-    constexpr void assign_pointers(active::ACtxRenderGL& rCtxRenderGl) noexcept
+    osp::active::acomp_storage_t<osp::active::TexGlId>  *m_pDiffuseTexId{nullptr};
+    osp::active::TexGlStorage_t                         *m_pTexGl{nullptr};
+
+    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
+    osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
+
+    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
+                                   active::RenderGL& rRenderGl) noexcept
     {
-        m_pDrawTf       = &rCtxRenderGl.m_drawTransform;
-        m_pDiffuseTexGl = &rCtxRenderGl.m_diffuseTexGl;
-        m_pMeshGl       = &rCtxRenderGl.m_meshGl;
+        m_pDrawTf       = &rCtxScnGl.m_drawTransform;
+        // TODO: ACompColor
+
+        m_pDiffuseTexId = &rCtxScnGl.m_diffuseTexId;
+        m_pTexGl        = &rRenderGl.m_texGl;
+
+        m_pMeshId       = &rCtxScnGl.m_meshId;
+        m_pMeshGl       = &rRenderGl.m_meshGl;
     }
 };
 
@@ -70,8 +80,8 @@ void draw_ent_phong(
  * @param entities              [in] Entities to consider
  * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
  * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
- * @param opaque            [in] Storage for opaque component
- * @param diffuse           [in] Storage for diffuse texture component
+ * @param opaque                [in] Storage for opaque component
+ * @param diffuse               [in] Storage for diffuse texture component
  * @param rData                 [in] Phong shader data, stable memory required
  */
 void assign_phong(
@@ -79,7 +89,7 @@ void assign_phong(
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
         active::acomp_storage_t<active::ACompOpaque> const& opaque,
-        active::acomp_storage_t<active::ACompTextureGL> const& diffuse,
+        active::acomp_storage_t<active::TexGlId> const& diffuse,
         ACtxDrawPhong &rData);
 
 

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -28,7 +28,8 @@
 
 #include <osp/types.h>
 #include <osp/UserInputHandler.h>
-#include <osp/Resource/Package.h>
+
+#include <osp/Active/opengl/SysRenderGL.h>
 
 #include <Magnum/Timeline.h>
 
@@ -74,9 +75,9 @@ public:
         return m_userInput;
     }
 
-    constexpr osp::Package& get_gl_resources() noexcept
+    constexpr osp::active::RenderGL& get_renderer() noexcept
     {
-        return m_glResources;
+        return m_renderer;
     }
 
 private:
@@ -89,7 +90,8 @@ private:
 
     Magnum::Timeline m_timeline;
 
-    osp::Package m_glResources;
+    osp::active::RenderGL m_renderer;
+
 };
 
 void config_controls(ActiveApplication& rApp);

--- a/src/test_application/ActiveApplication.h
+++ b/src/test_application/ActiveApplication.h
@@ -75,9 +75,9 @@ public:
         return m_userInput;
     }
 
-    constexpr osp::active::RenderGL& get_renderer() noexcept
+    constexpr osp::active::RenderGL& get_render_gl() noexcept
     {
-        return m_renderer;
+        return m_renderGl;
     }
 
 private:
@@ -90,7 +90,7 @@ private:
 
     Magnum::Timeline m_timeline;
 
-    osp::active::RenderGL m_renderer;
+    osp::active::RenderGL m_renderGl;
 
 };
 

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -76,14 +76,6 @@ struct EngineTestScene;
 entt::any setup_scene(osp::Package &rPkg);
 
 /**
- * @brief Load required textures and shaders used to render the engine test
- *        scene
- *
- * @param rApp [ref] Existing ActiveApplication used to store GL resources
- */
-void load_gl_resources(ActiveApplication& rApp);
-
-/**
  * @brief Generate ActiveApplication draw function
  *
  * This draw function stores renderer data, and is responsible for updating
@@ -113,14 +105,6 @@ struct PhysicsTestScene;
  * @return entt::any containing scene data
  */
 entt::any setup_scene(osp::Package &rPkg);
-
-/**
- * @brief Load required textures and shaders used to render the physics test
- *        scene
- *
- * @param rApp [ref] Existing ActiveApplication used to store GL resources
- */
-void load_gl_resources(ActiveApplication& rApp);
 
 /**
  * @brief Generate ActiveApplication draw function

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -36,7 +36,6 @@
 #include <osp/Active/opengl/SysRenderGL.h>
 
 #include <osp/Shaders/Phong.h>
-#include <osp/Shaders/MeshVisualizer.h>
 
 #include <osp/Resource/Package.h>
 
@@ -199,8 +198,6 @@ void render_test_scene(
     using Magnum::GL::FramebufferClear;
     using Magnum::GL::Texture2D;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
     // Assign Phong shader to entities with the gc_mat_common material, and put
     // results into the fwd_opaque render group
     RenderGroup &rGroupFwdOpaque
@@ -208,7 +205,7 @@ void render_test_scene(
     MaterialData const &rMatCommon = rScene.m_drawing.m_materials[gc_mat_common];
     assign_phong(
             rMatCommon.m_added, &rGroupFwdOpaque.m_entities, nullptr,
-            rScene.m_drawing.m_opaque, rRenderer.m_renderGl.m_diffuseTexGl,
+            rScene.m_drawing.m_opaque, rRenderer.m_renderGl.m_diffuseTexId,
             rRenderer.m_phong);
     SysRender::assure_draw_transforms(
                 rScene.m_basic.m_hierarchy,
@@ -219,12 +216,12 @@ void render_test_scene(
     // Load any required meshes
     SysRenderGL::compile_meshes(
             rScene.m_drawing.m_mesh, rScene.m_drawing.m_meshDirty,
-            rRenderer.m_renderGl.m_meshGl, rApp.get_gl_resources());
+            rRenderer.m_renderGl.m_meshId, rApp.get_render_gl());
 
     // Load any required textures
     SysRenderGL::compile_textures(
             rScene.m_drawing.m_diffuseTex, rScene.m_drawing.m_diffuseDirty,
-            rRenderer.m_renderGl.m_diffuseTexGl, rApp.get_gl_resources());
+            rRenderer.m_renderGl.m_diffuseTexId, rApp.get_render_gl());
 
     // Calculate hierarchy transforms
     SysRender::update_draw_transforms(
@@ -241,7 +238,7 @@ void render_test_scene(
             rCamera.calculate_projection()};
 
     // Bind offscreen FBO
-    Framebuffer &rFbo = *rGlResources.get<Framebuffer>("offscreen_fbo");
+    Framebuffer &rFbo = rApp.get_render_gl().m_fbo;
     rFbo.bind();
 
     // Clear it
@@ -254,28 +251,13 @@ void render_test_scene(
             rScene.m_drawing.m_visible, viewProj);
 
     // Display FBO
-    Texture2D &rFboColor = *rGlResources.get<Texture2D>("offscreen_fbo_color");
-    SysRenderGL::display_texture(rGlResources, rFboColor);
+    Texture2D &rFboColor = rApp.get_render_gl().m_texGl.get(rApp.get_render_gl().m_fboColor);
+    SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
 void load_gl_resources(ActiveApplication& rApp)
 {
-    using osp::shader::Phong;
-    using osp::shader::MeshVisualizer;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
-    // Create Phong shaders
-    auto texturedFlags = Phong::Flag::DiffuseTexture
-                       | Phong::Flag::AlphaMask
-                       | Phong::Flag::AmbientTexture;
-    rGlResources.add<Phong>("textured", Phong{texturedFlags, 2});
-    rGlResources.add<Phong>("notexture", Phong{{}, 2});
-
-    rGlResources.add<MeshVisualizer>(
-            "mesh_vis_shader",
-            MeshVisualizer{ MeshVisualizer::Flag::Wireframe
-                            | MeshVisualizer::Flag::NormalDirection});
 }
 
 on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp)
@@ -283,22 +265,19 @@ on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp)
     using namespace osp::active;
     using namespace osp::shader;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
     // Create renderer data. This uses a shared_ptr to allow being stored
     // inside an std::function, which require copyable types
     std::shared_ptr<EngineTestRenderer> pRenderer
             = std::make_shared<EngineTestRenderer>(rApp);
 
-    // Get or reserve shader resources. These are loaded in load_gl_resources,
-    // which can be called before or after this function
-    pRenderer->m_phong.m_shaderUntextured
-            = rGlResources.get_or_reserve<Phong>("notexture");
-    pRenderer->m_phong.m_shaderDiffuse
-            = rGlResources.get_or_reserve<Phong>("textured");
-
-    // Set component storage pointers, so that they can be accessed by shaders
-    pRenderer->m_phong.assign_pointers(pRenderer->m_renderGl);
+    // Create Phong shaders
+    auto const texturedFlags
+            = Phong::Flag::DiffuseTexture | Phong::Flag::AlphaMask
+            | Phong::Flag::AmbientTexture;
+    pRenderer->m_phong.m_shaderDiffuse      = Phong{texturedFlags, 2};
+    pRenderer->m_phong.m_shaderUntextured   = Phong{{}, 2};
+    pRenderer->m_phong.assign_pointers(
+            pRenderer->m_renderGl, rApp.get_render_gl());
 
     // Select first camera for rendering
     ActiveEnt const camEnt = rScene.m_basic.m_camera.at(0);

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -255,11 +255,6 @@ void render_test_scene(
     SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
-void load_gl_resources(ActiveApplication& rApp)
-{
-
-}
-
 on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp)
 {
     using namespace osp::active;

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -174,7 +174,7 @@ struct EngineTestRenderer
 
     osp::active::ACtxRenderGroups m_renderGroups{};
 
-    osp::active::ACtxRenderGL m_renderGl{};
+    osp::active::ACtxSceneRenderGL m_renderGl{};
 
     osp::active::ActiveEnt m_camera;
     ACtxCameraController m_camCtrl;

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -589,14 +589,6 @@ void render_test_scene(
     SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
-void load_gl_resources(ActiveApplication& rApp)
-{
-    using osp::shader::Phong;
-    using osp::shader::MeshVisualizer;
-
-
-}
-
 on_draw_t generate_draw_func(PhysicsTestScene& rScene, ActiveApplication& rApp)
 {
     using namespace osp::active;

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -514,8 +514,6 @@ void render_test_scene(
     using Magnum::GL::FramebufferClear;
     using Magnum::GL::Texture2D;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
     RenderGroup &rGroupFwdOpaque
             = rRenderer.m_renderGroups.m_groups["fwd_opaque"];
 
@@ -525,7 +523,7 @@ void render_test_scene(
         MaterialData const &rMatCommon = rScene.m_drawing.m_materials[gc_mat_common];
         assign_phong(
                 rMatCommon.m_added, &rGroupFwdOpaque.m_entities, nullptr,
-                rScene.m_drawing.m_opaque, rRenderer.m_renderGl.m_diffuseTexGl,
+                rScene.m_drawing.m_opaque, rRenderer.m_renderGl.m_diffuseTexId,
                 rRenderer.m_phong);
         SysRender::assure_draw_transforms(
                     rScene.m_basic.m_hierarchy,
@@ -552,12 +550,12 @@ void render_test_scene(
     // Load any required meshes
     SysRenderGL::compile_meshes(
             rScene.m_drawing.m_mesh, rScene.m_drawing.m_meshDirty,
-            rRenderer.m_renderGl.m_meshGl, rApp.get_gl_resources());
+            rRenderer.m_renderGl.m_meshId, rApp.get_render_gl());
 
     // Load any required textures
     SysRenderGL::compile_textures(
             rScene.m_drawing.m_diffuseTex, rScene.m_drawing.m_diffuseDirty,
-            rRenderer.m_renderGl.m_diffuseTexGl, rApp.get_gl_resources());
+            rRenderer.m_renderGl.m_diffuseTexId, rApp.get_render_gl());
 
     // Calculate hierarchy transforms
     SysRender::update_draw_transforms(
@@ -574,7 +572,7 @@ void render_test_scene(
             rCamera.calculate_projection()};
 
     // Bind offscreen FBO
-    Framebuffer &rFbo = *rGlResources.get<Framebuffer>("offscreen_fbo");
+    Framebuffer &rFbo = rApp.get_render_gl().m_fbo;
     rFbo.bind();
 
     // Clear it
@@ -587,8 +585,8 @@ void render_test_scene(
             rScene.m_drawing.m_visible, viewProj);
 
     // Display FBO
-    Texture2D &rFboColor = *rGlResources.get<Texture2D>("offscreen_fbo_color");
-    SysRenderGL::display_texture(rGlResources, rFboColor);
+    Texture2D &rFboColor = rApp.get_render_gl().m_texGl.get(rApp.get_render_gl().m_fboColor);
+    SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
 void load_gl_resources(ActiveApplication& rApp)
@@ -596,19 +594,6 @@ void load_gl_resources(ActiveApplication& rApp)
     using osp::shader::Phong;
     using osp::shader::MeshVisualizer;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
-    // Create Phong shaders
-    auto texturedFlags = Phong::Flag::DiffuseTexture
-                       | Phong::Flag::AlphaMask
-                       | Phong::Flag::AmbientTexture;
-    rGlResources.add<Phong>("textured", Phong{texturedFlags, 2});
-    rGlResources.add<Phong>("notexture", Phong{{}, 2});
-
-    // Create MeshVisualizer shader
-    rGlResources.add<MeshVisualizer>(
-            "mesh_vis_shader",
-            MeshVisualizer{ MeshVisualizer::Flag::Wireframe });
 
 }
 
@@ -617,25 +602,25 @@ on_draw_t generate_draw_func(PhysicsTestScene& rScene, ActiveApplication& rApp)
     using namespace osp::active;
     using namespace osp::shader;
 
-    osp::Package &rGlResources = rApp.get_gl_resources();
-
     // Create renderer data. This uses a shared_ptr to allow being stored
     // inside an std::function, which require copyable types
     std::shared_ptr<PhysicsTestRenderer> pRenderer
             = std::make_shared<PhysicsTestRenderer>(rApp);
 
-    // Get or reserve shader resources. These are loaded in load_gl_resources,
-    // which can be called before or after this function
-    pRenderer->m_phong.m_shaderUntextured
-            = rGlResources.get_or_reserve<Phong>("notexture");
-    pRenderer->m_phong.m_shaderDiffuse
-            = rGlResources.get_or_reserve<Phong>("textured");
-    pRenderer->m_visualizer.m_shader
-            = rGlResources.get_or_reserve<MeshVisualizer>("mesh_vis_shader");
+    // Setup Phong shaders
+    auto const texturedFlags
+            = Phong::Flag::DiffuseTexture | Phong::Flag::AlphaMask
+            | Phong::Flag::AmbientTexture;
+    pRenderer->m_phong.m_shaderDiffuse      = Phong{texturedFlags, 2};
+    pRenderer->m_phong.m_shaderUntextured   = Phong{{}, 2};
+    pRenderer->m_phong.assign_pointers(
+            pRenderer->m_renderGl, rApp.get_render_gl());
 
-    // Set component storage pointers, so that they can be accessed by shaders
-    pRenderer->m_phong.assign_pointers(pRenderer->m_renderGl);
-    pRenderer->m_visualizer.assign_pointers(pRenderer->m_renderGl);
+    // Setup Mesh Visualizer shader
+    pRenderer->m_visualizer.m_shader
+            = MeshVisualizer{ MeshVisualizer::Flag::Wireframe };
+    pRenderer->m_visualizer.assign_pointers(
+            pRenderer->m_renderGl, rApp.get_render_gl());
 
     // Select first camera for rendering
     ActiveEnt const camEnt = rScene.m_basic.m_camera.at(0);

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -485,7 +485,7 @@ struct PhysicsTestRenderer
 
     osp::active::ACtxRenderGroups m_renderGroups;
 
-    osp::active::ACtxRenderGL m_renderGl;
+    osp::active::ACtxSceneRenderGL m_renderGl;
 
     osp::active::ActiveEnt m_camera;
     ACtxCameraController m_camCtrl;

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -129,7 +129,6 @@ std::unordered_map<std::string_view, Option> const g_scenes
             EngineTestScene& rScene
                     = entt::any_cast<EngineTestScene&>(g_activeScene);
             rApp.set_on_draw(generate_draw_func(rScene, rApp));
-            load_gl_resources(*g_activeApplication);
         };
     }}},
     {"physicstest", {"Physics lol", [] {
@@ -142,7 +141,6 @@ std::unordered_map<std::string_view, Option> const g_scenes
             PhysicsTestScene& rScene
                     = entt::any_cast<PhysicsTestScene&>(g_activeScene);
             rApp.set_on_draw(generate_draw_func(rScene, rApp));
-            load_gl_resources(*g_activeApplication);
         };
     }}}
 };

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -290,9 +290,6 @@ void start_magnum_async()
         // Configure the controls
         config_controls(*g_activeApplication);
 
-        osp::active::SysRenderGL::setup_context(
-                    g_activeApplication->get_gl_resources());
-
         g_appSetup(*g_activeApplication);
 
         // Starts the main loop. This function is blocking, and will only return

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -290,6 +290,10 @@ void start_magnum_async()
         // Configure the controls
         config_controls(*g_activeApplication);
 
+        // Setup GL resources
+        osp::active::SysRenderGL::setup_context(g_activeApplication->get_render_gl());
+
+        // Setup scene-specific renderer
         g_appSetup(*g_activeApplication);
 
         // Starts the main loop. This function is blocking, and will only return


### PR DESCRIPTION
Depends on #171 

Most of the action happens in `src/osp/Active/opengl/SysRenderGL.h`.

The GL Resources Package was simply an osp::Package stored in ActiveApplication that stores instances of meshes, texture, and shaders on the renderer-side. Its reliance on string names and general inflexibility makes it hard to manage and is currently misused in a few places. This is now removed.

The new RenderGL struct is more specialized and serves a similar purpose, also stored in ActiveApplication. It's responsible for storing essential rendering resources that are accessible across multiple scenes. Renderer-side meshes and textures are each assigned integer IDs: MeshGlId and TexGlId. This makes them addressable regardless of their source, either from a framebuffer or loaded from a resource.

This is of course part of a gradual phase-out of the Package class. The old mesh and texture components are still used (ACompMesh and ACompTexture) which rely on Package resources. The string names of the resources are temporarily mapped to the new mesh and texture Ids, noting m_oldResToTex and m_oldResToMesh. 