### PR TITLE
Re-implement Vehicle inertia and RCS Drivers

### DIFF
--- a/src/adera/machines/links.cpp
+++ b/src/adera/machines/links.cpp
@@ -49,7 +49,14 @@ float thruster_influence(Vector3 const pos, Vector3 const dir, Vector3 const cmd
      * In the future, it would be neat to implement PWM so that unthrottlable
      * thrusters would pulse on and off in order to deliver reduced thrust
      */
-    return std::clamp(angInfluence + linInfluence, 0.0f, 1.0f);
+    float const totalInfluence = std::clamp(angInfluence + linInfluence, 0.0f, 1.0f);
+
+    if (totalInfluence != totalInfluence) // if NaN
+    {
+        return 0.0f;
+    }
+
+    return totalInfluence;
 }
 
 

--- a/src/adera/machines/links.cpp
+++ b/src/adera/machines/links.cpp
@@ -1,12 +1,56 @@
 #include "links.h"
 
+using namespace osp;
+
 using osp::link::MachTypeReg_t;
 using osp::link::MachTypeId;
 
 namespace adera
 {
 
-MachTypeId const gc_mtUserCtrl = osp::link::MachTypeReg_t::create();
-MachTypeId const gc_mtMagicRocket = osp::link::MachTypeReg_t::create();
+MachTypeId const gc_mtUserCtrl      = MachTypeReg_t::create();
+MachTypeId const gc_mtMagicRocket   = MachTypeReg_t::create();
+MachTypeId const gc_mtRcsDriver     = MachTypeReg_t::create();
+
+float thruster_influence(Vector3 const pos, Vector3 const dir, Vector3 const cmdLin, Vector3 const cmdAng) noexcept
+{
+    using Magnum::Math::cross;
+    using Magnum::Math::dot;
+
+    // Thrust is applied in opposite direction of thruster nozzle direction
+    Vector3 const thrustDir = std::negate{}(dir.normalized());
+
+    float angInfluence = 0.0f;
+    if (cmdAng.dot() > 0.0f)
+    {
+        Vector3 const torque = cross(pos, thrustDir).normalized();
+        angInfluence = dot(torque, cmdAng.normalized());
+    }
+
+    float linInfluence = 0.0f;
+    if (cmdLin.dot() > 0.0f)
+    {
+        linInfluence = dot(thrustDir, cmdLin.normalized());
+    }
+
+    // Total component of thrust in direction of command
+    float const total = angInfluence + linInfluence;
+
+    if (total < .01f)
+    {
+        /* Ignore small contributions from imprecision
+         * Real thrusters can't throttle this deep anyways, so if their
+         * contribution is this small, it'd be a waste of fuel to fire them.
+         */
+        return 0.0f;
+    }
+
+    /* Compute thruster throttle output demanded by current command.
+     * In the future, it would be neat to implement PWM so that unthrottlable
+     * thrusters would pulse on and off in order to deliver reduced thrust
+     */
+    return std::clamp(angInfluence + linInfluence, 0.0f, 1.0f);
+}
+
 
 } // namespace adera

