### PR TITLE
Add new glTF Loader

### DIFF
--- a/src/osp/Resource/ImporterData.h
+++ b/src/osp/Resource/ImporterData.h
@@ -41,13 +41,6 @@ namespace osp
 
 struct TextureImgSource : public ResIdOwner_t { };
 
-struct NodeTransform
-{
-    Vector3     m_translation;
-    Quaternion  m_rotation;
-    Vector3     m_scale;
-};
-
 struct ImporterData
 {
     using OptMaterialData_t = Corrade::Containers::Optional<Magnum::Trade::MaterialData>;
@@ -60,7 +53,7 @@ struct ImporterData
     std::vector<OptMaterialData_t>      m_materials;
 
     // [sceneId][child]
-    lgrn::IntArrayMultiMap<int, int>    m_scenes;
+    lgrn::IntArrayMultiMap<int, int>    m_scnTopLevel;
 
     // Object data
     // note: terminology for 'things' vary
@@ -70,7 +63,7 @@ struct ImporterData
     lgrn::IntArrayMultiMap<int, int>    m_objChildren;
 
     std::vector<std::string_view>       m_objNames;
-    std::vector<NodeTransform>          m_objTransforms;
+    std::vector<Matrix4>                m_objTransforms;
 
     std::vector<int>                    m_objMeshes;
     std::vector<int>                    m_objMaterials;

--- a/src/osp/Resource/ImporterData.h
+++ b/src/osp/Resource/ImporterData.h
@@ -1,0 +1,53 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "../types.h"
+#include "resourcetypes.h"
+
+#include <Magnum/Trade/SceneData.h>
+#include <Magnum/Trade/MaterialData.h>
+
+#include <vector>
+
+namespace osp
+{
+
+struct TextureImgSource : public ResIdOwner_t { };
+
+struct ImporterData
+{
+    std::vector<ResIdOwner_t> m_images;
+    std::vector<ResIdOwner_t> m_textures;
+    std::vector<ResIdOwner_t> m_meshes;
+    std::vector<Magnum::Trade::MaterialData> m_materials;
+
+    std::vector<std::string_view> m_nodeNames;
+    std::vector<int> m_nodeMeshes;
+
+    std::vector<Magnum::Trade::SceneData> m_scenes;
+};
+
+} // namespace osp

--- a/src/osp/Resource/ImporterData.h
+++ b/src/osp/Resource/ImporterData.h
@@ -30,6 +30,7 @@
 #include <Magnum/Trade/MaterialData.h>
 
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/String.h>
 
 #include <longeron/containers/intarray_multimap.hpp>
 
@@ -41,9 +42,15 @@ namespace osp
 
 struct TextureImgSource : public ResIdOwner_t { };
 
+/**
+ * @brief Describes a set of scene graphs that share data with each other
+ *
+ * Intended to be loaded from glTF files through any Magnum glTF loader
+ */
 struct ImporterData
 {
     using OptMaterialData_t = Corrade::Containers::Optional<Magnum::Trade::MaterialData>;
+    using String = Corrade::Containers::String;
 
     // Owned resources
     std::vector<ResIdOwner_t>           m_images;
@@ -52,7 +59,8 @@ struct ImporterData
 
     std::vector<OptMaterialData_t>      m_materials;
 
-    // [sceneId][child]
+    // Top-level nodes of each scene
+    // [scene Id][child object]
     lgrn::IntArrayMultiMap<int, int>    m_scnTopLevel;
 
     // Object data
@@ -62,11 +70,20 @@ struct ImporterData
     std::vector<int>                    m_objParents;
     lgrn::IntArrayMultiMap<int, int>    m_objChildren;
 
-    std::vector<std::string_view>       m_objNames;
+    std::vector<String>                 m_objNames;
     std::vector<Matrix4>                m_objTransforms;
 
     std::vector<int>                    m_objMeshes;
     std::vector<int>                    m_objMaterials;
+};
+
+/**
+ * @brief Groups objects in an ImporterData intended to make them instantiable
+ */
+struct Prefabs
+{
+    // [prefab Id][object]
+    lgrn::IntArrayMultiMap<int, int>    m_prefabs;
 };
 
 } // namespace osp

--- a/src/osp/Resource/ImporterData.h
+++ b/src/osp/Resource/ImporterData.h
@@ -27,9 +27,13 @@
 #include "../types.h"
 #include "resourcetypes.h"
 
