### PR TITLE
Add Common Test Scene

### DIFF
--- a/src/osp/Active/SysRender.cpp
+++ b/src/osp/Active/SysRender.cpp
@@ -103,12 +103,32 @@ void SysRender::update_draw_transforms(
     }
 }
 
-void SysRender::clear_dirty_materials(std::vector<MaterialData> &rMaterials)
+void SysRender::set_dirty_all(ACtxDrawing &rCtxDrawing)
 {
-    for (MaterialData &rMat : rMaterials)
+    using osp::active::active_sparse_set_t;
+
+    for (osp::active::MaterialData &rMat : rCtxDrawing.m_materials)
+    {
+        rMat.m_added.assign(std::begin(rMat.m_comp), std::end(rMat.m_comp));
+    }
+
+    // Set all meshs dirty
+    auto &rMeshSet = static_cast<active_sparse_set_t&>(rCtxDrawing.m_mesh);
+    rCtxDrawing.m_meshDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
+
+    // Set all textures dirty
+    auto &rDiffSet = static_cast<active_sparse_set_t&>(rCtxDrawing.m_diffuseTex);
+    rCtxDrawing.m_diffuseDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
+}
+
+void SysRender::clear_dirty_all(ACtxDrawing& rCtxDrawing)
+{
+    for (MaterialData &rMat : rCtxDrawing.m_materials)
     {
         rMat.m_added.clear();
         rMat.m_removed.clear();
     }
+    rCtxDrawing.m_meshDirty.clear();
+    rCtxDrawing.m_diffuseDirty.clear();
 }
 

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -183,11 +183,18 @@ public:
             acomp_storage_t<ACompDrawTransform>& rDrawTf);
 
     /**
-     * @brief Clear dirty vectors (m_added, m_removed) of all materials
+     * @brief Set all dirty flags/vectors
      *
-     * @param rMaterials [ref] Materials vector with vectors to clear
+     * @param rCtxDrawing [ref] Drawing data
      */
