### PR TITLE
Switch to new resource system

### DIFF
--- a/src/osp/Active/SysRender.cpp
+++ b/src/osp/Active/SysRender.cpp
@@ -56,7 +56,7 @@ void SysRender::clear_owners(ACtxDrawing& rCtxDrawing)
     }
 }
 
-void SysRender::clear_resource_owners(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& rCtxDrawingRes, Resources &rResources)
+void SysRender::clear_resource_owners(ACtxDrawingRes& rCtxDrawingRes, Resources &rResources)
 {
     for (auto & [_, rOwner] : std::exchange(rCtxDrawingRes.m_texToRes, {}))
     {

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -26,6 +26,8 @@
 
 #include "drawing.h"
 
+#include <unordered_map>
+
 namespace osp::active
 {
 

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -119,11 +119,38 @@ class SysRender
 {
 public:
 
-    static MeshId own_mesh_resource(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& rCtxDrawingRes, Resources &rResources, ResId resId);
+    /**
+     * @brief Attempt to create a scene mesh associated with a resource
+     *
+     * @param rCtxDrawing       [ref] Drawing data
+     * @param rCtxDrawingRes    [ref] Resource drawing data
+     * @param rResources        [ref] Application Resources containing meshes
+     * @param resId             [in] Mesh Resource Id
+     *
+     * @return Id of new mesh, existing mesh Id if it already exists.
+     */
+    static MeshId own_mesh_resource(
+            ACtxDrawing& rCtxDrawing,
+            ACtxDrawingRes& rCtxDrawingRes,
+            Resources &rResources,
+            ResId resId);
 
+    /**
+     * @brief Remove all mesh and texture components, aware of refcounts
+     *
+     * @param rCtxDrawing       [ref] Drawing data
+     */
     static void clear_owners(ACtxDrawing& rCtxDrawing);
 
-    static void clear_resource_owners(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& rCtxDrawingRes, Resources &rResources);
+    /**
+     * @brief Dissociate resources from the scene's meshes and textures
+     *
+     * @param rCtxDrawingRes    [ref] Resource drawing data
+     * @param rResources        [ref] Application Resources
+     */
+    static void clear_resource_owners(
+            ACtxDrawingRes& rCtxDrawingRes,
+            Resources &rResources);
 
     inline static void add_draw_transforms_recurse(
             acomp_storage_t<ACompHierarchy> const& hier,

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -119,6 +119,12 @@ class SysRender
 {
 public:
 
+    static MeshId own_mesh_resource(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& rCtxDrawingRes, Resources &rResources, ResId resId);
+
+    static void clear_owners(ACtxDrawing& rCtxDrawing);
+
+    static void clear_resource_owners(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& rCtxDrawingRes, Resources &rResources);
+
     inline static void add_draw_transforms_recurse(
             acomp_storage_t<ACompHierarchy> const& hier,
             acomp_storage_t<ACompDrawTransform>& rDrawTf,

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -134,7 +134,7 @@ public:
     static MeshId own_mesh_resource(
             ACtxDrawing& rCtxDrawing,
             ACtxDrawingRes& rCtxDrawingRes,
-            Resources &rResources,
+            Resources& rResources,
             ResId resId);
 
     /**
@@ -152,7 +152,7 @@ public:
      */
     static void clear_resource_owners(
             ACtxDrawingRes& rCtxDrawingRes,
-            Resources &rResources);
+            Resources& rResources);
 
     inline static void add_draw_transforms_recurse(
             acomp_storage_t<ACompHierarchy> const& hier,
@@ -191,11 +191,11 @@ public:
 
     template<typename IT_T>
     static void update_delete_drawing(
-            ACtxDrawing &rCtxDraw, IT_T first, IT_T last);
+            ACtxDrawing& rCtxDraw, IT_T first, IT_T last);
 
     template<typename IT_T>
     static void update_delete_groups(
-            ACtxRenderGroups &rCtxGroups, IT_T first, IT_T last);
+            ACtxRenderGroups& rCtxGroups, IT_T first, IT_T last);
 
 private:
 
@@ -254,7 +254,7 @@ void remove_refcounted(
 
 template<typename IT_T>
 void SysRender::update_delete_drawing(
-        ACtxDrawing &rCtxDraw, IT_T first, IT_T last)
+        ACtxDrawing& rCtxDraw, IT_T first, IT_T last)
 {
     while (first != last)
     {
@@ -278,7 +278,7 @@ void SysRender::update_delete_drawing(
 
 template<typename IT_T>
 void SysRender::update_delete_groups(
-        ACtxRenderGroups &rCtxGroups, IT_T first, IT_T last)
+        ACtxRenderGroups& rCtxGroups, IT_T first, IT_T last)
 {
     if (first == last)
     {

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -37,9 +37,6 @@
 #include <longeron/id_management/registry.hpp>
 #include <longeron/id_management/refcount.hpp>
 
-#include <functional>
-#include <unordered_map>
-
 namespace osp::active
 {
 
@@ -91,11 +88,18 @@ struct MaterialData
     std::vector<ActiveEnt>  m_removed;
 };
 
+using MeshRefCount_t    = lgrn::IdRefCount<MeshId>;
+using MeshIdOwner_t     = MeshRefCount_t::Storage_t;
+
+using TexRefCount_t     = lgrn::IdRefCount<TexId>;
+using TexIdOwner_t      = TexRefCount_t::Storage_t;
+
 /**
  * @brief Mesh Ids, texture Ids, and storage for drawing-related components
  */
 struct ACtxDrawing
 {
+
     // Drawing Components
     acomp_storage_t<ACompOpaque>            m_opaque;
     acomp_storage_t<ACompTransparent>       m_transparent;
@@ -108,17 +112,17 @@ struct ACtxDrawing
 
     // Scene-space Meshes
     lgrn::IdRegistry<MeshId>                m_meshIds;
-    lgrn::IdRefCount<MeshId>                m_meshRefCounts;
+    MeshRefCount_t                          m_meshRefCounts;
 
     // Scene-space Textures
     lgrn::IdRegistry<TexId>                 m_texIds;
-    lgrn::IdRefCount<TexId>                 m_texRefCounts;
+    TexRefCount_t                           m_texRefCounts;
 
     // Meshes and textures assigned to ActiveEnts
-    acomp_storage_t<TexId>                  m_diffuseTex;
+    acomp_storage_t<TexIdOwner_t>           m_diffuseTex;
     std::vector<osp::active::ActiveEnt>     m_diffuseDirty;
 
-    acomp_storage_t<MeshId>                 m_mesh;
+    acomp_storage_t<MeshIdOwner_t>          m_mesh;
     std::vector<osp::active::ActiveEnt>     m_meshDirty;
 };
 

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -96,13 +96,16 @@ struct ACompMeshGl
     MeshGlId    m_glId      {lgrn::id_null<MeshGlId>()};
 };
 
+using ACompMeshGlStorage_t = acomp_storage_t<ACompMeshGl>;
+using ACompTexGlStorage_t = acomp_storage_t<ACompTexGl>;
+
 /**
  * @brief OpenGL specific rendering components for rendering a scene
  */
 struct ACtxSceneRenderGL
 {
-    acomp_storage_t<ACompMeshGl>            m_meshId;
-    acomp_storage_t<ACompTexGl>             m_diffuseTexId;
+    ACompMeshGlStorage_t                    m_meshId;
+    ACompTexGlStorage_t                     m_diffuseTexId;
     acomp_storage_t<ACompDrawTransform>     m_drawTransform;
 };
 
@@ -132,6 +135,8 @@ public:
     static void display_texture(
             RenderGL& rRenderGl, Magnum::GL::Texture2D& rTex);
 
+    static void clear_resource_owners(RenderGL& rRenderGl, Resources& rResources);
+
     /**
      * @brief Compile required meshes and textures resources used by a scene
      *
@@ -155,7 +160,7 @@ public:
      * @param rRenderGl     [ref] Renderer state
      */
     static void assign_meshes(
-            acomp_storage_t<MeshId> const& cmpMeshIds,
+            acomp_storage_t<MeshIdOwner_t> const& cmpMeshIds,
             IdMap_t<MeshId, ResIdOwner_t> const& meshToRes,
             std::vector<ActiveEnt> const& entsDirty,
             acomp_storage_t<ACompMeshGl>& rCmpMeshGl,
@@ -171,7 +176,7 @@ public:
      * @param rRenderGl     [ref] Renderer state
      */
     static void assign_textures(
-            acomp_storage_t<TexId> const& cmpTexIds,
+            acomp_storage_t<TexIdOwner_t> const& cmpTexIds,
             IdMap_t<TexId, ResIdOwner_t> const& texToRes,
             std::vector<ActiveEnt> const& entsDirty,
             acomp_storage_t<ACompTexGl>& rCmpTexGl,

--- a/src/osp/Resource/resources.cpp
+++ b/src/osp/Resource/resources.cpp
@@ -40,7 +40,7 @@ ResId Resources::create(ResTypeId typeId, PkgId pkgId, std::string_view name)
     PerPkg &rPkg = m_pkgData[std::size_t(pkgId)];
     assert(rPkg.m_resTypeOwn.size() > std::size_t(typeId));
     PerPkgResType &rPkgType = rPkg.m_resTypeOwn[std::size_t(typeId)];
-    rPkgType.m_owned.resize(m_perResType.size());
+    rPkgType.m_owned.resize(rPerResType.m_resIds.capacity());
     rPkgType.m_owned.set(std::size_t(newResId));
 
     // Track name

--- a/src/osp/Resource/resources.cpp
+++ b/src/osp/Resource/resources.cpp
@@ -71,24 +71,25 @@ ResId Resources::find(ResTypeId typeId, PkgId pkgId, std::string_view name) cons
     return findIt->second;
 }
 
-void Resources::store(ResTypeId typeId, ResId resId, ResIdStorage_t &rStorage) noexcept
+ResIdOwner_t Resources::owner_create(ResTypeId typeId, ResId resId) noexcept
 {
-    assert(!rStorage.has_value());
     PerResType &rPerResType = get_type(typeId);
     rPerResType.m_resRefs[std::size_t(resId)] ++;
-    rStorage.m_id = resId;
+    ResIdOwner_t owner;
+    owner.m_id = resId;
+    return owner;
 }
 
-void Resources::release(ResTypeId typeId, ResIdStorage_t &rStorage) noexcept
+void Resources::owner_destroy(ResTypeId typeId, ResIdOwner_t&& rOwner) noexcept
 {
-    if (!rStorage.has_value())
+    if (!rOwner.has_value())
     {
         return;
     }
     PerResType &rPerResType = get_type(typeId);
-    int &rCount = rPerResType.m_resRefs[std::size_t(rStorage.m_id)];
+    int &rCount = rPerResType.m_resRefs[std::size_t(rOwner.m_id)];
     rCount --;
-    rStorage.m_id = lgrn::id_null<ResId>();
+    rOwner.m_id = ResIdOwner_t{};
 }
 
 PkgId Resources::pkg_create()

--- a/src/osp/Resource/resources.h
+++ b/src/osp/Resource/resources.h
@@ -219,7 +219,7 @@ T& Resources::data_add(ResTypeId typeId, ResId resId, ARGS_T&& ... args)
     PerResType &rPerResType = get_type(typeId);
 
     // Ensure resource ID exists
-    assert(rPerResType.m_resIds.capacity() > std::size_t(typeId));
+    assert(rPerResType.m_resIds.capacity() > std::size_t(resId));
     assert(rPerResType.m_resIds.exists(resId));
 
     res_container_t<T> &rContainer = get_container<T>(rPerResType, typeId);

--- a/src/osp/Resource/resources.h
+++ b/src/osp/Resource/resources.h
@@ -97,9 +97,9 @@ public:
 
     ResId find(ResTypeId typeId, PkgId pkgId, std::string_view name) const noexcept;
 
-    void store(ResTypeId typeId, ResId resId, ResIdStorage_t &rStorage) noexcept;
+    [[nodiscard]] ResIdOwner_t owner_create(ResTypeId typeId, ResId resId) noexcept;
 
-    void release(ResTypeId typeId, ResIdStorage_t &rStorage) noexcept;
+    void owner_destroy(ResTypeId typeId, ResIdOwner_t&& rOwner) noexcept;
 
     /**
      * @brief Register a datatype to a resource Id

--- a/src/osp/Resource/resourcetypes.h
+++ b/src/osp/Resource/resourcetypes.h
@@ -26,6 +26,7 @@
 
 #include <longeron/id_management/storage.hpp>
 
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -93,19 +94,40 @@ struct res_container
 template <typename T>
 using res_container_t = typename res_container<T>::type;
 
+// Resource Owner
+
 class Resources;
 
-using ResIdStorage_t = lgrn::IdStorage<ResId, Resources>;
+using ResIdOwner_t = lgrn::IdStorage<ResId, Resources>;
+
+
+// Resource Type Ids
+
+struct GenResTypeId
+{
+    friend inline ResTypeId resource_type_next() noexcept;
+    friend inline int resource_type_count() noexcept;
+private:
+    static inline int count{0};
+};
+
+inline ResTypeId resource_type_next() noexcept
+{
+    return ResTypeId(GenResTypeId::count++);
+}
+
+inline int resource_type_count() noexcept
+{
+    return GenResTypeId::count;
+}
 
 namespace restypes
 {
 
-constexpr inline ResTypeId const gc_image       = ResTypeId(0);
-constexpr inline ResTypeId const gc_texture     = ResTypeId(1);
-constexpr inline ResTypeId const gc_mesh        = ResTypeId(2);
+inline ResTypeId const gc_image         = resource_type_next();
+inline ResTypeId const gc_texture       = resource_type_next();
+inline ResTypeId const gc_mesh          = resource_type_next();
 
 } // namespace restypes
-
-constexpr inline std::size_t const gc_resTypeCount = 3;
 
 } // namespace osp

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -49,7 +49,8 @@ void shader::draw_ent_flat(
 
     if (rShader.flags() & Flag::Textured)
     {
-        rShader.bindTexture(rData.m_pTexGl->get(rData.m_pDiffuseTexId->get(ent)));
+        TexGlId const texGlId = rData.m_pDiffuseTexId->get(ent).m_glId;
+        rShader.bindTexture(rData.m_pTexGl->get(texGlId));
     }
 
     if (rData.m_pColor != nullptr)
@@ -59,7 +60,7 @@ void shader::draw_ent_flat(
                          : 0xffffffff_rgbaf);
     }
 
-    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    MeshGlId const meshId = rData.m_pMeshId->get(ent).m_glId;
     Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
 
     rShader
@@ -73,7 +74,7 @@ void shader::assign_flat(
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
         acomp_storage_t<active::ACompOpaque> const& opaque,
-        acomp_storage_t<active::TexGlId> const& diffuse,
+        acomp_storage_t<active::ACompTexGl> const& diffuse,
         ACtxDrawFlat &rData)
 {
 
@@ -89,12 +90,12 @@ void shader::assign_flat(
             if (diffuse.contains(ent))
             {
                 pStorageOpaque->emplace(
-                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &rData.m_shaderDiffuse} });
             }
             else
             {
                 pStorageOpaque->emplace(
-                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderUntextured)} });
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &rData.m_shaderUntextured} });
             }
         }
         else
@@ -108,12 +109,12 @@ void shader::assign_flat(
             if (diffuse.contains(ent))
             {
                 pStorageTransparent->emplace(
-                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderDiffuse)} });
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &rData.m_shaderDiffuse} });
             }
             else
             {
                 pStorageTransparent->emplace(
-                        ent, EntityToDraw{&draw_ent_flat, {&rData, &(*rData.m_shaderUntextured)} });
+                        ent, EntityToDraw{&draw_ent_flat, {&rData, &rData.m_shaderUntextured} });
             }
 
         }

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -24,10 +24,6 @@
  */
 #include "Flat.h"
 
-#include <osp/Active/SysRender.h>
-
-#include <Magnum/Math/Color.h>
-
 // for the 0xrrggbb_rgbf and angle literals
 using namespace Magnum::Math::Literals;
 

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -26,7 +26,6 @@
 
 
 #include <osp/Active/opengl/SysRenderGL.h>
-#include <osp/Resource/Resource.h>
 
 #include <Magnum/Shaders/FlatGL.h>
 
@@ -38,18 +37,31 @@ using Flat = Magnum::Shaders::FlatGL3D;
 
 struct ACtxDrawFlat
 {
+    template <typename T>
+    using acomp_storage_t = osp::active::acomp_storage_t<T>;
 
-    DependRes<Flat> m_shaderUntextured;
-    DependRes<Flat> m_shaderDiffuse;
+    Flat m_shaderUntextured     {Corrade::NoCreate};
+    Flat m_shaderDiffuse        {Corrade::NoCreate};
 
-    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
-    active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
+    acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    osp::active::ACompTexGlStorage_t            *m_pDiffuseTexId{nullptr};
+    osp::active::ACompMeshGlStorage_t           *m_pMeshId{nullptr};
 
-    osp::active::acomp_storage_t<osp::active::TexGlId>  *m_pDiffuseTexId{nullptr};
-    osp::active::TexGlStorage_t                         *m_pTexGl{nullptr};
+    osp::active::TexGlStorage_t                 *m_pTexGl{nullptr};
+    osp::active::MeshGlStorage_t                *m_pMeshGl{nullptr};
 
-    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
-    osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
+    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
+                                   active::RenderGL& rRenderGl) noexcept
+    {
+        m_pDrawTf       = &rCtxScnGl.m_drawTransform;
+        // TODO: ACompColor
+        m_pDiffuseTexId = &rCtxScnGl.m_diffuseTexId;
+        m_pMeshId       = &rCtxScnGl.m_meshId;
+
+        m_pTexGl        = &rRenderGl.m_texGl;
+        m_pMeshGl       = &rRenderGl.m_meshGl;
+    }
 };
 
 void draw_ent_flat(
@@ -73,7 +85,7 @@ void assign_flat(
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
         active::acomp_storage_t<active::ACompOpaque> const& opaque,
-        active::acomp_storage_t<active::TexGlId> const& diffuse,
+        active::acomp_storage_t<active::ACompTexGl> const& diffuse,
         ACtxDrawFlat &rData);
 
 

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -64,7 +64,7 @@ void shader::draw_ent_visualizer(
         Magnum::GL::Renderer::setDepthMask(false);
     }
 
-    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    MeshGlId const meshId = rData.m_pMeshId->get(ent).m_glId;
     Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
 
     rShader

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -25,11 +25,8 @@
 
 #include "MeshVisualizer.h"
 
-#include "../Active/SysRender.h"
-
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Renderer.h>
-#include <Magnum/Math/Color.h>
 
 // for the 0xrrggbb_rgbf and _deg literals
 using namespace Magnum::Math::Literals;

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -39,7 +39,7 @@ struct ACtxDrawMeshVisualizer
     MeshVisualizer m_shader{Corrade::NoCreate};
 
     active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
-    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
+    osp::active::ACompMeshGlStorage_t                   *m_pMeshId{nullptr};
     osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
 
     bool m_wireframeOnly{false};

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <osp/Active/opengl/SysRenderGL.h>
-#include <osp/Active/activetypes.h>
 
 #include <Magnum/Shaders/MeshVisualizerGL.h>
 

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -57,7 +57,8 @@ void shader::draw_ent_phong(
 
     if (rShader.flags() & Flag::DiffuseTexture)
     {
-        Magnum::GL::Texture2D &rTexture = rData.m_pTexGl->get(rData.m_pDiffuseTexId->get(ent));
+        TexGlId const texGlId = rData.m_pDiffuseTexId->get(ent).m_glId;
+        Magnum::GL::Texture2D &rTexture = rData.m_pTexGl->get(texGlId);
         rShader.bindDiffuseTexture(rTexture);
 
         if (rShader.flags() & (Flag::AmbientTexture | Flag::AlphaMask))
@@ -73,7 +74,7 @@ void shader::draw_ent_phong(
                                 : 0xffffffff_rgbaf);
     }
 
-    MeshGlId const meshId = rData.m_pMeshId->get(ent);
+    MeshGlId const meshId = rData.m_pMeshId->get(ent).m_glId;
     Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
 
     rShader
@@ -94,7 +95,7 @@ void shader::assign_phong(
         RenderGroup::Storage_t *pStorageOpaque,
         RenderGroup::Storage_t *pStorageTransparent,
         acomp_storage_t<ACompOpaque> const& opaque,
-        acomp_storage_t<active::TexGlId> const& diffuse,
+        acomp_storage_t<active::ACompTexGl> const& diffuse,
         ACtxDrawPhong &rData)
 {
 

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -24,10 +24,6 @@
  */
 #include "Phong.h"
 
-#include <osp/Active/SysRender.h>
-
-#include <Magnum/Math/Color.h>
-
 // for the 0xrrggbb_rgbf and angle literals
 using namespace Magnum::Math::Literals;
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -41,29 +41,29 @@ using Phong = Magnum::Shaders::PhongGL;
  */
 struct ACtxDrawPhong
 {
+    template <typename T>
+    using acomp_storage_t = osp::active::acomp_storage_t<T>;
 
-    Phong m_shaderUntextured{Corrade::NoCreate};
-    Phong m_shaderDiffuse{Corrade::NoCreate};
+    Phong m_shaderUntextured    {Corrade::NoCreate};
+    Phong m_shaderDiffuse       {Corrade::NoCreate};
 
-    active::acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
-    active::acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    acomp_storage_t<active::ACompDrawTransform> *m_pDrawTf{nullptr};
+    acomp_storage_t<active::ACompColor>         *m_pColor{nullptr};
+    osp::active::ACompTexGlStorage_t            *m_pDiffuseTexId{nullptr};
+    osp::active::ACompMeshGlStorage_t           *m_pMeshId{nullptr};
 
-    osp::active::acomp_storage_t<osp::active::TexGlId>  *m_pDiffuseTexId{nullptr};
-    osp::active::TexGlStorage_t                         *m_pTexGl{nullptr};
-
-    osp::active::acomp_storage_t<osp::active::MeshGlId> *m_pMeshId{nullptr};
-    osp::active::MeshGlStorage_t                        *m_pMeshGl{nullptr};
+    osp::active::TexGlStorage_t                 *m_pTexGl{nullptr};
+    osp::active::MeshGlStorage_t                *m_pMeshGl{nullptr};
 
     constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
                                    active::RenderGL& rRenderGl) noexcept
     {
         m_pDrawTf       = &rCtxScnGl.m_drawTransform;
         // TODO: ACompColor
-
         m_pDiffuseTexId = &rCtxScnGl.m_diffuseTexId;
-        m_pTexGl        = &rRenderGl.m_texGl;
-
         m_pMeshId       = &rCtxScnGl.m_meshId;
+
+        m_pTexGl        = &rRenderGl.m_texGl;
         m_pMeshGl       = &rRenderGl.m_meshGl;
     }
 };
@@ -89,7 +89,7 @@ void assign_phong(
         active::RenderGroup::Storage_t *pStorageOpaque,
         active::RenderGroup::Storage_t *pStorageTransparent,
         active::acomp_storage_t<active::ACompOpaque> const& opaque,
-        active::acomp_storage_t<active::TexGlId> const& diffuse,
+        active::acomp_storage_t<active::ACompTexGl> const& diffuse,
         ACtxDrawPhong &rData);
 
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -24,12 +24,9 @@
  */
 #pragma once
 
-
 #include <osp/Active/opengl/SysRenderGL.h>
-#include <osp/Resource/Resource.h>
 
 #include <Magnum/Shaders/PhongGL.h>
-
 
 namespace osp::shader
 {

--- a/src/osp/id_map.h
+++ b/src/osp/id_map.h
@@ -34,7 +34,9 @@ template <typename KEY_T, typename VALUE_T>
 using IdMap_t = entt::dense_hash_map<KEY_T, VALUE_T>;
 
 // TODO: Consider writing a wrapper that specializes the map with the integer
-//       underlying type of KEY_T. This will these maps easier to manage, and
-//       may improve compile times as only one specialization is actually made.
+//       underlying type of KEY_T. This will make maps easier to manage as they
+//       can be converted between each other, and may improve compile times as
+//       only one specialization is actually made.
+//       Also consider using extern templates
 
 }

--- a/src/osp/id_map.h
+++ b/src/osp/id_map.h
@@ -1,0 +1,40 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <entt/container/dense_hash_map.hpp>
+
+namespace osp
+{
+
+// Preferred container to map int/enum Ids with other Ids or small datatypes
+template <typename KEY_T, typename VALUE_T>
+using IdMap_t = entt::dense_hash_map<KEY_T, VALUE_T>;
+
+// TODO: Consider writing a wrapper that specializes the map with the integer
+//       underlying type of KEY_T. This will these maps easier to manage, and
+//       may improve compile times as only one specialization is actually made.
+
+}

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -26,7 +26,7 @@
 
 #include <entt/core/any.hpp>
 
-#include <osp/Resource/Package.h>
+#include <osp/Resource/resourcetypes.h>
 
 #include <functional>
 
@@ -69,11 +69,12 @@ struct EngineTestScene;
 /**
  * @brief Setup Engine Test Scene
  *
- * @param rPkg [in] Package containing cube mesh used by test scene
+ * @param rResources    [ref] Application Resources containing cube mesh
+ * @param pkg           [in] Package Id the cube mesh is under
  *
  * @return entt::any containing scene data
  */
-entt::any setup_scene(osp::Package &rPkg);
+entt::any setup_scene(osp::Resources& rResources, osp::PkgId pkg);
 
 /**
  * @brief Generate ActiveApplication draw function
@@ -100,11 +101,12 @@ struct PhysicsTestScene;
 /**
  * @brief Setup Physics Test Scene
  *
- * @param rPkg [in]
+ * @param rResources    [ref] Application Resources containing mesh primatives
+ * @param pkg           [in] Package Id the mesh primatives are under
  *
  * @return entt::any containing scene data
  */
-entt::any setup_scene(osp::Package &rPkg);
+entt::any setup_scene(osp::Resources& rResources, osp::PkgId pkg);
 
 /**
  * @brief Generate ActiveApplication draw function

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -48,6 +48,8 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 
+using osp::active::ActiveEnt;
+
 using Magnum::Trade::MeshData;
 using Magnum::Trade::ImageData2D;
 
@@ -79,7 +81,7 @@ struct EngineTestScene
     osp::Resources *m_pResources;
 
     // ID registry generates entity IDs, and keeps track of which ones exist
-    lgrn::IdRegistry<osp::active::ActiveEnt> m_activeIds;
+    lgrn::IdRegistry<ActiveEnt> m_activeIds;
 
     // Components and supporting data structures
     osp::active::ACtxBasic          m_basic;    
@@ -87,10 +89,10 @@ struct EngineTestScene
     osp::active::ACtxDrawingRes     m_drawingRes;
 
     // Hierarchy root, needs to exist so all hierarchy entities are connected
-    osp::active::ActiveEnt          m_hierRoot;
+    ActiveEnt                       m_hierRoot{lgrn::id_null<ActiveEnt>()};
 
     // The rotating cube
-    osp::active::ActiveEnt          m_cube;
+    ActiveEnt                       m_cube{lgrn::id_null<ActiveEnt>()};
 
     osp::active::MeshIdOwner_t      m_meshCube;
 };
@@ -195,7 +197,7 @@ struct EngineTestRenderer
 
     osp::active::ACtxSceneRenderGL m_renderGl{};
 
-    osp::active::ActiveEnt m_camera;
+    ActiveEnt m_camera{lgrn::id_null<ActiveEnt>()};
     ACtxCameraController m_camCtrl;
 
     osp::shader::ACtxDrawPhong m_phong{};

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -72,7 +72,7 @@ struct EngineTestScene
     ~EngineTestScene()
     {
         osp::active::SysRender::clear_owners(m_drawing);
-        osp::active::SysRender::clear_resource_owners(m_drawing, m_drawingRes, *m_pResources);
+        osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
         m_drawing.m_meshRefCounts.ref_release(m_meshCube);
     }
 
@@ -233,14 +233,15 @@ void render_test_scene(
                 std::cbegin(rMatCommon.m_added),
                 std::cend(rMatCommon.m_added));
 
+    // Load required meshes and textures into OpenGL
     SysRenderGL::sync_scene_resources(rScene.m_drawingRes, *rScene.m_pResources, rApp.get_render_gl());
 
-    // Load any required meshes
+    // Assign GL meshes to entities with a mesh component
     SysRenderGL::assign_meshes(
             rScene.m_drawing.m_mesh, rScene.m_drawingRes.m_meshToRes, rScene.m_drawing.m_meshDirty,
             rRenderer.m_renderGl.m_meshId, rApp.get_render_gl());
 
-    // Load any required textures
+    // Assign GL textures to entities with a texture component
     SysRenderGL::assign_textures(
             rScene.m_drawing.m_diffuseTex, rScene.m_drawingRes.m_texToRes, rScene.m_drawing.m_diffuseDirty,
             rRenderer.m_renderGl.m_diffuseTexId, rApp.get_render_gl());

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -118,7 +118,7 @@ struct PhysicsTestScene
     std::vector<ActiveEnt>          m_deleteTotal;
 
     // Hierarchy root, needs to exist so all hierarchy entities are connected
-    osp::active::ActiveEnt          m_hierRoot;
+    osp::active::ActiveEnt          m_hierRoot{lgrn::id_null<ActiveEnt>()};
 
     // Meshes used in the scene
     entt::dense_hash_map<EShape, MeshIdOwner_t> m_shapeToMesh;

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -88,7 +88,7 @@ struct PhysicsTestScene
     ~PhysicsTestScene()
     {
         osp::active::SysRender::clear_owners(m_drawing);
-        osp::active::SysRender::clear_resource_owners(m_drawing, m_drawingRes, *m_pResources);
+        osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
         m_drawing.m_meshRefCounts.ref_release(m_meshCube);
     }
 
@@ -553,14 +553,15 @@ void render_test_scene(
                     std::cend(rMatVisualizer.m_added));
     }
 
+    // Load required meshes and textures into OpenGL
     SysRenderGL::sync_scene_resources(rScene.m_drawingRes, *rScene.m_pResources, rApp.get_render_gl());
 
-    // Load any required meshes
+    // Assign GL meshes to entities with a mesh component
     SysRenderGL::assign_meshes(
             rScene.m_drawing.m_mesh, rScene.m_drawingRes.m_meshToRes, rScene.m_drawing.m_meshDirty,
             rRenderer.m_renderGl.m_meshId, rApp.get_render_gl());
 
-    // Load any required textures
+    // Assign GL textures to entities with a texture component
     SysRenderGL::assign_textures(
             rScene.m_drawing.m_diffuseTex, rScene.m_drawingRes.m_texToRes, rScene.m_drawing.m_diffuseDirty,
             rRenderer.m_renderGl.m_diffuseTexId, rApp.get_render_gl());

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -130,6 +130,8 @@ struct PhysicsTestScene
 
 };
 
+#if 0
+
 std::optional<osp::active::ACompMesh> mesh_from_shape(PhysicsTestScene& rScene, osp::phys::EShape shape)
 {
     using osp::active::ACompMesh;
@@ -682,5 +684,7 @@ on_draw_t generate_draw_func(PhysicsTestScene& rScene, ActiveApplication& rApp)
         SysRender::clear_dirty_materials(rScene.m_drawing.m_materials);
     };
 }
+
+#endif
 
 } // namespace testapp::physicstest

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -33,13 +33,9 @@
 #include "universes/simple.h"
 #include "universes/planets.h"
 
-#include <osp/Resource/AssetImporter.h>
 #include <osp/Resource/resources.h>
 #include <osp/string_concat.h>
 #include <osp/logging.h>
-
-#include <adera/ShipResources.h>
-#include <adera/Shaders/PlumeShader.h>
 
 #include <Magnum/MeshTools/Transform.h>
 #include <Magnum/Primitives/Cylinder.h>
@@ -363,7 +359,7 @@ void load_a_bunch_of_stuff()
 
 
     // Add a default primitives
-    auto add_mesh_quick = [] (std::string_view name, Trade::MeshData&& data)
+    auto const add_mesh_quick = [] (std::string_view name, Trade::MeshData&& data)
     {
         osp::ResId const meshId = g_resources.create(gc_mesh, g_defaultPkg, name);
         g_resources.data_add<Trade::MeshData>(gc_mesh, meshId, std::forward<Trade::MeshData>(data));
@@ -396,40 +392,6 @@ void debug_print_help()
         << "* help      - Show this again\n"
         << "* reopen    - Re-open Magnum Application\n"
         << "* exit      - Deallocate everything and return memory to OS\n";
-}
-
-template <typename RES_T>
-void debug_print_resource_group(osp::Package const& rPkg)
-{
-    auto const pGroup = rPkg.group_get<RES_T>();
-
-    if (pGroup == nullptr)
-    {
-        return;
-    }
-
-    std::cout << "  * TYPE: " << entt::type_name<RES_T>().value() << "\n";
-
-    for (auto const& [key, resource] : *pGroup)
-    {
-        std::cout << "    * " << (resource.m_data.has_value() ? "LOADED" : "RESERVED") << ": " << key << "\n";
-    }
-}
-
-void debug_print_package(osp::Package const& rPkg, osp::ResPrefix_t const& prefix)
-{
-    std::cout << "* PACKAGE: " << prefix << "\n";
-
-    // TODO: maybe consider polymorphic access to resources?
-    debug_print_resource_group<osp::PrototypePart>(rPkg);
-    debug_print_resource_group<osp::BlueprintVehicle>(rPkg);
-
-    debug_print_resource_group<Magnum::Trade::ImageData2D>(rPkg);
-    debug_print_resource_group<Magnum::Trade::MeshData>(rPkg);
-    debug_print_resource_group<Magnum::GL::Texture2D>(rPkg);
-    debug_print_resource_group<Magnum::GL::Mesh>(rPkg);
-
-    debug_print_resource_group<adera::active::machines::ShipResourceType>(rPkg);
 }
 
 void debug_print_resources()

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -134,12 +134,11 @@ std::unordered_map<std::string_view, Option> const g_scenes
             rApp.set_on_draw(generate_draw_func(rScene, rApp));
         };
     }}}
-#if 0
     ,
     {"physicstest", {"Physics lol", [] {
 
         using namespace physicstest;
-        g_activeScene = setup_scene(g_packages.find("lzdb"));
+        g_activeScene = setup_scene(g_resources, g_defaultPkg);
 
         g_appSetup = [] (ActiveApplication& rApp)
         {
@@ -148,7 +147,6 @@ std::unordered_map<std::string_view, Option> const g_scenes
             rApp.set_on_draw(generate_draw_func(rScene, rApp));
         };
     }}}
-#endif
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Details on how the `osp::Resources` class works is here: #174

This PR switches the test scenes away from the old resource system to the new one, most notable the mesh and texture components.

### Scene Mesh and Textures

see `src/osp/Active/drawing.h`

Instead of indirectly storing a pointer to a Texture resource through DependRes<TextureData>, the scene itself now keeps its own set of Texture Ids (TexId). Some of these 'scene-space' texture IDs can be associated with a Resource Id (ResId).

This also allows scenes to have textures that aren't associated with a resource, ie. in-game screens that require render-to-texture. All this applies to meshes too, ie. planet terrain mesh. The task of associating with a resource naturally decoupled from the scene itself; consequently, this also entirely decouples the scene's dependency on any resource system >:)

All of the meshes and texture resources used by the scene are easily accessible, stored in a fast-to-iterate entt dense hash map.

Copying a mesh in the scene, does not need to increment the reference count of the Resources class. The scene itself holds only a single 'owner' instance of each unique mesh/texture it uses. The scene instead keeps its own reference counts for its mesh and texture Ids.

### Reference counting and owners

A bit of a refresher: the Longeron IdStorage class is a move-only wrapped integer Id, that can only be modified by a single friend class. This will soon be renamed to IdOwner to better describe its intentions.

Containers can use IdOwners as safe reference-counted integer Ids that does not require pointers to the container. A container can have functions to create and destroy owners. Owners cannot be copied (unless unsafe code is used), and will assert when destructed while still holding a value. A container can keep track of how many owners it creates and destroys to work as a reference count.

Owner cleanup needs to be done manually; but as an upside, they have little side effects compared to typical RAII like in shared_ptr. This makes them potentially free of overhead on release builds, and just compile down to a single int.

see `test/resources/main.cpp`

Owners are used for resources, as ResIdOwner_t, as well as meshes and textures: TexIdOwner_t and MeshIdOwner_t. 