-#include <Magnum/Trade/SceneData.h>
 #include <Magnum/Trade/MaterialData.h>
 
+#include <Corrade/Containers/Optional.h>
+
+#include <longeron/containers/intarray_multimap.hpp>
+
+#include <string_view>
 #include <vector>
 
 namespace osp
@@ -37,17 +41,39 @@ namespace osp
 
 struct TextureImgSource : public ResIdOwner_t { };
 
+struct NodeTransform
+{
+    Vector3     m_translation;
+    Quaternion  m_rotation;
+    Vector3     m_scale;
+};
+
 struct ImporterData
 {
-    std::vector<ResIdOwner_t> m_images;
-    std::vector<ResIdOwner_t> m_textures;
-    std::vector<ResIdOwner_t> m_meshes;
-    std::vector<Magnum::Trade::MaterialData> m_materials;
+    using OptMaterialData_t = Corrade::Containers::Optional<Magnum::Trade::MaterialData>;
 
-    std::vector<std::string_view> m_nodeNames;
-    std::vector<int> m_nodeMeshes;
+    // Owned resources
+    std::vector<ResIdOwner_t>           m_images;
+    std::vector<ResIdOwner_t>           m_textures;
+    std::vector<ResIdOwner_t>           m_meshes;
 
-    std::vector<Magnum::Trade::SceneData> m_scenes;
+    std::vector<OptMaterialData_t>      m_materials;
+
+    // [sceneId][child]
+    lgrn::IntArrayMultiMap<int, int>    m_scenes;
+
+    // Object data
+    // note: terminology for 'things' vary
+    // * Magnum: Object       * glTF: Node       * OSP & EnTT: Entity
+
+    std::vector<int>                    m_objParents;
+    lgrn::IntArrayMultiMap<int, int>    m_objChildren;
+
+    std::vector<std::string_view>       m_objNames;
+    std::vector<NodeTransform>          m_objTransforms;
+
+    std::vector<int>                    m_objMeshes;
+    std::vector<int>                    m_objMaterials;
 };
 
 } // namespace osp