--- a/src/adera/machines/links.cpp
+++ b/src/adera/machines/links.cpp
@@ -36,7 +36,7 @@ float thruster_influence(Vector3 const pos, Vector3 const dir, Vector3 const cmd
     // Total component of thrust in direction of command
     float const total = angInfluence + linInfluence;
 
-    if (total < .01f)
+    if (total < 0.01f)
     {
         /* Ignore small contributions from imprecision
          * Real thrusters can't throttle this deep anyways, so if their

--- a/src/adera/machines/links.h
+++ b/src/adera/machines/links.h
@@ -52,6 +52,8 @@ using osp::link::gc_ntSigFloat;
 using osp::link::gc_sigIn;
 
 PortEntry const gc_throttleIn       { gc_ntSigFloat, 0, gc_sigIn };
+PortEntry const gc_multiplierIn     { gc_ntSigFloat, 1, gc_sigIn };
+
 }
 
 } // namespace adera

--- a/src/adera/machines/links.h
+++ b/src/adera/machines/links.h
@@ -39,6 +39,8 @@ extern osp::link::MachTypeId const gc_mtUserCtrl;
 extern osp::link::MachTypeId const gc_mtMagicRocket;
 extern osp::link::MachTypeId const gc_mtRcsDriver;
 
+constexpr osp::Vector3 gc_rocketForward{0.0f, 0.0f, 1.0f};
+
 namespace ports_userctrl
 {
 PortEntry const gc_throttleOut      { gc_ntSigFloat, 0, gc_sigOut };

--- a/src/adera/machines/links.h
+++ b/src/adera/machines/links.h
@@ -30,15 +30,17 @@
 namespace adera
 {
 
+using osp::link::PortEntry;
+using osp::link::gc_ntSigFloat;
+using osp::link::gc_sigIn;
+using osp::link::gc_sigOut;
+
 extern osp::link::MachTypeId const gc_mtUserCtrl;
 extern osp::link::MachTypeId const gc_mtMagicRocket;
+extern osp::link::MachTypeId const gc_mtRcsDriver;
 
 namespace ports_userctrl
 {
-using osp::link::PortEntry;
-using osp::link::gc_ntSigFloat;
-using osp::link::gc_sigOut;
-
 PortEntry const gc_throttleOut      { gc_ntSigFloat, 0, gc_sigOut };
 PortEntry const gc_pitchOut         { gc_ntSigFloat, 1, gc_sigOut };
 PortEntry const gc_yawOut           { gc_ntSigFloat, 2, gc_sigOut };
@@ -47,13 +49,27 @@ PortEntry const gc_rollOut          { gc_ntSigFloat, 3, gc_sigOut };
 
 namespace ports_magicrocket
 {
-using osp::link::PortEntry;
-using osp::link::gc_ntSigFloat;
-using osp::link::gc_sigIn;
-
 PortEntry const gc_throttleIn       { gc_ntSigFloat, 0, gc_sigIn };
 PortEntry const gc_multiplierIn     { gc_ntSigFloat, 1, gc_sigIn };
-
 }
+
+namespace ports_rcsdriver
+{
+PortEntry const gc_posXIn           { gc_ntSigFloat, 0, gc_sigIn };
+PortEntry const gc_posYIn           { gc_ntSigFloat, 1, gc_sigIn };
+PortEntry const gc_posZIn           { gc_ntSigFloat, 2, gc_sigIn };
+PortEntry const gc_dirXIn           { gc_ntSigFloat, 3, gc_sigIn };
+PortEntry const gc_dirYIn           { gc_ntSigFloat, 4, gc_sigIn };
+PortEntry const gc_dirZIn           { gc_ntSigFloat, 5, gc_sigIn };
+PortEntry const gc_cmdLinXIn        { gc_ntSigFloat, 6, gc_sigIn };
+PortEntry const gc_cmdLinYIn        { gc_ntSigFloat, 7, gc_sigIn };
+PortEntry const gc_cmdLinZIn        { gc_ntSigFloat, 8, gc_sigIn };
+PortEntry const gc_cmdAngXIn        { gc_ntSigFloat, 9, gc_sigIn };
+PortEntry const gc_cmdAngYIn        { gc_ntSigFloat, 10, gc_sigIn };
+PortEntry const gc_cmdAngZIn        { gc_ntSigFloat, 11, gc_sigIn };
+PortEntry const gc_throttleOut      { gc_ntSigFloat, 12, gc_sigOut };
+}
+
+float thruster_influence(osp::Vector3 pos, osp::Vector3 dir, osp::Vector3 cmdLin, osp::Vector3 cmdAng) noexcept;
 
 } // namespace adera

--- a/src/newtondynamics_physics/SysNewton.cpp
+++ b/src/newtondynamics_physics/SysNewton.cpp
@@ -63,9 +63,6 @@ using osp::active::ACtxPhysics;
 using osp::active::SysPhysics;
 using osp::active::SysSceneGraph;
 
-using osp::active::ACompShape;
-
-
 using osp::Matrix3;
 using osp::Matrix4;
 using osp::Vector3;

--- a/src/newtondynamics_physics/SysNewton.h
+++ b/src/newtondynamics_physics/SysNewton.h
@@ -52,8 +52,6 @@ class SysNewton
     using ACtxPhysics               = osp::active::ACtxPhysics;
     using ACtxSceneGraph            = osp::active::ACtxSceneGraph;
     using ACompTransform            = osp::active::ACompTransform;
-    using ACompTransformControlled  = osp::active::ACompTransformControlled;
-    using ACompTransformMutable     = osp::active::ACompTransformMutable;
 public:
 
     using NwtThreadIndex_t = int;
@@ -168,23 +166,6 @@ private:
             ActiveEnt                               ent,
             osp::Matrix4 const&                     transform,
             NewtonCollision*                        pCompound) noexcept;
-
-    /**
-     * @brief Create Newton bodies and colliders for entities with ACompPhysBody
-     *
-     * @param rScene    [ref] ActiveScene containing entity and physics world
-     * @param entity    [in] Entity containing ACompNwtBody
-     * @param pNwtWorld [in] Newton physics world
-     */
-    static void create_body(
-            ACtxPhysics const& rCtxPhys,
-            ACtxNwtWorld& rCtxWorld,
-            ACtxSceneGraph const& rScnGraph,
-            acomp_storage_t<ACompTransform> const& rTf,
-            acomp_storage_t<ACompTransformControlled>& rTfControlled,
-            acomp_storage_t<ACompTransformMutable>& rTfMutable,
-            ActiveEnt ent,
-            NewtonWorld const* pNwtWorld) noexcept;
 
 };
 

--- a/src/newtondynamics_physics/ospnewton.h
+++ b/src/newtondynamics_physics/ospnewton.h
@@ -29,6 +29,7 @@
 #include <osp/Active/activetypes.h>
 #include <osp/Active/basic.h>
 #include <osp/id_map.h>
+#include <osp/bitvector.h>
 
 #include <Newton.h>
 
@@ -92,6 +93,7 @@ struct ACtxNwtWorld
     lgrn::IdRegistryStl<BodyId>                     m_bodyIds;
     std::vector<NwtBodyPtr_t>                       m_bodyPtrs;
     std::vector<ForceFactors_t>                     m_bodyFactors;
+    osp::BitVector_t                                m_bodyDirty;
 
     std::vector<osp::active::ActiveEnt>             m_bodyToEnt;
     osp::IdMap_t<osp::active::ActiveEnt, BodyId>    m_entToBody;

--- a/src/osp/Active/SysPhysics.cpp
+++ b/src/osp/Active/SysPhysics.cpp
@@ -4,14 +4,45 @@
 using namespace osp;
 using namespace osp::active;
 
-
-void SysPhysics::calculate_subtree_mass_inertia(
+void SysPhysics::calculate_subtree_mass_center(
         acomp_storage_t<ACompTransform> const&  rTf,
         ACtxPhysics&                            rCtxPhys,
         ACtxSceneGraph&                         rScnGraph,
         ActiveEnt                               root,
         Vector3&                                rMassPos,
         float&                                  rTotalMass,
+        Matrix4 const&                          currentTf)
+{
+    for (ActiveEnt const child : SysSceneGraph::children(rScnGraph, root))
+    {
+        Matrix4 const childTf = currentTf * rTf.get(child).m_transform;
+
+        if (rCtxPhys.m_mass.contains(child))
+        {
+            ACompMass const& childMass = rCtxPhys.m_mass.get(child);
+
+            Matrix3 inertiaTensor{};
+            inertiaTensor[0][0] = childMass.m_inertia.x();
+            inertiaTensor[1][1] = childMass.m_inertia.y();
+            inertiaTensor[2][2] = childMass.m_inertia.z();
+
+            rTotalMass  += childMass.m_mass;
+            rMassPos    += childTf.translation() * childMass.m_mass;
+        }
+
+        if (rCtxPhys.m_hasColliders.test(std::size_t(child)))
+        {
+            calculate_subtree_mass_center(rTf, rCtxPhys, rScnGraph, child, rMassPos, rTotalMass, childTf);
+        }
+    }
+}
+
+
+void SysPhysics::calculate_subtree_mass_inertia(
+        acomp_storage_t<ACompTransform> const&  rTf,
+        ACtxPhysics&                            rCtxPhys,
+        ACtxSceneGraph&                         rScnGraph,
+        ActiveEnt                               root,
         Matrix3&                                rInertiaTensor,
         Matrix4 const&                          currentTf)
 {
@@ -31,14 +62,11 @@ void SysPhysics::calculate_subtree_mass_inertia(
             Vector3 const offset = childTf.translation() + childMass.m_offset * childTf.scaling();
 
             rInertiaTensor += phys::transform_inertia_tensor(inertiaTensor, childMass.m_mass, offset, childTf.rotation());
-
-            rTotalMass  += childMass.m_mass;
-            rMassPos    += childTf.translation() * childMass.m_mass;
         }
 
         if (rCtxPhys.m_hasColliders.test(std::size_t(child)))
         {
-            calculate_subtree_mass_inertia(rTf, rCtxPhys, rScnGraph, child, rMassPos, rTotalMass, rInertiaTensor, childTf);
+            calculate_subtree_mass_inertia(rTf, rCtxPhys, rScnGraph, child, rInertiaTensor, childTf);
         }
     }
 }

--- a/src/osp/Active/SysPhysics.cpp
+++ b/src/osp/Active/SysPhysics.cpp
@@ -4,29 +4,41 @@
 using namespace osp;
 using namespace osp::active;
 
-void SysPhysics::update_subtree_mass_inertia(ACtxPhysics& rCtxPhys, ACtxSceneGraph& rScnGraph, ActiveEnt ent, ACompMass& rHierMass)
+
+void SysPhysics::calculate_subtree_mass_inertia(
+        acomp_storage_t<ACompTransform> const&  rTf,
+        ACtxPhysics&                            rCtxPhys,
+        ACtxSceneGraph&                         rScnGraph,
+        ActiveEnt                               root,
+        Vector3&                                rMassPos,
+        float&                                  rTotalMass,
+        Matrix3&                                rInertiaTensor,
+        Matrix4 const&                          currentTf)
 {
-#if 0
-    rCtxPhys.m_hierMassDirty.reset(std::size_t(ent));
-
-    ACompMass hierMassTotal;
-
-    for (ActiveEnt const childEnt : SysSceneGraph::children(rScnGraph, ent))
+    for (ActiveEnt const child : SysSceneGraph::children(rScnGraph, root))
     {
+        Matrix4 const childTf = currentTf * rTf.get(child).m_transform;
 
-
-        if (rCtxPhys.m_hierMass.contains(childEnt))
+        if (rCtxPhys.m_mass.contains(child))
         {
-            if (rCtxPhys.m_hierMassDirty.test(std::size_t(childEnt)))
-            {
-                //update_subtree_mass_inertia
-            }
+            ACompMass const& childMass = rCtxPhys.m_mass.get(child);
 
-            phys::transform_inertia_tensor()
+            Matrix3 inertiaTensor{};
+            inertiaTensor[0][0] = childMass.m_inertia.x();
+            inertiaTensor[1][1] = childMass.m_inertia.y();
+            inertiaTensor[2][2] = childMass.m_inertia.z();
+
+            Vector3 const offset = childTf.translation() + childMass.m_offset * childTf.scaling();
+
+            rInertiaTensor += phys::transform_inertia_tensor(inertiaTensor, childMass.m_mass, offset, childTf.rotation());
+
+            rTotalMass  += childMass.m_mass;
+            rMassPos    += childTf.translation() * childMass.m_mass;
         }
 
-
-        if (rCtxPhys.m_ownMass)
+        if (rCtxPhys.m_hasColliders.test(std::size_t(child)))
+        {
+            calculate_subtree_mass_inertia(rTf, rCtxPhys, rScnGraph, child, rMassPos, rTotalMass, rInertiaTensor, childTf);
+        }
     }
-#endif
 }

--- a/src/osp/Active/SysPhysics.cpp
+++ b/src/osp/Active/SysPhysics.cpp
@@ -1,2 +1,32 @@
 #include "SysPhysics.h"
-#include "basic.h"
+#include "SysSceneGraph.h"
+
+using namespace osp;
+using namespace osp::active;
+
+void SysPhysics::update_subtree_mass_inertia(ACtxPhysics& rCtxPhys, ACtxSceneGraph& rScnGraph, ActiveEnt ent, ACompMass& rHierMass)
+{
+#if 0
+    rCtxPhys.m_hierMassDirty.reset(std::size_t(ent));
+
+    ACompMass hierMassTotal;
+
+    for (ActiveEnt const childEnt : SysSceneGraph::children(rScnGraph, ent))
+    {
+
+
+        if (rCtxPhys.m_hierMass.contains(childEnt))
+        {
+            if (rCtxPhys.m_hierMassDirty.test(std::size_t(childEnt)))
+            {
+                //update_subtree_mass_inertia
+            }
+
+            phys::transform_inertia_tensor()
+        }
+
+
+        if (rCtxPhys.m_ownMass)
+    }
+#endif
+}

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -53,13 +53,13 @@ public:
             Matrix3&                                rInertiaTensor,
             Matrix4 const&                          currentTf = {});
 
-    template<typename IT_T>
-    static void update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, IT_T const& last);
+    template<typename IT_T, typename ITB_T>
+    static void update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, ITB_T const& last);
 
 };
 