-    static void clear_dirty_materials(std::vector<MaterialData> &rMaterials);
+    static void set_dirty_all(ACtxDrawing& rCtxDrawing);
+
+    /**
+     * @brief Clear all dirty flags/vectors
+     *
+     * @param rCtxDrawing [ref] Drawing data
+     */
+    static void clear_dirty_all(ACtxDrawing& rCtxDrawing);
 
     template<typename IT_T>
     static void update_delete_drawing(

--- a/src/test_application/activescenes/common_renderer_gl.cpp
+++ b/src/test_application/activescenes/common_renderer_gl.cpp
@@ -31,7 +31,7 @@
 namespace testapp
 {
 
-void CommonRendererGL::setup(ActiveApplication& rApp, CommonTestScene& rScene)
+void CommonSceneRendererGL::setup(ActiveApplication& rApp, CommonTestScene& rScene)
 {
     using namespace osp::active;
     using namespace osp::shader;
@@ -56,7 +56,7 @@ void CommonRendererGL::setup(ActiveApplication& rApp, CommonTestScene& rScene)
 
 }
 
-void CommonRendererGL::render(ActiveApplication& rApp, CommonTestScene& rScene)
+void CommonSceneRendererGL::render(ActiveApplication& rApp, CommonTestScene& rScene)
 {
     using namespace osp::active;
     using namespace osp::shader;
@@ -142,7 +142,7 @@ void CommonRendererGL::render(ActiveApplication& rApp, CommonTestScene& rScene)
     SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
-void CommonRendererGL::update_delete(std::vector<osp::active::ActiveEnt> const& toDelete)
+void CommonSceneRendererGL::update_delete(std::vector<osp::active::ActiveEnt> const& toDelete)
 {
     auto first = std::cbegin(toDelete);
     auto last = std::cend(toDelete);

--- a/src/test_application/activescenes/common_renderer_gl.cpp
+++ b/src/test_application/activescenes/common_renderer_gl.cpp
@@ -1,0 +1,153 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "common_renderer_gl.h"
+
+#include <Magnum/GL/DefaultFramebuffer.h>
+
+#include <Corrade/Containers/ArrayViewStl.h>
+
+namespace testapp
+{
+
+void CommonRendererGL::setup(ActiveApplication& rApp, CommonTestScene& rScene)
+{
+    using namespace osp::active;
+    using namespace osp::shader;
+
+    // Setup Phong shaders
+    auto const texturedFlags
+            = Phong::Flag::DiffuseTexture | Phong::Flag::AlphaMask
+            | Phong::Flag::AmbientTexture;
+    m_phong.m_shaderDiffuse      = Phong{texturedFlags, 2};
+    m_phong.m_shaderUntextured   = Phong{{}, 2};
+    m_phong.assign_pointers(
+            m_renderGl, rApp.get_render_gl());
+
+    // Setup Mesh Visualizer shader
+    m_visualizer.m_shader
+            = MeshVisualizer{ MeshVisualizer::Flag::Wireframe };
+    m_visualizer.assign_pointers(
+            m_renderGl, rApp.get_render_gl());
+
+    // Create render group for forward opaque pass
+    m_renderGroups.m_groups.emplace("fwd_opaque", RenderGroup{});
+
+}
+
+void CommonRendererGL::render(ActiveApplication& rApp, CommonTestScene& rScene)
+{
+    using namespace osp::active;
+    using namespace osp::shader;
+    using Magnum::GL::Framebuffer;
+    using Magnum::GL::FramebufferClear;
+    using Magnum::GL::Texture2D;
+
+    RenderGroup &rGroupFwdOpaque
+            = m_renderGroups.m_groups["fwd_opaque"];
+
+    // Assign Phong shader to entities with the gc_mat_common material, and put
+    // results into the fwd_opaque render group
+    {
+        MaterialData const &rMatCommon = rScene.m_drawing.m_materials[rScene.m_matCommon];
+        assign_phong(
+                rMatCommon.m_added, &rGroupFwdOpaque.m_entities, nullptr,
+                rScene.m_drawing.m_opaque, m_renderGl.m_diffuseTexId,
+                m_phong);
+        SysRender::assure_draw_transforms(
+                    rScene.m_basic.m_hierarchy,
+                    m_renderGl.m_drawTransform,
+                    std::cbegin(rMatCommon.m_added),
+                    std::cend(rMatCommon.m_added));
+    }
+
+    // Same thing but with MeshVisualizer and gc_mat_visualizer
+    {
+        MaterialData const &rMatVisualizer
+                = rScene.m_drawing.m_materials[rScene.m_matVisualizer];
+
+        assign_visualizer(
+                rMatVisualizer.m_added, rGroupFwdOpaque.m_entities,
+                m_visualizer);
+        SysRender::assure_draw_transforms(
+                    rScene.m_basic.m_hierarchy,
+                    m_renderGl.m_drawTransform,
+                    std::cbegin(rMatVisualizer.m_added),
+                    std::cend(rMatVisualizer.m_added));
+    }
+
+    // Load required meshes and textures into OpenGL
+    SysRenderGL::sync_scene_resources(rScene.m_drawingRes, *rScene.m_pResources, rApp.get_render_gl());
+
+    // Assign GL meshes to entities with a mesh component
+    SysRenderGL::assign_meshes(
+            rScene.m_drawing.m_mesh, rScene.m_drawingRes.m_meshToRes, rScene.m_drawing.m_meshDirty,
+            m_renderGl.m_meshId, rApp.get_render_gl());
+
+    // Assign GL textures to entities with a texture component
+    SysRenderGL::assign_textures(
+            rScene.m_drawing.m_diffuseTex, rScene.m_drawingRes.m_texToRes, rScene.m_drawing.m_diffuseDirty,
+            m_renderGl.m_diffuseTexId, rApp.get_render_gl());
+
+    // Calculate hierarchy transforms
+    SysRender::update_draw_transforms(
+            rScene.m_basic.m_hierarchy,
+            rScene.m_basic.m_transform,
+            m_renderGl.m_drawTransform);
+
+    // Get camera to calculate view and projection matrix
+    ACompCamera const &rCamera = rScene.m_basic.m_camera.get(m_camera);
+    ACompDrawTransform const &cameraDrawTf
+            = m_renderGl.m_drawTransform.get(m_camera);
+    ViewProjMatrix viewProj{
+            cameraDrawTf.m_transformWorld.inverted(),
+            rCamera.calculate_projection()};
+
+    // Bind offscreen FBO
+    Framebuffer &rFbo = rApp.get_render_gl().m_fbo;
+    rFbo.bind();
+
+    // Clear it
+    rFbo.clear( FramebufferClear::Color | FramebufferClear::Depth
+                | FramebufferClear::Stencil);
+
+    // Forward Render fwd_opaque group to FBO
+    SysRenderGL::render_opaque(
+            m_renderGroups.m_groups.at("fwd_opaque"),
+            rScene.m_drawing.m_visible, viewProj);
+
+    // Display FBO
+    Texture2D &rFboColor = rApp.get_render_gl().m_texGl.get(rApp.get_render_gl().m_fboColor);
+    SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
+}
+
+void CommonRendererGL::update_delete(std::vector<osp::active::ActiveEnt> const& toDelete)
+{
+    auto first = std::cbegin(toDelete);
+    auto last = std::cend(toDelete);
+    osp::active::SysRender::update_delete_groups(m_renderGroups, first, last);
+    osp::active::SysRenderGL::update_delete(m_renderGl, first, last);
+}
+
+} // namespace testapp

--- a/src/test_application/activescenes/common_renderer_gl.cpp
+++ b/src/test_application/activescenes/common_renderer_gl.cpp
@@ -28,12 +28,13 @@
 
 #include <Corrade/Containers/ArrayViewStl.h>
 
+using namespace osp::active;
+
 namespace testapp
 {
 
-void CommonSceneRendererGL::setup(ActiveApplication& rApp, CommonTestScene const& rScene)
+void CommonSceneRendererGL::setup(ActiveApplication& rApp)
 {
-    using namespace osp::active;
     using namespace osp::shader;
 
     // Setup Phong shaders
@@ -58,7 +59,6 @@ void CommonSceneRendererGL::setup(ActiveApplication& rApp, CommonTestScene const
 
 void CommonSceneRendererGL::sync(ActiveApplication& rApp, CommonTestScene const& rScene)
 {
-    using namespace osp::active;
     using namespace osp::shader;
 
     RenderGroup &rGroupFwdOpaque
@@ -116,7 +116,6 @@ void CommonSceneRendererGL::sync(ActiveApplication& rApp, CommonTestScene const&
 
 void CommonSceneRendererGL::render(ActiveApplication& rApp, CommonTestScene const& rScene)
 {
-    using namespace osp::active;
     using Magnum::GL::Framebuffer;
     using Magnum::GL::FramebufferClear;
     using Magnum::GL::Texture2D;
@@ -147,28 +146,27 @@ void CommonSceneRendererGL::render(ActiveApplication& rApp, CommonTestScene cons
     SysRenderGL::display_texture(rApp.get_render_gl(), rFboColor);
 }
 
-void CommonSceneRendererGL::update_delete(std::vector<osp::active::ActiveEnt> const& toDelete)
+void CommonSceneRendererGL::update_delete(std::vector<ActiveEnt> const& toDelete)
 {
     auto first = std::cbegin(toDelete);
     auto last = std::cend(toDelete);
-    osp::active::SysRender::update_delete_groups(m_renderGroups, first, last);
-    osp::active::SysRenderGL::update_delete(m_renderGl, first, last);
+    SysRender::update_delete_groups(m_renderGroups, first, last);
+    SysRenderGL::update_delete(m_renderGl, first, last);
 }
 
 on_draw_t generate_common_draw(CommonTestScene& rScene, ActiveApplication& rApp, setup_renderer_t setup_scene)
 {
-    std::shared_ptr<CommonSceneRendererGL> pRenderer
-            = std::make_shared<CommonSceneRendererGL>();
+    auto pRenderer = std::make_shared<CommonSceneRendererGL>();
 
     // Setup default resources
-    pRenderer->setup(rApp, rScene);
+    pRenderer->setup(rApp);
 
     // Setup scene-specifc stuff
     setup_scene(*pRenderer, rScene, rApp);
 
     // Set all drawing stuff dirty then sync with renderer.
     // This allows clean re-openning of the scene
-    osp::active::SysRender::set_dirty_all(rScene.m_drawing);
+    SysRender::set_dirty_all(rScene.m_drawing);
     pRenderer->sync(rApp, rScene);
 
     return [&rScene, pRenderer = std::move(pRenderer)] (ActiveApplication& rApp, float delta)

--- a/src/test_application/activescenes/common_renderer_gl.h
+++ b/src/test_application/activescenes/common_renderer_gl.h
@@ -46,7 +46,7 @@ namespace testapp
 struct CommonSceneRendererGL : MultiAny
 {
     using on_custom_draw_t = void(*)(CommonSceneRendererGL&, CommonTestScene&,
-                                     ActiveApplication&, float);
+                                     ActiveApplication&, float) noexcept;
 
     // Most test scenes will be drawn in the exact same way: by calling the
     // draw functions of shaders.
@@ -66,9 +66,8 @@ struct CommonSceneRendererGL : MultiAny
      * @brief Setup default shaders and render groups
      *
      * @param rApp      [ref] Application with GL context
-     * @param rScene    [ref] Test scene to render
      */
-    void setup(ActiveApplication& rApp, CommonTestScene const& rScene);
+    void setup(ActiveApplication& rApp);
 
     /**
      * @brief Sync GL resources with scene meshes, textures, and materials
@@ -95,7 +94,7 @@ struct CommonSceneRendererGL : MultiAny
 };
 
 
-using setup_renderer_t = void(*)(CommonSceneRendererGL&, CommonTestScene&, ActiveApplication&);
+using setup_renderer_t = void(*)(CommonSceneRendererGL&, CommonTestScene&, ActiveApplication&) noexcept;
 
 /**
  * @brief Generate a draw function for drawing a single common scene

--- a/src/test_application/activescenes/common_renderer_gl.h
+++ b/src/test_application/activescenes/common_renderer_gl.h
@@ -1,0 +1,63 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "common_scene.h"
+
+#include "../ActiveApplication.h"
+
+#include <osp/Active/opengl/SysRenderGL.h>
+
+#include <osp/Shaders/Phong.h>
+#include <osp/Shaders/MeshVisualizer.h>
+
+namespace testapp
+{
+
+struct CommonRendererGL
+{
+    osp::active::ACtxRenderGroups m_renderGroups;
+
+    osp::active::ACtxSceneRenderGL m_renderGl;
+
+    osp::shader::ACtxDrawPhong m_phong;
+    osp::shader::ACtxDrawMeshVisualizer m_visualizer;
+
+    osp::active::ActiveEnt m_camera;
+
+    void setup(ActiveApplication& rApp, CommonTestScene& rScene);
+
+    /**
+     * @brief Render a CommonTestScene
+     *
+     * @param rApp      [ref] Application with GL context and resources
+     * @param rScene    [ref] Test scene to render
+     * @param rRenderer [ref] Renderer data for test scene
+     */
+    void render(ActiveApplication& rApp, CommonTestScene& rScene);
+    void update_delete(std::vector<osp::active::ActiveEnt> const& toDelete);
+};
+
+} // namespace testapp

--- a/src/test_application/activescenes/common_renderer_gl.h
+++ b/src/test_application/activescenes/common_renderer_gl.h
@@ -36,27 +36,45 @@
 namespace testapp
 {
 
-struct CommonRendererGL : MultiAny
+/**
+ * @brief Common data needed to render a scene
+ *
+ * Note: GPU resources and application-level rendering data can be found in
+ *       osp::active::RenderGL
+ *
+ */
+struct CommonSceneRendererGL : MultiAny
 {
-    osp::active::ACtxRenderGroups m_renderGroups;
-
     osp::active::ACtxSceneRenderGL m_renderGl;
+
+    osp::active::ACtxRenderGroups m_renderGroups;
 
     osp::shader::ACtxDrawPhong m_phong;
     osp::shader::ACtxDrawMeshVisualizer m_visualizer;
 
     osp::active::ActiveEnt m_camera;
 
+    /**
+     * @brief Setup default shaders and render groups
+     *
+     * @param rApp      [ref] Application with GL context
+     * @param rScene    [ref] Test scene to render
+     */
     void setup(ActiveApplication& rApp, CommonTestScene& rScene);
 
     /**
      * @brief Render a CommonTestScene
      *
-     * @param rApp      [ref] Application with GL context and resources
+     * @param rApp      [ref] Application with GL context
      * @param rScene    [ref] Test scene to render
-     * @param rRenderer [ref] Renderer data for test scene
      */
     void render(ActiveApplication& rApp, CommonTestScene& rScene);
+
+    /**
+     * @brief Delete components of entities to delete
+     *
+     * @param toDelete  [in] Vector of deleted entities
+     */
     void update_delete(std::vector<osp::active::ActiveEnt> const& toDelete);
 };
 

--- a/src/test_application/activescenes/common_renderer_gl.h
+++ b/src/test_application/activescenes/common_renderer_gl.h
@@ -45,6 +45,14 @@ namespace testapp
  */
 struct CommonSceneRendererGL : MultiAny
 {
+    using on_custom_draw_t = void(*)(CommonSceneRendererGL&, CommonTestScene&,
+                                     ActiveApplication&, float);
+
+    // Most test scenes will be drawn in the exact same way: by calling the
+    // draw functions of shaders.
+    // For more sophistication, make a custom on_draw_t instead
+    on_custom_draw_t m_onCustomDraw{nullptr};
+
     osp::active::ACtxSceneRenderGL m_renderGl;
 
     osp::active::ACtxRenderGroups m_renderGroups;
@@ -60,15 +68,23 @@ struct CommonSceneRendererGL : MultiAny
      * @param rApp      [ref] Application with GL context
      * @param rScene    [ref] Test scene to render
      */
-    void setup(ActiveApplication& rApp, CommonTestScene& rScene);
+    void setup(ActiveApplication& rApp, CommonTestScene const& rScene);
 
     /**
-     * @brief Render a CommonTestScene
+     * @brief Sync GL resources with scene meshes, textures, and materials
      *
      * @param rApp      [ref] Application with GL context
      * @param rScene    [ref] Test scene to render
      */
-    void render(ActiveApplication& rApp, CommonTestScene& rScene);
+    void sync(ActiveApplication& rApp, CommonTestScene const& rScene);
+
+    /**
+     * @brief Render to default framebuffer
+     *
+     * @param rApp      [ref] Application with GL context
+     * @param rScene    [ref] Test scene to render
+     */
+    void render(ActiveApplication& rApp, CommonTestScene const& rScene);
 
     /**
      * @brief Delete components of entities to delete
@@ -77,5 +93,23 @@ struct CommonSceneRendererGL : MultiAny
      */
     void update_delete(std::vector<osp::active::ActiveEnt> const& toDelete);
 };
+
+
+using setup_renderer_t = void(*)(CommonSceneRendererGL&, CommonTestScene&, ActiveApplication&);
+
+/**
+ * @brief Generate a draw function for drawing a single common scene
+ *
+ * @param rScene [ref] Common scene to draw. Must be in stable memory.
+ * @param rApp   [ref] Application with GL context
+ * @param setup  [in] Scene-specific setup function
+ *
+ * @return ActiveApplication draw function
+ */
+on_draw_t generate_common_draw(
+        CommonTestScene& rScene,
+        ActiveApplication& rApp,
+        setup_renderer_t setup);
+
 
 } // namespace testapp

--- a/src/test_application/activescenes/common_renderer_gl.h
+++ b/src/test_application/activescenes/common_renderer_gl.h
@@ -36,7 +36,7 @@
 namespace testapp
 {
 
-struct CommonRendererGL
+struct CommonRendererGL : MultiAny
 {
     osp::active::ACtxRenderGroups m_renderGroups;
 

--- a/src/test_application/activescenes/common_scene.cpp
+++ b/src/test_application/activescenes/common_scene.cpp
@@ -57,7 +57,7 @@ void CommonTestScene::update_hierarchy_delete()
     SysHierarchy::update_delete_descendents(
             m_basic.m_hierarchy,
             std::cbegin(m_delete), std::cend(m_delete),
-            [=] (ActiveEnt ent)
+            [this] (ActiveEnt ent)
     {
         m_deleteTotal.push_back(ent);
     });

--- a/src/test_application/activescenes/common_scene.cpp
+++ b/src/test_application/activescenes/common_scene.cpp
@@ -43,7 +43,7 @@ CommonTestScene::~CommonTestScene()
     osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
 }
 
-void CommonTestScene::update_total_delete()
+void CommonTestScene::update_hierarchy_delete()
 {
     using namespace osp::active;
     // Cut deleted entities out of the hierarchy

--- a/src/test_application/activescenes/common_scene.cpp
+++ b/src/test_application/activescenes/common_scene.cpp
@@ -80,22 +80,4 @@ void CommonTestScene::update_delete()
     }
 }
 
-void CommonTestScene::set_all_dirty()
-{
-    using osp::active::active_sparse_set_t;
-
-    for (osp::active::MaterialData &rMat : m_drawing.m_materials)
-    {
-        rMat.m_added.assign(std::begin(rMat.m_comp), std::end(rMat.m_comp));
-    }
-
-    // Set all meshs dirty
-    auto &rMeshSet = static_cast<active_sparse_set_t&>(m_drawing.m_mesh);
-    m_drawing.m_meshDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
-
-    // Set all textures dirty
-    auto &rDiffSet = static_cast<active_sparse_set_t&>(m_drawing.m_diffuseTex);
-    m_drawing.m_diffuseDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
-}
-
 } // namespace testapp

--- a/src/test_application/activescenes/common_scene.cpp
+++ b/src/test_application/activescenes/common_scene.cpp
@@ -33,6 +33,12 @@ namespace testapp
 
 CommonTestScene::~CommonTestScene()
 {
+    // Clear data first
+    for (on_cleanup_t *cleanup : m_onCleanup)
+    {
+        cleanup(*this);
+    }
+
     osp::active::SysRender::clear_owners(m_drawing);
     osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
 }

--- a/src/test_application/activescenes/common_scene.cpp
+++ b/src/test_application/activescenes/common_scene.cpp
@@ -1,0 +1,95 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "common_scene.h"
+
+#include <osp/Active/SysRender.h>
+
+#include <osp/Active/SysHierarchy.h>
+
+namespace testapp
+{
+
+CommonTestScene::~CommonTestScene()
+{
+    osp::active::SysRender::clear_owners(m_drawing);
+    osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
+}
+
+void CommonTestScene::update_total_delete()
+{
+    using namespace osp::active;
+    // Cut deleted entities out of the hierarchy
+    SysHierarchy::update_delete_cut(
+            m_basic.m_hierarchy,
+            std::cbegin(m_delete), std::cend(m_delete));
+
+    // Create a new delete vector that includes the descendents of our current
+    // vector of entities to delete
+    m_deleteTotal = m_delete;
+    SysHierarchy::update_delete_descendents(
+            m_basic.m_hierarchy,
+            std::cbegin(m_delete), std::cend(m_delete),
+            [=] (ActiveEnt ent)
+    {
+        m_deleteTotal.push_back(ent);
+    });
+}
+
+void CommonTestScene::update_delete()
+{
+    auto first = std::cbegin(m_deleteTotal);
+    auto last = std::cend(m_deleteTotal);
+    osp::active::update_delete_basic                (m_basic,   first, last);
+    osp::active::SysRender::update_delete_drawing   (m_drawing, first, last);
+
+    // Delete entity IDs
+    for (ActiveEnt const ent : m_deleteTotal)
+    {
+        if (m_activeIds.exists(ent))
+        {
+            m_activeIds.remove(ent);
+        }
+    }
+}
+
+void CommonTestScene::set_all_dirty()
+{
+    using osp::active::active_sparse_set_t;
+
+    for (osp::active::MaterialData &rMat : m_drawing.m_materials)
+    {
+        rMat.m_added.assign(std::begin(rMat.m_comp), std::end(rMat.m_comp));
+    }
+
+    // Set all meshs dirty
+    auto &rMeshSet = static_cast<active_sparse_set_t&>(m_drawing.m_mesh);
+    m_drawing.m_meshDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
+
+    // Set all textures dirty
+    auto &rDiffSet = static_cast<active_sparse_set_t&>(m_drawing.m_diffuseTex);
+    m_drawing.m_diffuseDirty.assign(std::begin(rMeshSet), std::end(rMeshSet));
+}
+
+} // namespace testapp

--- a/src/test_application/activescenes/common_scene.h
+++ b/src/test_application/activescenes/common_scene.h
@@ -53,6 +53,7 @@ struct MultiAny
 template <typename T, typename ... ARGS_T>
 T& MultiAny::emplace(ARGS_T&& ... args)
 {
+    // search for an empty spot in m_data, to emplace T into
     Array_t::iterator found = std::find_if(std::begin(m_data), std::end(m_data),
                               [] (entt::any const &any)
     {

--- a/src/test_application/activescenes/common_scene.h
+++ b/src/test_application/activescenes/common_scene.h
@@ -1,0 +1,65 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <osp/Active/basic.h>
+#include <osp/Active/drawing.h>
+
+
+namespace testapp
+{
+struct CommonTestScene
+{
+    using ActiveEnt = osp::active::ActiveEnt;
+
+    ~CommonTestScene();
+
+    osp::Resources *m_pResources;
+
+    // ID registry generates entity IDs, and keeps track of which ones exist
+    lgrn::IdRegistry<osp::active::ActiveEnt> m_activeIds;
+
+    // Basic and Drawing components
+    osp::active::ACtxBasic          m_basic;
+    osp::active::ACtxDrawing        m_drawing;
+    osp::active::ACtxDrawingRes     m_drawingRes;
+
+    // Entity delete list/queue
+    std::vector<ActiveEnt>          m_delete;
+    std::vector<ActiveEnt>          m_deleteTotal;
+
+    // Hierarchy root, needs to exist so all hierarchy entities are connected
+    ActiveEnt                       m_hierRoot;
+
+    int     m_materialCount     {0};
+    int     m_matCommon         {m_materialCount++};
+    int     m_matVisualizer     {m_materialCount++};
+
+    void update_total_delete();
+    void update_delete();
+    void set_all_dirty();
+};
+
+} // namespace testapp

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -33,6 +33,7 @@
 namespace testapp
 {
 
+struct CommonTestScene;
 class ActiveApplication;
 
 using on_draw_t = std::function<void(ActiveApplication&, float delta)>;
@@ -96,17 +97,14 @@ on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp);
 namespace physicstest
 {
 
-struct PhysicsTestScene;
-
 /**
  * @brief Setup Physics Test Scene
  *
- * @param rResources    [ref] Application Resources containing mesh primatives
  * @param pkg           [in] Package Id the mesh primatives are under
  *
  * @return entt::any containing scene data
  */
-entt::any setup_scene(osp::Resources& rResources, osp::PkgId pkg);
+void setup_scene(CommonTestScene &rScene, osp::PkgId pkg);
 
 /**
  * @brief Generate ActiveApplication draw function
@@ -119,7 +117,7 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId pkg);
  *
  * @return ActiveApplication draw function
  */
-on_draw_t generate_draw_func(PhysicsTestScene& rScene, ActiveApplication& rApp);
+on_draw_t generate_draw_func(CommonTestScene& rScene, ActiveApplication& rApp);
 
 } // namespace physicstest
 

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -105,7 +105,7 @@ namespace scenes
 struct PhysicsTest
 {
     static void setup_scene(CommonTestScene &rScene, osp::PkgId pkg);
-    static void setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTestScene& rScene, ActiveApplication& rApp);
+    static void setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTestScene& rScene, ActiveApplication& rApp) noexcept;
 };
 
 } // namespace scenes

--- a/src/test_application/activescenes/scenarios.h
+++ b/src/test_application/activescenes/scenarios.h
@@ -34,10 +34,12 @@ namespace testapp
 {
 
 struct CommonTestScene;
+struct CommonSceneRendererGL;
 class ActiveApplication;
 
+// Stored inside an ActiveApplicaton to use as a main draw function.
+// Renderer state can be stored in lambda capture
 using on_draw_t = std::function<void(ActiveApplication&, float delta)>;
-
 
 namespace flight
 {
@@ -94,31 +96,19 @@ on_draw_t generate_draw_func(EngineTestScene& rScene, ActiveApplication& rApp);
 
 //-----------------------------------------------------------------------------
 
-namespace physicstest
+namespace scenes
 {
 
-/**
- * @brief Setup Physics Test Scene
- *
- * @param pkg           [in] Package Id the mesh primatives are under
- *
- * @return entt::any containing scene data
- */
-void setup_scene(CommonTestScene &rScene, osp::PkgId pkg);
+// Note: Use generate_common_draw to setup common scenes
+//       in common_renderer_gl.h
 
-/**
- * @brief Generate ActiveApplication draw function
- *
- * This draw function stores renderer data, and is responsible for updating
- * and drawing the engine test scene.
- *
- * @param rScene [ref] Engine test scene. Must be in stable memory.
- * @param rApp   [ref] Existing ActiveApplication to use GL resources of
- *
- * @return ActiveApplication draw function
- */
-on_draw_t generate_draw_func(CommonTestScene& rScene, ActiveApplication& rApp);
+struct PhysicsTest
+{
+    static void setup_scene(CommonTestScene &rScene, osp::PkgId pkg);
+    static void setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTestScene& rScene, ActiveApplication& rApp);
+};
 
-} // namespace physicstest
+} // namespace scenes
+
 
 } // namespace testapp

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -90,6 +90,10 @@ struct PhysicsTestScene
         osp::active::SysRender::clear_owners(m_drawing);
         osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
         m_drawing.m_meshRefCounts.ref_release(m_meshCube);
+        for (auto & [_, rOwner] : std::exchange(m_shapeToMesh, {}))
+        {
+            m_drawing.m_meshRefCounts.ref_release(rOwner);
+        }
     }
 
     osp::Resources *m_pResources;

--- a/src/test_application/activescenes/scenarios_physicstest.cpp
+++ b/src/test_application/activescenes/scenarios_physicstest.cpp
@@ -471,7 +471,7 @@ struct PhysicsTestControls
     osp::input::EButtonControlIndex m_btnThrow;
 };
 
-void PhysicsTest::setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTestScene& rScene, ActiveApplication& rApp)
+void PhysicsTest::setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTestScene& rScene, ActiveApplication& rApp) noexcept
 {
     using namespace osp::active;
 
@@ -492,7 +492,7 @@ void PhysicsTest::setup_renderer_gl(CommonSceneRendererGL& rRenderer, CommonTest
 
     rRenderer.m_onCustomDraw = [] (
             CommonSceneRendererGL& rRenderer, CommonTestScene& rScene,
-            ActiveApplication& rApp, float delta)
+            ActiveApplication& rApp, float delta) noexcept
     {
         auto &rScnTest = rScene.get<PhysicsTestData>();
         auto &rControls = rRenderer.get<PhysicsTestControls>();

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -29,6 +29,7 @@
 
 #include "ActiveApplication.h"
 #include "activescenes/scenarios.h"
+#include "activescenes/common_scene.h"
 
 #include "universes/simple.h"
 #include "universes/planets.h"
@@ -133,14 +134,16 @@ std::unordered_map<std::string_view, Option> const g_scenes
     ,
     {"physicstest", {"Physics lol", [] {
 
-        using namespace physicstest;
-        g_activeScene = setup_scene(g_resources, g_defaultPkg);
+        g_activeScene.emplace<testapp::CommonTestScene>(g_resources);
+        auto &rScene = entt::any_cast<CommonTestScene&>(g_activeScene);
+
+        physicstest::setup_scene(rScene, g_defaultPkg);
 
         g_appSetup = [] (ActiveApplication& rApp)
         {
-            PhysicsTestScene& rScene
-                    = entt::any_cast<PhysicsTestScene&>(g_activeScene);
-            rApp.set_on_draw(generate_draw_func(rScene, rApp));
+            auto& rScene
+                    = entt::any_cast<CommonTestScene&>(g_activeScene);
+            rApp.set_on_draw(physicstest::generate_draw_func(rScene, rApp));
         };
     }}}
 };


### PR DESCRIPTION
Common test scenes aim to reduce the absurd amount of duplicate code that would have been necessary when creating new test scenes.

The notable classes added are CommonTestScene and CommonSceneRendererGL, mostly consisting of code moved out of `scenarios_physicstest.cpp`.

`scenarios_enginetest.cpp` is designed to be self contained, so it does not use the new common test scene.

### CommonTestScene

CommonTestScene contains common data that every test scene will probably use: IdRegistry for entities, basic components such as hierarchy, drawing, etc.. Taking a composition approach, additional arbitrary data can be added using `emplace<T>()` and `get<T>()`. Besides cleanup functions, CommonTestScene is mostly pure data, and does not describe any procedures for updating.

### CommonSceneRendererGL

CommonSceneRendererGL contains common data needed for forward rendering a single scene. It comes with material IDs, shaders, and features the same composition approach as CommonTestScene. It has a few important member functions, but it's also mostly just data.

### Draw function and test scene 'class'

The primary way to draw and update the world, is to inject an `on_draw_t` std::function into ActiveApplication. The std::function stores renderer data using lambda capture.

The enginetest has `testapp::enginetest::generate_draw_func` for creating an `on_draw_t`, storing an EngineTestRenderer into it.

Common test scenes have `testapp::generate_common_draw` in `common_renderer_gl.cpp` to create an `on_draw_t`. Custom renderer setup code can be injected as a parameter.

CommonTestScene does not depend on CommonSceneRendererGL. ActiveApplication is made for Magnum and OpenGL. It shouldn't be too difficult to make a text mode renderer, vulkan renderer, RTX raytracer, or whatever.