--- a/src/osp/Resource/load_tinygltf.cpp
+++ b/src/osp/Resource/load_tinygltf.cpp
@@ -1,0 +1,195 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "load_tinygltf.h"
+
+#include "ImporterData.h"
+#include "resources.h"
+
+#include "../logging.h"
+#include "../string_concat.h"
+
+#include <MagnumPlugins/TinyGltfImporter/TinyGltfImporter.h>
+#include <MagnumExternal/TinyGltf/tiny_gltf.h>
+
+#include <Magnum/Trade/ImageData.h>
+#include <Magnum/Trade/TextureData.h>
+#include <Magnum/Trade/MeshData.h>
+#include <Magnum/Trade/ObjectData3D.h>
+
+#include <Corrade/PluginManager/Manager.h>
+
+using namespace osp;
+
+using Magnum::Trade::TinyGltfImporter;
+
+using Magnum::Trade::ImageData2D;
+using Magnum::Trade::TextureData;
+using Magnum::Trade::MeshData;
+using Magnum::Trade::ObjectData3D;
+
+using Magnum::UnsignedInt;
+
+using PluginManager = Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter>;
+using Corrade::Containers::Optional;
+using Corrade::Containers::Pointer;
+
+using TinyGltfNodeExtras_t = std::vector<tinygltf::Value>;
+
+static void load_gltf(TinyGltfImporter &rImporter, ResId res, std::string_view name, Resources &rResources, PkgId pkg)
+{
+    ImporterData &rImportData = rResources.data_add<ImporterData>(restypes::gc_importer, res);
+
+    // Combine resource names. Maybe make this customizable
+    // ie: name = "dir/file.gltf" and resName = "mytexture"
+    // "dir/file.gltf:mytexture"
+    // "unnamed-[id]" is used as the resource name if it's empty
+    auto format_name = [tempStr = std::string{}, name]
+            (std::string_view resName, UnsignedInt id) mutable -> std::string const&
+    {
+        tempStr.clear();
+        if ( ! resName.empty())
+        {
+            string_append(tempStr, name, ":", resName);
+        }
+        else
+        {
+            // i don't like std::to_string but screw it, fix it later
+            string_append(tempStr, name, ":unnamed-", std::to_string(id));
+        }
+
+        return tempStr;
+    };
+
+    using namespace restypes;
+
+    // Load images
+    rImportData.m_images.resize(rImporter.image2DCount());
+    for (UnsignedInt i = 0; i < rImporter.image2DCount(); i ++)
+    {
+        Optional<ImageData2D> img = rImporter.image2D(i);
+
+        if ( ! bool(img) )
+        {
+            continue;
+        }
+
+        // Create and keep track of resource Id
+        ResId const imgRes = rResources.create(gc_image, pkg, format_name(rImporter.image2DName(i), i));
+        rImportData.m_images[i] = rResources.owner_create(gc_image, imgRes);
+
+        // Add image data to resource
+        rResources.data_add<ImageData2D>(gc_image, imgRes, std::move(*img));
+    }
+
+    // Load textures
+    rImportData.m_textures.resize(rImporter.textureCount());
+    for (UnsignedInt i = 0; i < rImporter.textureCount(); i ++)
+    {
+        Optional<TextureData> tex = rImporter.texture(i);
+
+        if ( ! bool(tex) )
+        {
+            continue;
+        }
+
+        // Create and keep track of resource Id
+        ResId const texRes = rResources.create(gc_texture, pkg, format_name(rImporter.textureName(i), i));
+        rImportData.m_textures[i] = rResources.owner_create(gc_texture, texRes);
+
+        // Add data to resource
+        rResources.data_add<TextureData>(gc_texture, texRes, std::move(*tex));
+
+        // Keep track of which image this texture uses
+        if (ResIdOwner_t const& imgRes = rImportData.m_images.at(tex->image());
+            imgRes.has_value())
+        {
+            ResIdOwner_t imgOwner = rResources.owner_create(gc_image, imgRes);
+            rResources.data_add<TextureImgSource>(gc_texture, texRes, TextureImgSource{std::move(imgOwner)} );
+        }
+    }
+
+    // load meshes
+    rImportData.m_meshes.resize(rImporter.meshCount());
+    for (UnsignedInt i = 0; i < rImporter.meshCount(); i ++)
+    {
+        Optional<MeshData> mesh = rImporter.mesh(i);
+
+        if ( ! bool(mesh) )
+        {
+            continue;
+        }
+
+        ResId const meshRes = rResources.create(gc_mesh, pkg, format_name(rImporter.meshName(i), i));
+        rResources.data_add<MeshData>(gc_mesh, meshRes, std::move(*mesh));
+        rImportData.m_meshes[i] = rResources.owner_create(gc_mesh, meshRes);
+    }
+
+    // copy custom properties
+    TinyGltfNodeExtras_t nodeExtras;
+    nodeExtras.resize(rImporter.object3DCount());
+    for (UnsignedInt i = 0; i < rImporter.object3DCount(); i ++)
+    {
+        Pointer<ObjectData3D> obj = rImporter.object3D(i);
+
+        if ( obj == nullptr )
+        {
+            continue;
+        }
+
+        tinygltf::Node const *pNode = static_cast<tinygltf::Node const*>(obj->importerState());
+
+        nodeExtras[i] = pNode->extras;
+
+    }
+
+    rImporter.object3DCount();
+}
+
+ResId osp::load_tinygltf_file(std::string_view filepath, Resources &rResources, PkgId pkg)
+{
+    PluginManager pluginManager;
+
+    // Create Importer resource
+    ResId const res = rResources.create(restypes::gc_importer, pkg, filepath);
+    TinyGltfImporter importer{pluginManager};
+
+    // note: Magnum master branch has a Corrade StringView version of this function
+    importer.openFile(std::string{filepath});
+
+    if (!importer.isOpened() || importer.defaultScene() == -1)
+    {
+        // TODO: delete resource (not yet implemented)
+        OSP_LOG_ERROR("Could not open file {}", filepath);
+        return lgrn::id_null<ResId>();
+    }
+
+    load_gltf(importer, res, filepath, rResources, pkg);
+
+    importer.close();
+
+    return res;
+}
+