-template<typename IT_T>
-void SysPhysics::update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, IT_T const& last)
+template<typename IT_T, typename ITB_T>
+void SysPhysics::update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, ITB_T const& last)
 {
     rCtxPhys.m_mass.remove(first, last);
 }

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -36,7 +36,15 @@ class SysPhysics
 {
 public:
 
-    static void update_subtree_mass_inertia(ACtxPhysics& rCtxPhys, ACtxSceneGraph& rScnGraph, ActiveEnt ent, ACompMass& rHierMass);
+    static void calculate_subtree_mass_inertia(
+            acomp_storage_t<ACompTransform> const&  rTf,
+            ACtxPhysics&                            rCtxPhys,
+            ACtxSceneGraph&                         rScnGraph,
+            ActiveEnt                               root,
+            Vector3&                                rMassPos,
+            float&                                  rTotalMass,
+            Matrix3&                                rInertiaTensor,
+            Matrix4 const&                          currentTf = {});
 
     template<typename IT_T>
     static void update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, IT_T const& last);

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -36,13 +36,20 @@ class SysPhysics
 {
 public:
 
-    static void calculate_subtree_mass_inertia(
+    static void calculate_subtree_mass_center(
             acomp_storage_t<ACompTransform> const&  rTf,
             ACtxPhysics&                            rCtxPhys,
             ACtxSceneGraph&                         rScnGraph,
             ActiveEnt                               root,
             Vector3&                                rMassPos,
             float&                                  rTotalMass,
+            Matrix4 const&                          currentTf = {});
+
+    static void calculate_subtree_mass_inertia(
+            acomp_storage_t<ACompTransform> const&  rTf,
+            ACtxPhysics&                            rCtxPhys,
+            ACtxSceneGraph&                         rScnGraph,
+            ActiveEnt                               root,
             Matrix3&                                rInertiaTensor,
             Matrix4 const&                          currentTf = {});
 

--- a/src/osp/Active/SysPhysics.h
+++ b/src/osp/Active/SysPhysics.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "physics.h"
+#include "basic.h"
 
 namespace osp::active
 {
@@ -35,22 +36,17 @@ class SysPhysics
 {
 public:
 
-    enum EIncludeRootMass { Ignore, Include };
-
-    // TODO: rewrite hierarchy inertia calculations for new mass/inertia system
+    static void update_subtree_mass_inertia(ACtxPhysics& rCtxPhys, ACtxSceneGraph& rScnGraph, ActiveEnt ent, ACompMass& rHierMass);
 
     template<typename IT_T>
-    static void update_delete_phys(
-            ACtxPhysics &rCtxPhys, IT_T first, IT_T const& last);
+    static void update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, IT_T const& last);
 
 };
 
 template<typename IT_T>
-void SysPhysics::update_delete_phys(
-        ACtxPhysics &rCtxPhys, IT_T first, IT_T const& last)
+void SysPhysics::update_delete_phys(ACtxPhysics& rCtxPhys, IT_T const& first, IT_T const& last)
 {
-    rCtxPhys.m_ownDyn.remove(first, last);
-    rCtxPhys.m_totalDyn.remove(first, last);
+    rCtxPhys.m_mass.remove(first, last);
 }
 
 

--- a/src/osp/Active/SysPrefabInit.cpp
+++ b/src/osp/Active/SysPrefabInit.cpp
@@ -246,20 +246,22 @@ void SysPrefabInit::init_physics(
             float const     mass        = rPrefabData.m_objMass[objectId];
             EShape const    shape       = rPrefabData.m_objShape[objectId];
 
+
             rCtxPhys.m_shape[std::size_t(ent)] = shape;
-            if (shape != EShape::None)
+
+            if (mass != 0.0f)
+            {
+                Vector3 const scale = rImportData.m_objTransforms[objectId].scaling();
+                Vector3 const inertia = phys::collider_inertia_tensor(shape, scale, mass);
+                Vector3 const offset{0.0f, 0.0f, 0.0f};
+                rCtxPhys.m_mass.emplace( ent, ACompMass{ offset, inertia, mass } );
+
+                //assign_dyn_recurse(assign_dyn_recurse, objectId, ent);
+            }
+
+            if ( (mass != 0.0f) || (shape != EShape::None) )
             {
                 assign_collider_recurse(assign_collider_recurse, objectId, ent);
-
-                if (mass != 0.0f)
-                {
-                    Vector3 const scale = rImportData.m_objTransforms[objectId].scaling();
-                    Vector3 const inertia = phys::collider_inertia_tensor(shape, scale, mass);
-                    Vector3 const offset{0.0f, 0.0f, 0.0f};
-                    rCtxPhys.m_mass.emplace( ent, ACompMass{ inertia, offset, mass } );
-
-                    //assign_dyn_recurse(assign_dyn_recurse, objectId, ent);
-                }
             }
         }
 

--- a/src/osp/Active/SysPrefabInit.cpp
+++ b/src/osp/Active/SysPrefabInit.cpp
@@ -197,9 +197,9 @@ void SysPrefabInit::init_physics(
         auto const &rPrefabData = rResources.data_get<osp::Prefabs const>(
                 gc_importer, rPfBasic.m_importerRes);
 
-        ArrayView<ActiveEnt const>  ents        = *itPfEnts;
-        lgrn::Span<int const>       objects     = rPrefabData.m_prefabs[rPfBasic.m_prefabId];
-        lgrn::Span<int const>       parents     = rPrefabData.m_prefabParents[rPfBasic.m_prefabId];
+        auto const ents     = ArrayView<ActiveEnt const>{*itPfEnts};
+        auto const objects  = lgrn::Span<int const>     {rPrefabData.m_prefabs[rPfBasic.m_prefabId]};
+        auto const parents  = lgrn::Span<int const>     {rPrefabData.m_prefabParents[rPfBasic.m_prefabId]};
 
 #if 0
         auto const assign_dyn_recurse = [&rCtxPhys, ents, objects, parents] (auto const& self, int objectId, ActiveEnt ent) -> void

--- a/src/osp/Active/basic.h
+++ b/src/osp/Active/basic.h
@@ -42,29 +42,6 @@ struct ACompTransform
     osp::Matrix4 m_transform;
 };
 
-// TODO: this scheme of controlled and mutable likely isn't the best, maybe
-//       consider other options
-
-/**
- * @brief Indicates that an entity's ACompTransform is owned by some specific
- *        system, and shouldn't be modified freely.
- *
- * This can be used by a physics or animation system, which may set the
- * transform each frame.
- */
-struct ACompTransformControlled { };
-
-/**
- * @brief Allows mutation for entities with ACompTransformControlled, as long as
- *        a dirty flag is set.
- */
-struct ACompTransformMutable{ bool m_dirty{false}; };
-
-/**
- * @brief The ACompFloatingOrigin struct
- */
-struct ACompFloatingOrigin { };
-
 /**
  * @brief Simple name component
  */
@@ -105,16 +82,12 @@ struct ACtxBasic
     ACtxSceneGraph m_scnGraph;
 
     acomp_storage_t<ACompTransform>             m_transform;
-    acomp_storage_t<ACompTransformControlled>   m_transformControlled;
-    acomp_storage_t<ACompTransformMutable>      m_transformMutable;
-    acomp_storage_t<ACompFloatingOrigin>        m_floatingOrigin;
     acomp_storage_t<ACompName>                  m_name;
 };
 
 template<typename IT_T>
 void update_delete_basic(ACtxBasic &rCtxBasic, IT_T first, IT_T const& last)
 {
-    rCtxBasic.m_floatingOrigin  .remove(first, last);
     rCtxBasic.m_name            .remove(first, last);
 
     while (first != last)
@@ -124,8 +97,6 @@ void update_delete_basic(ACtxBasic &rCtxBasic, IT_T first, IT_T const& last)
         if (rCtxBasic.m_transform.contains(ent))
         {
             rCtxBasic.m_transform           .remove(ent);
-            rCtxBasic.m_transformControlled .remove(ent);
-            rCtxBasic.m_transformMutable    .remove(ent);
 
         }
 

--- a/src/osp/Active/parts.h
+++ b/src/osp/Active/parts.h
@@ -43,14 +43,18 @@ using WeldId = uint32_t;
 
 struct Parts
 {
+    using MapPartToMachines_t = lgrn::IntArrayMultiMap<PartId, link::MachinePair>;
+
     lgrn::IdRegistryStl<PartId>                     m_partIds;
     std::vector<PrefabPair>                         m_partPrefabs;
     std::vector<WeldId>                             m_partToWeld;
     std::vector<Matrix4>                            m_partTransformWeld;
-    lgrn::IntArrayMultiMap<PartId, link::MachAnyId> m_partToMachines;
+    MapPartToMachines_t                             m_partToMachines;
+    std::vector<WeldId>                             m_partDirty;
 
     lgrn::IdRegistryStl<WeldId>                     m_weldIds;
     lgrn::IntArrayMultiMap<WeldId, PartId>          m_weldToParts;
+    std::vector<WeldId>                             m_weldDirty;
 
     link::Machines                                  m_machines;
     std::vector<PartId>                             m_machineToPart;

--- a/src/osp/Active/parts.h
+++ b/src/osp/Active/parts.h
@@ -68,8 +68,9 @@ struct ACtxParts : Parts
     std::vector<ActiveEnt>                          m_weldToEnt;
 };
 
-using NewPartId = uint32_t;
-using NewWeldId = uint32_t;
+using NewVehicleId  = uint32_t;
+using NewPartId     = uint32_t;
+using NewWeldId     = uint32_t;
 
 struct ACtxVehicleSpawn
 {
@@ -85,17 +86,19 @@ struct ACtxVehicleSpawn
         return m_newVhBasicIn.size();
     }
 
-    std::vector<TmpToInit>      m_newVhBasicIn;
-    std::vector<NewPartId>      m_newVhPartOffsets;
-    std::vector<NewWeldId>      m_newVhWeldOffsets;
+    std::vector<TmpToInit>          m_newVhBasicIn;
+    std::vector<NewPartId>          m_newVhPartOffsets;
+    std::vector<NewWeldId>          m_newVhWeldOffsets;
 
-    std::vector<PartId>         m_newPartToPart;
-    std::vector<uint32_t>       m_newPartPrefabs;
+    std::vector<PartId>             m_newPartToPart;
+    std::vector<uint32_t>           m_newPartPrefabs;
 
-    std::vector<NewPartId>      m_partToNewPart;
+    std::vector<NewPartId>          m_partToNewPart;
 
-    std::vector<WeldId>         m_newWeldToWeld;
-    std::vector<ActiveEnt>      m_newWeldToEnt;
+    std::vector<WeldId>             m_newWeldToWeld;
+    std::vector<ActiveEnt>          m_newWeldToEnt;
+
+    std::vector<link::MachAnyId>    m_newMachToMach;
 };
 
 } // namespace osp::active

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -32,24 +32,14 @@
 namespace osp::active
 {
 
-//using RigidBodyId_t = uint32_t;
-
-/**
- * @brief Represents the shape of an entity
- */
-struct ACompShape
-{
-    phys::EShape m_shape{phys::EShape::None};
-};
-
 /**
  * @brief Generic Mass and inertia intended for entities
  */
-struct ACompSubBody
+struct ACompMass
 {
     Vector3 m_offset;
     Vector3 m_inertia;
-    float m_mass;
+    float   m_mass;
 };
 
 /**
@@ -60,13 +50,12 @@ struct ACtxPhysics
     std::vector<phys::EShape>       m_shape;
     EntSet_t                        m_hasColliders;
 
-    acomp_storage_t<ACompSubBody>   m_ownDyn;
-    acomp_storage_t<ACompSubBody>   m_totalDyn;
+    acomp_storage_t<ACompMass>      m_mass;
+
 
     Vector3                         m_originTranslate;
-    EntVector_t                     m_bodyDirty;
+
     EntVector_t                     m_colliderDirty;
-    EntVector_t                     m_inertiaDirty;
 
     std::vector< std::pair<ActiveEnt, Vector3> > m_setVelocity;
 

--- a/src/osp/CommonPhysics.cpp
+++ b/src/osp/CommonPhysics.cpp
@@ -73,6 +73,8 @@ Vector3 collider_inertia_tensor(EShape shape, Vector3 scale, float mass)
 {
     switch (shape)
     {
+    case EShape::None:
+        return Vector3{0.0f};
     case EShape::Cylinder:
     {
         // Default cylinder dimensions: radius 1, height 2

--- a/src/osp/bitvector.h
+++ b/src/osp/bitvector.h
@@ -34,7 +34,7 @@ namespace osp
 
 using BitVector_t = lgrn::BitView< std::vector<uint64_t> >;
 
-constexpr void bitvector_resize(BitVector_t &rBitVector, std::size_t size)
+inline void bitvector_resize(BitVector_t &rBitVector, std::size_t size)
 {
     rBitVector.ints().resize(size / 64 + (size % 64 != 0));
 }

--- a/src/osp/bitvector.h
+++ b/src/osp/bitvector.h
@@ -24,26 +24,17 @@
  */
 #pragma once
 
-#include <cstddef>
+#include <longeron/containers/bit_view.hpp>
+
+#include <cstdint>
+#include <vector>
 
 namespace osp
 {
 
-template <typename ID_T, typename DUMMY_T = void>
-struct GlobalIdReg
-{
-    [[nodiscard]] static inline ID_T create() noexcept
-    {
-        return ID_T(sm_count++);
-    }
-
-    [[nodiscard]] static inline std::size_t size() noexcept
-    {
-        return sm_count;
-    }
-
-private:
-    static inline std::size_t sm_count{0};
-};
+using BitVector_t = lgrn::BitView< std::vector<uint64_t> >;
 
 } // namespace osp
+
+
+

--- a/src/osp/bitvector.h
+++ b/src/osp/bitvector.h
@@ -34,6 +34,11 @@ namespace osp
 
 using BitVector_t = lgrn::BitView< std::vector<uint64_t> >;
 
+constexpr void bitvector_resize(BitVector_t &rBitVector, std::size_t size)
+{
+    rBitVector.ints().resize(size / 64 + (size % 64 != 0));
+}
+
 } // namespace osp
 
 

