### PR TITLE
Implement rotations for CoordTransformer

### DIFF
--- a/test/universe/CMakeLists.txt
+++ b/test/universe/CMakeLists.txt
@@ -25,5 +25,5 @@
 PROJECT(test_universe CXX)
 ADD_TEST_DIRECTORY(${PROJECT_NAME})
 
-TARGET_LINK_LIBRARIES(test_universe longeron EnTT::EnTT Corrade::Main Magnum::Magnum)
+TARGET_LINK_LIBRARIES(test_universe longeron EnTT::EnTT Magnum::Magnum)
 TARGET_SOURCES(test_universe PRIVATE)


### PR DESCRIPTION
Planets rotate, the Active Area rotates, and transforming coordinates between them will lead to a rapid decline in sanity when taking the wrong approach. Luckily, there is now CoordTransformer.

CoordTransformer is useful for almost every operation involving coordinate spaces. eg:
* Transferring satellites between coordinate spaces
* Transforming positions of satellites to local-space for rendering

The implementation is quite algebra-heavy, and may take a while to fully understand. I find it quite mathematically elegant how some parts 'just work' or cancel out. I put heavy considerations in respecting integer range and floating point precision.

I did not intend to put this on the main repo, but oh well.