--- a/src/osp/Resource/load_tinygltf.cpp
+++ b/src/osp/Resource/load_tinygltf.cpp
@@ -192,6 +192,12 @@ static void load_gltf(TinyGltfImporter &rImporter, ResId res, std::string_view n
     std::vector<int> topLevel;
     topLevel.reserve(rImporter.objectCount());
 
+    // Iterate all objects
+    for (UnsignedInt obj = 0; obj < rImporter.objectCount(); obj ++)
+    {
+        rImportData.m_objNames[obj] = rImporter.objectName(obj);
+    }
+
     // Iterate scenes and their objects
     for (UnsignedInt scn = 0; scn < rImporter.sceneCount(); scn ++)
     {
@@ -226,6 +232,13 @@ static void load_gltf(TinyGltfImporter &rImporter, ResId res, std::string_view n
                 else
                 {
                     topLevel.push_back(obj);
+                }
+
+                // Also store transforms here
+                if (Optional<Matrix4> objTf = scene->transformation3DFor(obj);
+                    bool(objTf))
+                {
+                    rImportData.m_objTransforms[obj] = *objTf;
                 }
             }
 

--- a/src/osp/Resource/load_tinygltf.h
+++ b/src/osp/Resource/load_tinygltf.h
@@ -31,8 +31,7 @@
 namespace osp
 {
 
-
-
+void register_tinygltf_resources(Resources &rResources);
 ResId load_tinygltf_file(std::string_view filepath, Resources &rResources, PkgId pkg);
 
 }

--- a/src/osp/Resource/load_tinygltf.h
+++ b/src/osp/Resource/load_tinygltf.h
@@ -1,0 +1,38 @@
+/**
+ * Open Space Program
+ * Copyright © 2019-2022 Open Space Program Project
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include "resourcetypes.h"
+
+#include <string_view>
+
+namespace osp
+{
+
+
+
+ResId load_tinygltf_file(std::string_view filepath, Resources &rResources, PkgId pkg);
+
+}

--- a/src/osp/Resource/resources.cpp
+++ b/src/osp/Resource/resources.cpp
@@ -71,6 +71,11 @@ ResId Resources::find(ResTypeId typeId, PkgId pkgId, std::string_view name) cons
     return findIt->second;
 }
 
+lgrn::IdRegistry<ResId> const& Resources::ids(ResTypeId typeId) const noexcept
+{
+    return get_type(typeId).m_resIds;
+}
+
 ResIdOwner_t Resources::owner_create(ResTypeId typeId, ResId resId) noexcept
 {
     PerResType &rPerResType = get_type(typeId);

--- a/src/osp/Resource/resources.h
+++ b/src/osp/Resource/resources.h
@@ -97,6 +97,8 @@ public:
 
     ResId find(ResTypeId typeId, PkgId pkgId, std::string_view name) const noexcept;
 
+    lgrn::IdRegistry<ResId> const& ids(ResTypeId typeId) const noexcept;
+
     [[nodiscard]] ResIdOwner_t owner_create(ResTypeId typeId, ResId resId) noexcept;
 
     void owner_destroy(ResTypeId typeId, ResIdOwner_t&& rOwner) noexcept;

--- a/src/osp/Resource/resourcetypes.h
+++ b/src/osp/Resource/resourcetypes.h
@@ -127,6 +127,8 @@ namespace restypes
 inline ResTypeId const gc_image         = resource_type_next();
 inline ResTypeId const gc_texture       = resource_type_next();
 inline ResTypeId const gc_mesh          = resource_type_next();
+inline ResTypeId const gc_importer      = resource_type_next();
+inline ResTypeId const gc_prefab        = resource_type_next();
 
 } // namespace restypes
 

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -370,6 +370,7 @@ void load_a_bunch_of_stuff()
     g_resources.data_register<osp::TextureImgSource>(gc_texture);
     g_resources.data_register<Trade::MeshData>(gc_mesh);
     g_resources.data_register<osp::ImporterData>(gc_importer);
+    osp::register_tinygltf_resources(g_resources);
     g_defaultPkg = g_resources.pkg_create();
 
     // Load sturdy glTF files


### PR DESCRIPTION
This adds a new general purpose glTF loader utilizing the new resource system. It's far less janky, and isn't specifically made for in-game parts compared to the old one. As of now, it's able to load all the existing gltf files without crashing 

The main loading code simply uses Magnum TinyGltfLoader to populate a "ImporterData" struct. ImporterData is independent of whatever importer was used, and is associated with a Resource Id.

In the future, code that loads OSP-specific data can simply read the ImporterData, and add new types to the Resource Id.