--- a/src/osp/link/machines.cpp
+++ b/src/osp/link/machines.cpp
@@ -29,34 +29,6 @@ namespace osp::link
 
 NodeTypeId const gc_ntSigFloat = NodeTypeReg_t::create();
 
-void copy_machines(
-        Machines const &rSrc,
-        Machines &rDst,
-        Corrade::Containers::ArrayView<MachAnyId> remapMachOut)
-{
-
-    for (MachAnyId const srcMach : rSrc.m_ids.bitview().zeros())
-    {
-        MachTypeId const srcType = rSrc.m_machTypes[srcMach];
-        PerMachType &rDstPerMach = rDst.m_perType[srcType];
-
-        // TODO: optimize multiple calls to IdRegistryStl::create()
-        //       (linear search for non-zero uint64_t is done each call)
-        MachAnyId const dstMach = rDst.m_ids.create();
-        MachLocalId const dstLocal = rDstPerMach.m_localIds.create();
-
-        // TODO: allocate once before this for loop
-        rDst.m_machToLocal.resize(rDst.m_ids.capacity());
-        rDst.m_machTypes.resize(rDst.m_ids.capacity());
-        rDstPerMach.m_localToAny.resize(rDstPerMach.m_localIds.capacity());
-
-        rDstPerMach.m_localToAny[dstLocal]  = dstMach;
-        rDst.m_machTypes[dstMach]           = srcType;
-        rDst.m_machToLocal[dstMach]         = dstLocal;
-
-        remapMachOut[srcMach] = dstMach;
-    }
-}
 
 void copy_nodes(
         Nodes const &rSrcNodes,

--- a/src/osp/link/machines.cpp
+++ b/src/osp/link/machines.cpp
@@ -90,7 +90,9 @@ void copy_nodes(
             auto dstPortIt = std::begin(dstPorts);
             for (NodeId const srcNode : srcPorts)
             {
-                *dstPortIt = remapNode[srcNode];
+                *dstPortIt = (srcNode != lgrn::id_null<NodeId>())
+                           ? remapNode[srcNode]
+                           : lgrn::id_null<NodeId>();
 
                 std::advance(dstPortIt, 1);
             }

--- a/src/osp/link/machines.h
+++ b/src/osp/link/machines.h
@@ -48,7 +48,7 @@ using PortId        = uint16_t;
 using JunctionId    = uint16_t;
 using JuncCustom    = uint16_t;
 
-using MachTypeReg_t = GlobalIdReg<MachLocalId>;
+using MachTypeReg_t = GlobalIdReg<MachTypeId>;
 using NodeTypeReg_t = GlobalIdReg<NodeTypeId>;
 
 extern NodeTypeId const gc_ntSigFloat;

--- a/src/osp/link/machines.h
+++ b/src/osp/link/machines.h
@@ -83,10 +83,14 @@ struct UpdMachPerType
     std::vector<BitVector_t> m_localDirty;
 };
 
-struct Junction
+struct MachinePair
 {
     MachLocalId     m_local{lgrn::id_null<MachLocalId>()};
     MachTypeId      m_type{lgrn::id_null<MachTypeId>()};
+};
+
+struct Junction : MachinePair
+{
     JuncCustom      m_custom{0};
 };
 

--- a/src/osp/link/machines.h
+++ b/src/osp/link/machines.h
@@ -25,24 +25,17 @@
 #pragma once
 
 #include "../global_id.h"
+#include "../bitvector.h"
+#include "../types.h"
 
 #include <longeron/containers/intarray_multimap.hpp>
 #include <longeron/containers/bit_view.hpp>
 #include <longeron/id_management/registry_stl.hpp>
 
-#include <Corrade/Containers/ArrayView.h>
-
 #include <vector>
-
-namespace osp
-{
-using Corrade::Containers::ArrayView;
-}
 
 namespace osp::link
 {
-
-using BitVector_t = lgrn::BitView< std::vector<uint64_t> >;
 
 using MachTypeId    = uint16_t;
 using MachAnyId     = uint32_t;
@@ -133,15 +126,15 @@ inline NodeId connected_node(lgrn::Span<NodeId const> portSpan, PortId port) noe
 void copy_machines(
         Machines const &rSrc,
         Machines &rDst,
-        Corrade::Containers::ArrayView<MachAnyId> remapMachOut);
+        ArrayView<MachAnyId> remapMachOut);
 
 void copy_nodes(
         Nodes const &rSrcNodes,
         Machines const &rSrcMach,
-        Corrade::Containers::ArrayView<MachAnyId const> remapMach,
+        ArrayView<MachAnyId const> remapMach,
         Nodes &rDstNodes,
         Machines &rDstMach,
-        Corrade::Containers::ArrayView<NodeId> remapNodeOut);
+        ArrayView<NodeId> remapNodeOut);
 
 
 } // namespace osp::wire

--- a/src/osp/link/machines.h
+++ b/src/osp/link/machines.h
@@ -89,8 +89,10 @@ struct MachinePair
     MachTypeId      m_type{lgrn::id_null<MachTypeId>()};
 };
 
-struct Junction : MachinePair
+struct Junction
 {
+    MachLocalId     m_local{lgrn::id_null<MachLocalId>()};
+    MachTypeId      m_type{lgrn::id_null<MachTypeId>()};
     JuncCustom      m_custom{0};
 };
 

--- a/src/osp/link/signal.h
+++ b/src/osp/link/signal.h
@@ -26,8 +26,6 @@
 
 #include "machines.h"
 
-#include <Corrade/Containers/ArrayView.h>
-
 namespace osp::link
 {
 
@@ -55,8 +53,8 @@ bool update_signal_nodes(
         RANGE_T const&                                  toUpdate,
         Nodes::NodeToMach_t const&                      nodeToMach,
         Machines const&                                 machines,
-        Corrade::Containers::ArrayView<VALUE_T const>   newValues,
-        Corrade::Containers::ArrayView<VALUE_T>         currentValues,
+        ArrayView<VALUE_T const>   newValues,
+        ArrayView<VALUE_T>         currentValues,
         UpdMachPerType&                                 rUpdMach)
 {
     bool somethingNotified = false;

--- a/src/osp/link/signal.h
+++ b/src/osp/link/signal.h
@@ -41,8 +41,11 @@ struct UpdateNodes
     BitVector_t                 m_nodeDirty;
     SignalValues_t<VALUE_T>     m_nodeNewValues;
 
-    void assign(NodeId node, VALUE_T&& value)
+    bool                        m_dirty{false};
+
+    void assign(NodeId node, VALUE_T value)
     {
+        m_dirty = true;
         m_nodeDirty.set(node);
         m_nodeNewValues[node] = std::forward<VALUE_T>(value);
     }
@@ -50,12 +53,12 @@ struct UpdateNodes
 
 template <typename VALUE_T, typename RANGE_T>
 bool update_signal_nodes(
-        RANGE_T const&                                  toUpdate,
-        Nodes::NodeToMach_t const&                      nodeToMach,
-        Machines const&                                 machines,
-        ArrayView<VALUE_T const>   newValues,
-        ArrayView<VALUE_T>         currentValues,
-        UpdMachPerType&                                 rUpdMach)
+        RANGE_T const&                  toUpdate,
+        Nodes::NodeToMach_t const&      nodeToMach,
+        Machines const&                 machines,
+        ArrayView<VALUE_T const>        newValues,
+        ArrayView<VALUE_T>              currentValues,
+        UpdMachPerType&                 rUpdMach)
 {
     bool somethingNotified = false;
 

--- a/src/osp/tasks/execute_simple.cpp
+++ b/src/osp/tasks/execute_simple.cpp
@@ -192,6 +192,8 @@ void task_start(Tags const& tags, Tasks const& tasks, ExecutionContext &rExec, T
     {
         rExec.m_tagRunningCounts[tag] ++;
     }
+
+    rExec.m_taskQueuedCounts[std::size_t(task)] --;
 }
 
 void task_finish(Tags const& tags, Tasks const& tasks, ExecutionContext &rExec, TaskId const task)
@@ -216,8 +218,6 @@ void task_finish(Tags const& tags, Tasks const& tasks, ExecutionContext &rExec, 
             }
         }
     }
-
-    rExec.m_taskQueuedCounts[std::size_t(task)] --;
 }
 
 } // namespace osp

--- a/src/test_application/VehicleBuilder.cpp
+++ b/src/test_application/VehicleBuilder.cpp
@@ -257,10 +257,10 @@ VehicleData VehicleBuilder::finalize_release()
     // Assign part-to-machine partitions
     for (MachAnyId const mach : rData.m_machines.m_ids.bitview().zeros())
     {
-        MachLocalId const local = rData.m_machines.m_machToLocal[mach];
-        MachTypeId const  type  = rData.m_machines.m_machTypes[mach];
-        PartId const      part  = rData.m_machToPart[mach];
-        lgrn::Span<MachinePair> machines = rData.m_partToMachines[part];
+        MachLocalId const   local       = rData.m_machines.m_machToLocal[mach];
+        MachTypeId const    type        = rData.m_machines.m_machTypes[mach];
+        PartId const        part        = rData.m_machToPart[mach];
+        auto const          machines    = lgrn::Span<MachinePair>{rData.m_partToMachines[part]};
 
         // Reuse machine count to track how many are currently added.
         // By the end, these should all be zero

--- a/src/test_application/VehicleBuilder.cpp
+++ b/src/test_application/VehicleBuilder.cpp
@@ -214,9 +214,15 @@ VehicleData VehicleBuilder::finalize_release()
             lgrn::Span<NodeId> portSpan = rPerNodeType.m_machToNode[mach];
             lgrn::Span<JuncCustom> customSpan = rPerNodeType.m_machToNodeCustom[mach];
 
-            auto customIt = std::begin(customSpan);
-            for (NodeId node : portSpan)
+            for (int i = 0; i < portSpan.size(); ++i)
             {
+                NodeId node = portSpan[i];
+
+                if (node == lgrn::id_null<NodeId>())
+                {
+                    continue;
+                }
+
                 lgrn::Span<Junction> const juncSpan = rPerNodeType.m_nodeToMach[node];
 
                 // find empty spot
@@ -234,9 +240,7 @@ VehicleData VehicleBuilder::finalize_release()
 
                 found->m_local  = local;
                 found->m_type   = type;
-                found->m_custom = *customIt;
-
-                std::advance(customIt, 1);
+                found->m_custom = customSpan[i];
             }
         }
     }

--- a/src/test_application/VehicleBuilder.cpp
+++ b/src/test_application/VehicleBuilder.cpp
@@ -66,14 +66,14 @@ void VehicleBuilder::set_prefabs(std::initializer_list<SetPrefab> const& setPref
     }
 }
 
-WeldId VehicleBuilder::weld(std::initializer_list<SetTransform> const& setTransform)
+WeldId VehicleBuilder::weld(osp::ArrayView<PartToWeld const> toWeld)
 {
     WeldId const weld = m_data->m_weldIds.create();
     m_data->m_weldToParts.ids_reserve(m_data->m_weldIds.capacity());
 
-    PartId *pPartInWeld = m_data->m_weldToParts.emplace(weld, setTransform.size());
+    PartId *pPartInWeld = m_data->m_weldToParts.emplace(weld, toWeld.size());
 
-    for (SetTransform const& set : setTransform)
+    for (PartToWeld const& set : toWeld)
     {
         m_data->m_partTransformWeld[set.m_part] = set.m_transform;
 

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -103,6 +103,14 @@ class VehicleBuilder
 
 public:
 
+    struct PartToWeld
+    {
+        PartId m_part;
+        osp::Matrix4 m_transform;
+    };
+
+    using WeldVec_t = std::vector<VehicleBuilder::PartToWeld>;
+
     VehicleBuilder(osp::Resources *pResources)
      : m_pResources{pResources}
     {
@@ -125,13 +133,13 @@ public:
 
     void set_prefabs(std::initializer_list<SetPrefab> const& setPrefab);
 
-    struct SetTransform
-    {
-        PartId m_part;
-        osp::Matrix4 const& m_transform;
-    };
 
-    WeldId weld(std::initializer_list<SetTransform> const& setTransform);
+    WeldId weld(osp::ArrayView<PartToWeld const> toWeld);
+
+    WeldId weld(std::initializer_list<PartToWeld const> const& toWeld)
+    {
+        return weld(osp::arrayView(toWeld));
+    }
 
     osp::Matrix4 align_attach(PartId partA, std::string_view attachA,
                               PartId partB, std::string_view attachB);

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -218,8 +218,17 @@ template <typename VALUES_T>
 VALUES_T& VehicleBuilder::node_values(NodeTypeId nodeType)
 {
     PerNodeType &rPerNodeType = m_data->m_nodePerType[nodeType];
-    rPerNodeType.m_nodeValues.emplace<VALUES_T>();
-    return entt::any_cast<VALUES_T&>(rPerNodeType.m_nodeValues);
+
+    // Emplace values container if it doesn't exist
+    if ( ! bool(rPerNodeType.m_nodeValues))
+    {
+        rPerNodeType.m_nodeValues.emplace<VALUES_T>();
+    }
+
+    auto &rValues = entt::any_cast<VALUES_T&>(rPerNodeType.m_nodeValues);
+    rValues.resize(node_capacity(nodeType));
+
+    return rValues;
 }
 
 struct ACtxVehicleSpawnVB

--- a/src/test_application/VehicleBuilder.h
+++ b/src/test_application/VehicleBuilder.h
@@ -67,6 +67,7 @@ struct VehicleData
 {
     using MachToNodeCustom_t = lgrn::IntArrayMultiMap<osp::link::MachAnyId,
                                                       osp::link::JuncCustom>;
+    using MapPartToMachines_t = osp::active::Parts::MapPartToMachines_t;
 
     VehicleData() = default;
     VehicleData(VehicleData const& copy) = delete;
@@ -75,8 +76,8 @@ struct VehicleData
     lgrn::IdRegistryStl<PartId>             m_partIds;
     std::vector<osp::Matrix4>               m_partTransformWeld;
     std::vector<osp::PrefabPair>            m_partPrefabs;
-    std::vector<uint16_t>                   m_partMachCount;
     std::vector<WeldId>                     m_partToWeld;
+    MapPartToMachines_t                     m_partToMachines;
 
     lgrn::IdRegistryStl<WeldId>             m_weldIds;
     lgrn::IntArrayMultiMap<WeldId, PartId>  m_weldToParts;
@@ -156,6 +157,7 @@ private:
 
     entt::dense_map< std::string_view, osp::PrefabPair > m_prefabs;
 
+    std::vector<uint16_t> m_partMachCount;
     std::optional<VehicleData> m_data;
 
     // put more attachment data here
@@ -169,7 +171,7 @@ std::array<PartId, N> VehicleBuilder::create_parts()
     m_data->m_partIds.create(std::begin(out), std::end(out));
 
     std::size_t const capacity = m_data->m_partIds.capacity();
-    m_data->m_partMachCount         .resize(capacity);
+    m_partMachCount                 .resize(capacity);
     m_data->m_partPrefabs           .resize(capacity);
     m_data->m_partTransformWeld     .resize(capacity);
     m_data->m_partToWeld            .resize(capacity);

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -109,10 +109,10 @@
 
 #define OSP_DATA_TESTAPP_PARTS 4, \
     idScnParts, idPartInit, idUpdMach, idMachEvtTags
-#define OSP_TAGS_TESTAPP_PARTS 10, \
-    tgPartMod,          tgPartReq,                              \
+#define OSP_TAGS_TESTAPP_PARTS 12, \
+    tgPartMod,          tgPartReq,          tgPartClr,          \
     tgMapPartEntMod,    tgMapPartEntReq,                        \
-    tgWeldMod,          tgWeldReq,                              \
+    tgWeldMod,          tgWeldReq,          tgWeldClr,          \
     tgLinkMod,          tgLinkReq,                              \
     tgLinkMhUpdMod,     tgLinkMhUpdReq
 
@@ -179,6 +179,9 @@
     tgNwtVhHierMod,     tgNwtVhHierReq
 
 
+
+#define OSP_DATA_TESTAPP_ROCKETS_NWT 1, \
+    idRocketsNwt
 
 
 

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -120,21 +120,23 @@
 
 #define OSP_DATA_TESTAPP_VEHICLE_SPAWN 1, \
     idVehicleSpawn
-#define OSP_TAGS_TESTAPP_VEHICLE_SPAWN 9, \
-    tgVhSpBasicInMod,   tgVhSpBasicInReq,   tgVhSpBasicInClr,   \
-    tgVhSpPartMod,      tgVhSpPartReq,                          \
-    tgVhSpWeldMod,      tgVhSpWeldReq,                          \
-    tgVhSpPartPfMod,    tgVhSpPartPfReq
+#define OSP_TAGS_TESTAPP_VEHICLE_SPAWN 11, \
+    tgVsBasicInMod,     tgVsBasicInReq,     tgVsBasicInClr,     \
+    tgVsPartMod,        tgVsPartReq,                            \
+    tgVsMapPartMachMod, tgVsMapPartMachReq,                     \
+    tgVsWeldMod,        tgVsWeldReq,                            \
+    tgVsPartPfMod,      tgVsPartPfReq
 
 
 
 #define OSP_DATA_TESTAPP_VEHICLE_SPAWN_VB 1, \
     idVehicleSpawnVB
-#define OSP_TAGS_TESTAPP_VEHICLE_SPAWN_VB 8, \
-    tgVBSpBasicInMod,   tgVBSpBasicInReq,                       \
-    tgVBPartMod,        tgVBPartReq,                            \
-    tgVBWeldMod,        tgVBWeldReq,                            \
-    tgVBMachMod,        tgVBMachReq
+#define OSP_TAGS_TESTAPP_VEHICLE_SPAWN_VB 10, \
+    tgVbSpBasicInMod,   tgVbSpBasicInReq,                       \
+    tgVbPartMod,        tgVbPartReq,                            \
+    tgVbWeldMod,        tgVbWeldReq,                            \
+    tgVbMachMod,        tgVbMachReq,                            \
+    tgVbNodeMod,        tgVbNodeReq
 
 
 #define OSP_DATA_TESTAPP_TEST_VEHICLES 1, \

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -82,7 +82,6 @@
 
 
 
-
 #define OSP_DATA_TESTAPP_SHAPE_SPAWN 2, \
     idSpawner, idSpawnerEnts
 #define OSP_TAGS_TESTAPP_SHAPE_SPAWN 5, \

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -107,14 +107,16 @@
 
 
 
-#define OSP_DATA_TESTAPP_PARTS 4, \
-    idScnParts, idPartInit, idUpdMach, idMachEvtTags
-#define OSP_TAGS_TESTAPP_PARTS 12, \
+#define OSP_DATA_TESTAPP_PARTS 6, \
+    idScnParts, idPartInit, idUpdMach, idMachEvtTags, idMachUpdEnqueue, idtgNodeUpdEvt
+#define OSP_TAGS_TESTAPP_PARTS 17, \
     tgPartMod,          tgPartReq,          tgPartClr,          \
     tgMapPartEntMod,    tgMapPartEntReq,                        \
     tgWeldMod,          tgWeldReq,          tgWeldClr,          \
     tgLinkMod,          tgLinkReq,                              \
-    tgLinkMhUpdMod,     tgLinkMhUpdReq
+    tgLinkMhUpdMod,     tgLinkMhUpdReq,                         \
+    tgNodeAnyUpdMod,    tgNodeAnyUpdReq,                        \
+    tgMachUpdEnqMod,    tgMachUpdEnqReq,    tgNodeUpdEvt
 
 
 
@@ -144,12 +146,11 @@
 
 
 
-#define OSP_DATA_TESTAPP_SIGNALS_FLOAT 3, \
-    idSigValFloat,      idSigUpdFloat,      idTgSigFloatUpdEvt
-#define OSP_TAGS_TESTAPP_SIGNALS_FLOAT 7, \
+#define OSP_DATA_TESTAPP_SIGNALS_FLOAT 2, \
+    idSigValFloat,      idSigUpdFloat
+#define OSP_TAGS_TESTAPP_SIGNALS_FLOAT 5, \
     tgSigFloatLinkMod,  tgSigFloatLinkReq,                      \
-    tgSigFloatValMod,   tgSigFloatValReq,   tgSigFloatUpdEvt,   \
-    tgSigFloatUpdMod,   tgSigFloatUpdReq
+    tgSigFloatUpdMod,   tgSigFloatUpdReq,   tgSigFloatUpdEvt    \
 
 
 

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -158,7 +158,8 @@
 #define OSP_TAGS_TESTAPP_MACH_ROCKET 1, \
     tgMhRocketEvt
 
-
+#define OSP_TAGS_TESTAPP_MACH_RCSDRIVER 1, \
+    tgMhRcsDriverEvt
 
 #define OSP_DATA_TESTAPP_NEWTON 1, \
     idNwt

--- a/src/test_application/activescenes/scenarios.cpp
+++ b/src/test_application/activescenes/scenarios.cpp
@@ -191,16 +191,16 @@ static ScenarioMap_t make_scenarios()
         auto &rTags             = mainView.m_rTags;
         Builder_t builder{rTags, mainView.m_rTasks, mainView.m_rTaskData};
 
-        sceneOut.resize(23);
+        sceneOut.resize(24);
         auto &
         [
             scnCommon, matVisual, physics, shapeSpawn,
             prefabs, parts,
             vehicleSpawn, vehicleSpawnVB, vehicleSpawnRgd,
-            signalsFloat, machRocket,
+            signalsFloat, machRocket, machRcsDriver,
             testVehicles, droppers, gravity, bounds, thrower,
             newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt, nwtRocketSet, rocketsNwt
-        ] = unpack<23>(sceneOut);
+        ] = unpack<24>(sceneOut);
 
         scnCommon           = setup_common_scene        (builder, rTopData, rTags, idResources, pkg);
         matVisual           = setup_material            (builder, rTopData, rTags, scnCommon);
@@ -212,6 +212,7 @@ static ScenarioMap_t make_scenarios()
         vehicleSpawn        = setup_vehicle_spawn       (builder, rTopData, rTags, scnCommon);
         vehicleSpawnVB      = setup_vehicle_spawn_vb    (builder, rTopData, rTags, scnCommon, prefabs, parts, vehicleSpawn, signalsFloat, idResources);
         machRocket          = setup_mach_rocket         (builder, rTopData, rTags, scnCommon, parts, signalsFloat);
+        machRcsDriver       = setup_mach_rcsdriver      (builder, rTopData, rTags, scnCommon, parts, signalsFloat);
         testVehicles        = setup_test_vehicles       (builder, rTopData, rTags, scnCommon, idResources);
         droppers            = setup_droppers            (builder, rTopData, rTags, scnCommon, shapeSpawn);
         bounds              = setup_bounds              (builder, rTopData, rTags, scnCommon, physics, shapeSpawn);
@@ -258,10 +259,10 @@ static ScenarioMap_t make_scenarios()
                 scnCommon, matVisual, physics, shapeSpawn,
                 prefabs, parts,
                 vehicleSpawn, vehicleSpawnVB, vehicleSpawnRgd,
-                signalsFloat, machRocket,
+                signalsFloat, machRocket, machRcsDriver,
                 testVehicles, droppers, gravity, bounds, thrower,
-                newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt, rocketsNwt
-            ] = unpack<22>(scene);
+                newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt, nwtRocketSet, rocketsNwt
+            ] = unpack<24>(scene);
 
             rendererOut.resize(6);
             auto & [scnRender, cameraCtrl, shVisual, camThrow, vehicleCtrl, cameraVehicle] = unpack<6>(rendererOut);

--- a/src/test_application/activescenes/scenarios.cpp
+++ b/src/test_application/activescenes/scenarios.cpp
@@ -208,9 +208,9 @@ static ScenarioMap_t make_scenarios()
         shapeSpawn          = setup_shape_spawn         (builder, rTopData, rTags, scnCommon, physics, matVisual);
         prefabs             = setup_prefabs             (builder, rTopData, rTags, scnCommon, physics, matVisual, idResources);
         parts               = setup_parts               (builder, rTopData, rTags, scnCommon, idResources);
-        vehicleSpawn        = setup_vehicle_spawn       (builder, rTopData, rTags, scnCommon);
-        vehicleSpawnVB      = setup_vehicle_spawn_vb    (builder, rTopData, rTags, scnCommon, prefabs, parts, vehicleSpawn, idResources);
         signalsFloat        = setup_signals_float       (builder, rTopData, rTags, scnCommon, parts);
+        vehicleSpawn        = setup_vehicle_spawn       (builder, rTopData, rTags, scnCommon);
+        vehicleSpawnVB      = setup_vehicle_spawn_vb    (builder, rTopData, rTags, scnCommon, prefabs, parts, vehicleSpawn, signalsFloat, idResources);
         machRocket          = setup_mach_rocket         (builder, rTopData, rTags, scnCommon, parts, signalsFloat);
         testVehicles        = setup_test_vehicles       (builder, rTopData, rTags, scnCommon, idResources);
         droppers            = setup_droppers            (builder, rTopData, rTags, scnCommon, shapeSpawn);
@@ -236,7 +236,7 @@ static ScenarioMap_t make_scenarios()
         auto &rVehicleSpawn     = top_get<ACtxVehicleSpawn>     (rTopData, idVehicleSpawn);
         auto &rVehicleSpawnVB   = top_get<ACtxVehicleSpawnVB>   (rTopData, idVehicleSpawnVB);
 
-        for (int i = 0; i < 4; ++i)
+        for (int i = 0; i < 10; ++i)
         {
             rVehicleSpawn.m_newVhBasicIn.push_back(
             {

--- a/src/test_application/activescenes/scenarios.cpp
+++ b/src/test_application/activescenes/scenarios.cpp
@@ -191,7 +191,7 @@ static ScenarioMap_t make_scenarios()
         auto &rTags             = mainView.m_rTags;
         Builder_t builder{rTags, mainView.m_rTasks, mainView.m_rTaskData};
 
-        sceneOut.resize(21);
+        sceneOut.resize(23);
         auto &
         [
             scnCommon, matVisual, physics, shapeSpawn,
@@ -199,8 +199,8 @@ static ScenarioMap_t make_scenarios()
             vehicleSpawn, vehicleSpawnVB, vehicleSpawnRgd,
             signalsFloat, machRocket,
             testVehicles, droppers, gravity, bounds, thrower,
-            newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt
-        ] = unpack<21>(sceneOut);
+            newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt, nwtRocketSet, rocketsNwt
+        ] = unpack<23>(sceneOut);
 
         scnCommon           = setup_common_scene        (builder, rTopData, rTags, idResources, pkg);
         matVisual           = setup_material            (builder, rTopData, rTags, scnCommon);
@@ -221,7 +221,8 @@ static ScenarioMap_t make_scenarios()
         nwtGrav             = setup_newton_force_accel  (builder, rTopData, rTags, newton, nwtGravSet, Vector3{0.0f, 0.0f, -9.81f});
         shapeSpawnNwt       = setup_shape_spawn_newton  (builder, rTopData, rTags, scnCommon, physics, shapeSpawn, newton, nwtGravSet);
         vehicleSpawnNwt     = setup_vehicle_spawn_newton(builder, rTopData, rTags, scnCommon, physics, prefabs, parts, vehicleSpawn, newton, idResources);
-
+        nwtRocketSet        = setup_newton_factors      (builder, rTopData, rTags);
+        rocketsNwt          = setup_rocket_thrust_newton(builder, rTopData, rTags, scnCommon, physics, prefabs, parts, signalsFloat, newton, nwtRocketSet);
 
         OSP_SESSION_UNPACK_DATA(scnCommon,      TESTAPP_COMMON_SCENE);
         OSP_SESSION_UNPACK_DATA(vehicleSpawn,   TESTAPP_VEHICLE_SPAWN);
@@ -259,8 +260,8 @@ static ScenarioMap_t make_scenarios()
                 vehicleSpawn, vehicleSpawnVB, vehicleSpawnRgd,
                 signalsFloat, machRocket,
                 testVehicles, droppers, gravity, bounds, thrower,
-                newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt
-            ] = unpack<21>(scene);
+                newton, nwtGravSet, nwtGrav, shapeSpawnNwt, vehicleSpawnNwt, rocketsNwt
+            ] = unpack<22>(scene);
 
             rendererOut.resize(6);
             auto & [scnRender, cameraCtrl, shVisual, camThrow, vehicleCtrl, cameraVehicle] = unpack<6>(rendererOut);

--- a/src/test_application/activescenes/scene_newton.cpp
+++ b/src/test_application/activescenes/scene_newton.cpp
@@ -469,9 +469,9 @@ struct BodyRocket
     Quaternion      m_rotation;
     Vector3         m_offset;
 
-    MachLocalId     m_local;
-    NodeId          m_throttleIn;
-    NodeId          m_multiplierIn;
+    MachLocalId     m_local         {lgrn::id_null<MachLocalId>()};
+    NodeId          m_throttleIn    {lgrn::id_null<NodeId>()};
+    NodeId          m_multiplierIn  {lgrn::id_null<NodeId>()};
 };
 
 struct ACtxRocketsNwt

--- a/src/test_application/activescenes/scene_newton.h
+++ b/src/test_application/activescenes/scene_newton.h
@@ -100,5 +100,16 @@ osp::Session setup_vehicle_spawn_newton(
         osp::Session const&         newton,
         osp::TopDataId const        idResources);
 
+osp::Session setup_rocket_thrust_newton(
+        Builder_t&                  rBuilder,
+        osp::ArrayView<entt::any>   topData,
+        osp::Tags&                  rTags,
+        osp::Session const&         scnCommon,
+        osp::Session const&         physics,
+        osp::Session const&         prefabs,
+        osp::Session const&         parts,
+        osp::Session const&         signalsFloat,
+        osp::Session const&         newton,
+        osp::Session const&         nwtFactors);
 
 } // namespace testapp::scenes

--- a/src/test_application/activescenes/scene_newton.h
+++ b/src/test_application/activescenes/scene_newton.h
@@ -100,6 +100,9 @@ osp::Session setup_vehicle_spawn_newton(
         osp::Session const&         newton,
         osp::TopDataId const        idResources);
 
+/**
+ * @brief Add thrust forces to Magic Rockets from setup_mach_rocket
+ */
 osp::Session setup_rocket_thrust_newton(
         Builder_t&                  rBuilder,
         osp::ArrayView<entt::any>   topData,

--- a/src/test_application/activescenes/scene_physics.cpp
+++ b/src/test_application/activescenes/scene_physics.cpp
@@ -205,7 +205,7 @@ Session setup_shape_spawn(
                 Vector3 const inertia
                         = phys::collider_inertia_tensor(spawn.m_shape, spawn.m_size, spawn.m_mass);
                 Vector3 const offset{0.0f, 0.0f, 0.0f};
-                rPhys.m_ownDyn.emplace( child, ACompSubBody{ inertia, offset, spawn.m_mass } );
+                rPhys.m_mass.emplace( child, ACompMass{ inertia, offset, spawn.m_mass } );
             }
 
             rPhys.m_shape[std::size_t(child)] = spawn.m_shape;
@@ -335,6 +335,7 @@ Session setup_prefabs(
             wrap_args([] (ActiveReg_t const& rActiveIds, ACtxPrefabInit& rPrefabInit, Resources& rResources, ACtxPhysics& rPhys) noexcept
     {
         rPhys.m_hasColliders.ints().resize(rActiveIds.vec().capacity());
+        //rPhys.m_massDirty.ints().resize(rActiveIds.vec().capacity());
         rPhys.m_shape.resize(rActiveIds.capacity());
         SysPrefabInit::init_physics(rPrefabInit, rResources, rPhys);
     }));

--- a/src/test_application/activescenes/scene_vehicles.cpp
+++ b/src/test_application/activescenes/scene_vehicles.cpp
@@ -873,7 +873,7 @@ Session setup_vehicle_spawn_vb(
             }
 
             PerNodeType const&  srcFloatNodes       = pVData->m_nodePerType[gc_ntSigFloat];
-            entt::any const     srcFloatValuesAny   = srcFloatNodes.m_nodeValues;
+            entt::any const&    srcFloatValuesAny   = srcFloatNodes.m_nodeValues;
             auto const&         srcFloatValues      = entt::any_cast< SignalValues_t<float> >(srcFloatValuesAny);
             std::size_t const   nodeRemapOffset     = remapNodeOffsets2d[vhId][gc_ntSigFloat];
             auto const          nodeRemap           = arrayView(rVSVB.m_remapNodes).exceptPrefix(nodeRemapOffset);
@@ -1035,7 +1035,7 @@ Session setup_test_vehicles(
 
             for (Rad ang = 0.0_degf; ang < Rad(360.0_degf); ang += Rad(360.0_degf)/rcsRingBlocks)
             {
-               Quaternion rotZ = Quaternion::rotation(ang, {0.0f, 0.0f, 1.0f});
+               Quaternion const rotZ = Quaternion::rotation(ang, {0.0f, 0.0f, 1.0f});
                add_rcs_block(vbuilder, toWeld, rcsInputs, rcsThrust, rotZ.transformVector(rcsOset), rotZ);
             }
         }
@@ -1170,12 +1170,12 @@ Session setup_vehicle_control(
 
         Vector3 const attitude
         {
-              float(rUserInput.button_state(rVhControls.m_btnPitchUp).m_held)
-            - float(rUserInput.button_state(rVhControls.m_btnPitchDn).m_held),
+              float(rUserInput.button_state(rVhControls.m_btnPitchDn).m_held)
+            - float(rUserInput.button_state(rVhControls.m_btnPitchUp).m_held),
               float(rUserInput.button_state(rVhControls.m_btnYawLf).m_held)
             - float(rUserInput.button_state(rVhControls.m_btnYawRt).m_held),
-              float(rUserInput.button_state(rVhControls.m_btnRollLf).m_held)
-            - float(rUserInput.button_state(rVhControls.m_btnRollRt).m_held)
+              float(rUserInput.button_state(rVhControls.m_btnRollRt).m_held)
+            - float(rUserInput.button_state(rVhControls.m_btnRollLf).m_held)
         };
 
 

--- a/src/test_application/activescenes/scene_vehicles.cpp
+++ b/src/test_application/activescenes/scene_vehicles.cpp
@@ -993,7 +993,7 @@ Session setup_test_vehicles(
         toWeld.push_back( {capsule,  quick_transform({ 0.0f,  0.0f,  3.0f}, {})} );
         toWeld.push_back( {fueltank, quick_transform({ 0.0f,  0.0f,  0.0f}, {})} );
         toWeld.push_back( {engineA,  quick_transform({ 0.7f,  0.0f, -2.9f}, {})} );
-        toWeld.push_back( {engineB,  quick_transform({-0.7f,  0.0f, -2.9f},{})} );
+        toWeld.push_back( {engineB,  quick_transform({-0.7f,  0.0f, -2.9f}, {})} );
 
         namespace ports_magicrocket = adera::ports_magicrocket;
         namespace ports_userctrl = adera::ports_userctrl;

--- a/src/test_application/activescenes/scene_vehicles.h
+++ b/src/test_application/activescenes/scene_vehicles.h
@@ -87,6 +87,7 @@ osp::Session setup_vehicle_spawn_vb(
         osp::Session const&         prefabs,
         osp::Session const&         parts,
         osp::Session const&         vehicleSpawn,
+        osp::Session const&         signalsFloat,
         osp::TopDataId const        idResources);
 
 /**

--- a/src/test_application/activescenes/scene_vehicles.h
+++ b/src/test_application/activescenes/scene_vehicles.h
@@ -54,9 +54,22 @@ osp::Session setup_signals_float(
         osp::Session const&         parts);
 
 /**
- * @brief 'Rockets' that print values to the console
+ * @brief Links for Magic Rockets
+ *
+ * This only sets up links and does not apply forces, see setup_rocket_thrust_newton
  */
 osp::Session setup_mach_rocket(
+        Builder_t&                  rBuilder,
+        osp::ArrayView<entt::any>   topData,
+        osp::Tags&                  rTags,
+        osp::Session const&         scnCommon,
+        osp::Session const&         parts,
+        osp::Session const&         signalsFloat);
+
+/**
+ * @brief Links for RCS Drivers, which output thrust levels given pitch/yaw/roll controls
+ */
+osp::Session setup_mach_rcsdriver(
         Builder_t&                  rBuilder,
         osp::ArrayView<entt::any>   topData,
         osp::Tags&                  rTags,


### PR DESCRIPTION
Re-adding quite a bit of math that was previously removed.

## Wire/links

Fixed up to actually work properly.

Copied from a comment, referring to scene_vehicles.h/cpp

 Passing values:

1. Tasks write new values to idSigUpdFloat
2. The "Reduce Signal-Float Nodes" task reads new values from idSigUpdFloat(s) and writes them
    into idSigValFloat. This changes the input values of connected Machines, marking them dirty.
    Tags for each unique dirty machine type is added to rMachUpdEnqueue.
    Other 'reduce node' tasks could be running in parallel here.

3. The "Enqueue Machine & Node update tasks" task from setup_parts runs, and enqueues machine
    tasks from rMachUpdEnqueue as well as every tgNodeUpdEvt task, including
    "Reduce Signal-Float Nodes".

 4. Repeat until nothing is dirty


 This seemingly complex scheme allows different node types to interoperate seamlessly.

 eg. A float signal can trigger a fuel valve that triggers a pressure sensor which outputs
     another float signal, all running within a single frame.

## RCS Driver

Previously named "MachineRCSController" or something. Renamed since it conflicts with other things named 'controller'.

The previous version was aware of its own transform and center of mass of its vehicle. The newer version is dumb and is not aware of this. It's simply a function that takes takes float inputs:
* xyz Position
* xyz Direction
* xyz Linear command (translation)
* xyz Angular command (pitch/yaw/roll)
(12 total floats)
then outputs a single float throttle value.

Getting center of mass and awareness of the positions of parts within a vehicle can be handled by a separate machine. part 

## ForceFactors

Text below copied from PR #224, this time it's actually used for rockets. 

Previously, lots of separate systems would write forces into rigid bodies. Rocket thrust, gravity, and potentially aerodynamic forces are separate calls that roughly write to a single net force value for each rigid body.

This multiple-writers scheme is simply difficult to multi-thread. Atomics would help, but the problem is best avoided entirely.

Solution: Make the physics engine read from multiple sources to calculate all factors that contribute to force for each rigid body.

Each rigid body is assigned a bitset, which describe which functions are called in order to calculate its net force (and torque too). These functions are referred to as "ForceFactors." See setup_newton_force_accel(...) in scene_newton.cpp for a constant-acceleration ForceFactor used for gravity.