### PR TITLE
Fix Universe test scene

### DIFF
--- a/src/newtondynamics_physics/SysNewton.cpp
+++ b/src/newtondynamics_physics/SysNewton.cpp
@@ -244,7 +244,7 @@ void SysNewton::find_colliders_recurse(
         // cylinder needs to be rotated 90 degrees Z to aligned with Y axis
         // TODO: replace this with something more sophisticated some time
         Matrix4 const &colliderTf
-                = (rCtxPhys.m_shape[std::size_t(ent)] != EShape::Cylinder)
+                = (rCtxPhys.m_shape[ent] != EShape::Cylinder)
                 ? transform : transform * Matrix4::rotationZ(90.0_degf);
 
         Matrix4 const normScale = Matrix4::from(colliderTf.rotation(), colliderTf.translation());

--- a/src/osp/Active/SysPrefabInit.cpp
+++ b/src/osp/Active/SysPrefabInit.cpp
@@ -111,6 +111,7 @@ void SysPrefabInit::init_transforms(
     }
 }
 
+#if 0
 void SysPrefabInit::init_drawing(
         ACtxPrefabInit const&               rPrefabInit,
         Resources&                          rResources,
@@ -226,6 +227,7 @@ void SysPrefabInit::init_drawing(
         ++itPfEnts;
     }
 }
+#endif
 
 void SysPrefabInit::init_physics(
             ACtxPrefabInit const&               rPrefabInit,
@@ -292,7 +294,7 @@ void SysPrefabInit::init_physics(
             EShape const    shape       = rPrefabData.m_objShape[objectId];
 
 
-            rCtxPhys.m_shape[std::size_t(ent)] = shape;
+            rCtxPhys.m_shape[ent] = shape;
 
             if (mass != 0.0f)
             {

--- a/src/osp/Active/SysRender.cpp
+++ b/src/osp/Active/SysRender.cpp
@@ -59,14 +59,14 @@ TexId SysRender::own_texture_resource(ACtxDrawing& rCtxDrawing, ACtxDrawingRes& 
     return it->second;
 };
 
-void SysRender::clear_owners(ACtxDrawing& rCtxDrawing)
+void SysRender::clear_owners(ACtxSceneRender& rCtxScnRdr, ACtxDrawing& rCtxDrawing)
 {
-    for (TexIdOwner_t &rOwner : std::exchange(rCtxDrawing.m_diffuseTex, {}))
+    for (TexIdOwner_t &rOwner : std::exchange(rCtxScnRdr.m_diffuseTex, {}))
     {
         rCtxDrawing.m_texRefCounts.ref_release(std::move(rOwner));
     }
 
-    for (MeshIdOwner_t &rOwner : std::exchange(rCtxDrawing.m_mesh, {}))
+    for (MeshIdOwner_t &rOwner : std::exchange(rCtxScnRdr.m_mesh, {}))
     {
         rCtxDrawing.m_meshRefCounts.ref_release(std::move(rOwner));
     }
@@ -86,39 +86,6 @@ void SysRender::clear_resource_owners(ACtxDrawingRes& rCtxDrawingRes, Resources 
     }
     rCtxDrawingRes.m_resToMesh.clear();
 }
-
-void SysRender::set_dirty_all(ACtxDrawing &rCtxDrawing)
-{
-    using osp::active::active_sparse_set_t;
-
-
-    for (std::size_t const drawEntInt : rCtxDrawing.m_drawIds.bitview().zeros())
-    {
-        auto const drawEnt = DrawEnt(drawEntInt);
-
-        // Set all meshs dirty
-        if (rCtxDrawing.m_mesh[drawEnt] != lgrn::id_null<MeshId>())
-        {
-            rCtxDrawing.m_meshDirty.push_back(drawEnt);
-        }
-
-        // Set all textures dirty
-        if (rCtxDrawing.m_diffuseTex[drawEnt] != lgrn::id_null<TexId>())
-        {
-            rCtxDrawing.m_diffuseDirty.push_back(drawEnt);
-        }
-    }
-
-    for (std::size_t const materialInt : rCtxDrawing.m_materialIds.bitview().zeros())
-    {
-        Material &mat = rCtxDrawing.m_materials[MaterialId(materialInt)];
-        for (std::size_t const entInt : mat.m_ents.ones())
-        {
-            mat.m_dirty.push_back(DrawEnt(entInt));
-        }
-    }
-}
-
 
 void SysRender::update_draw_transforms_recurse(
         ACtxSceneGraph const&                   rScnGraph,

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -32,8 +32,6 @@
 namespace osp::active
 {
 
-using DrawTransforms_t = KeyedVec<DrawEnt, Matrix4>;
-
 /**
  * @brief View and Projection matrix
  */

--- a/src/osp/Active/SysRender.h
+++ b/src/osp/Active/SysRender.h
@@ -114,17 +114,6 @@ struct RenderGroup
 
 }; // struct RenderGroup
 
-struct ACtxRenderGroups
-{
-    // Required for std::is_copy_assignable to work properly inside of entt::any
-    ACtxRenderGroups() = default;
-    ACtxRenderGroups(ACtxRenderGroups const& copy) = delete;
-    ACtxRenderGroups(ACtxRenderGroups&& move) = default;
-
-    std::unordered_map< std::string, RenderGroup > m_groups;
-
-};
-
 class SysRender
 {
 public:
@@ -153,10 +142,8 @@ public:
 
     /**
      * @brief Remove all mesh and texture components, aware of refcounts
-     *
-     * @param rCtxDrawing       [ref] Drawing data
      */
-    static void clear_owners(ACtxDrawing& rCtxDrawing);
+    static void clear_owners(ACtxSceneRender& rCtxScnRdr, ACtxDrawing& rCtxDrawing);
 
     /**
      * @brief Dissociate resources from the scene's meshes and textures
@@ -192,11 +179,7 @@ public:
 
     template<typename IT_T>
     static void update_delete_drawing(
-            ACtxDrawing& rCtxDraw, IT_T const& first, IT_T const& last);
-
-    template<typename IT_T>
-    static void update_delete_groups(
-            ACtxRenderGroups& rCtxGroups, IT_T first, IT_T const& last);
+            ACtxSceneRender& rCtxScnRdr, ACtxDrawing& rCtxDrawing, IT_T const& first, IT_T const& last);
 
     static MeshIdOwner_t add_drawable_mesh(ACtxDrawing& rDrawing, ACtxDrawingRes& rDrawingRes, Resources& rResources, PkgId const pkg, std::string_view const name);
 
@@ -263,28 +246,14 @@ void remove_refcounted(
 
 template<typename IT_T>
 void SysRender::update_delete_drawing(
-        ACtxDrawing& rCtxDraw, IT_T const& first, IT_T const& last)
+        ACtxSceneRender& rCtxScnRdr, ACtxDrawing& rCtxDrawing, IT_T const& first, IT_T const& last)
 {
     for (auto it = first; it != last; std::advance(it, 1))
     {
         DrawEnt const drawEnt = *it;
 
-        remove_refcounted(drawEnt, rCtxDraw.m_diffuseTex, rCtxDraw.m_texRefCounts);
-        remove_refcounted(drawEnt, rCtxDraw.m_mesh,       rCtxDraw.m_meshRefCounts);
-    }
-}
-
-template<typename IT_T>
-void SysRender::update_delete_groups(
-        ACtxRenderGroups& rCtxGroups, IT_T first, IT_T const& last)
-{
-    if (first == last)
-    {
-        return;
-    }
-    for ([[maybe_unused]] auto& [_, rGroup] : rCtxGroups.m_groups)
-    {
-        rGroup.m_entities.remove(first, last);
+        remove_refcounted(drawEnt, rCtxScnRdr.m_diffuseTex, rCtxDrawing.m_texRefCounts);
+        remove_refcounted(drawEnt, rCtxScnRdr.m_mesh,       rCtxDrawing.m_meshRefCounts);
     }
 }
 

--- a/src/osp/Active/activetypes.h
+++ b/src/osp/Active/activetypes.h
@@ -38,6 +38,7 @@
 #include <longeron/id_management/registry_stl.hpp>      // for lgrn::IdRegistryStl
 #include <longeron/containers/bit_view.hpp>             // for lgrn::BitView
 
+#include <optional>
 #include <vector>
 
 namespace osp::active
@@ -62,6 +63,30 @@ using DrawEntSet_t  = BitVector_t;
 
 
 enum class MaterialId : uint32_t { };
+
+
+/**
+ * @brief Emplace, Reassign, or Remove a value from an entt::basic_storage
+ */
+template <typename COMP_T, typename ENT_T>
+void storage_assign(entt::basic_storage<COMP_T, ENT_T> &rStorage, ENT_T const ent, std::optional<COMP_T> value)
+{
+    if (value.has_value())
+    {
+        if (rStorage.contains(ent))
+        {
+            rStorage.get(ent) = std::move(*value);
+        }
+        else
+        {
+            rStorage.emplace(ent, std::move(*value));
+        }
+    }
+    else
+    {
+        rStorage.remove(ent); // checks contains(ent) internally
+    }
+}
 
 
 } // namespace osp::active

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -73,7 +73,6 @@ using TexIdOwner_t      = TexRefCount_t::Owner_t;
  */
 struct ACtxDrawing
 {
-
     // Scene-space Meshes
     lgrn::IdRegistryStl<MeshId>             m_meshIds;
     MeshRefCount_t                          m_meshRefCounts;
@@ -104,7 +103,7 @@ struct ACtxDrawingRes
 
 using DrawEntColors_t = KeyedVec<DrawEnt, Magnum::Color4>;
 using DrawEntTextures_t = KeyedVec<DrawEnt, TexIdOwner_t>;
-
+using DrawTransforms_t = KeyedVec<DrawEnt, Matrix4>;
 
 struct ACtxSceneRender
 {
@@ -121,9 +120,15 @@ struct ACtxSceneRender
         bitvector_resize(m_transparent, size);
         bitvector_resize(m_visible,     size);
 
+        m_drawTransform .resize(size);
         m_color         .resize(size, {1.0f, 1.0f, 1.0f, 1.0f}); // Default white
         m_diffuseTex    .resize(size);
         m_mesh          .resize(size);
+
+        for (uint32_t matInt : m_materialIds.bitview().zeros())
+        {
+            bitvector_resize(m_materials[MaterialId(matInt)].m_ents, size);
+        }
     }
 
     void resize_active(std::size_t const size)
@@ -141,6 +146,8 @@ struct ACtxSceneRender
 
     DrawEntSet_t                            m_needDrawTf;
     KeyedVec<ActiveEnt, DrawEnt>            m_activeToDraw;
+
+    DrawTransforms_t                        m_drawTransform;
 
     // Meshes and textures assigned to DrawEnts
     KeyedVec<DrawEnt, TexIdOwner_t>         m_diffuseTex;

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -41,13 +41,6 @@
 namespace osp::active
 {
 
-
-struct BasicDrawProps
-{
-    bool m_opaque:1         { false };
-    bool m_transparent:1    { false };
-};
-
 struct Material
 {
     DrawEntSet_t m_ents;
@@ -109,6 +102,10 @@ struct ACtxDrawingRes
     IdMap_t<MeshId, ResIdOwner_t>           m_meshToRes;
 };
 
+using DrawEntColors_t = KeyedVec<DrawEnt, Magnum::Color4>;
+using DrawEntTextures_t = KeyedVec<DrawEnt, TexIdOwner_t>;
+
+
 struct ACtxSceneRender
 {
     // Required for std::is_copy_assignable to work properly inside of entt::any
@@ -120,9 +117,11 @@ struct ACtxSceneRender
     {
         std::size_t const size = m_drawIds.capacity();
 
-        bitvector_resize(m_visible, size);
-        m_drawBasic     .resize(size);
-        m_color         .resize(size);
+        bitvector_resize(m_opaque,      size);
+        bitvector_resize(m_transparent, size);
+        bitvector_resize(m_visible,     size);
+
+        m_color         .resize(size, {1.0f, 1.0f, 1.0f, 1.0f}); // Default white
         m_diffuseTex    .resize(size);
         m_mesh          .resize(size);
     }
@@ -135,24 +134,23 @@ struct ACtxSceneRender
 
     lgrn::IdRegistryStl<DrawEnt>            m_drawIds;
 
+    DrawEntSet_t                            m_opaque;
+    DrawEntSet_t                            m_transparent;
     DrawEntSet_t                            m_visible;
-    KeyedVec<DrawEnt, BasicDrawProps>       m_drawBasic;
-    KeyedVec<DrawEnt, Magnum::Color4>       m_color;
+    DrawEntColors_t                         m_color;
 
     DrawEntSet_t                            m_needDrawTf;
     KeyedVec<ActiveEnt, DrawEnt>            m_activeToDraw;
 
     // Meshes and textures assigned to DrawEnts
     KeyedVec<DrawEnt, TexIdOwner_t>         m_diffuseTex;
-    std::vector<DrawEnt>                    m_diffuseDirty;
+    DrawEntVec_t                            m_diffuseDirty;
 
     KeyedVec<DrawEnt, MeshIdOwner_t>        m_mesh;
-    std::vector<DrawEnt>                    m_meshDirty;
+    DrawEntVec_t                            m_meshDirty;
 
     lgrn::IdRegistryStl<MaterialId>         m_materialIds;
     KeyedVec<MaterialId, Material>          m_materials;
-
-    //DrawTransforms_t        m_drawTransform;
 };
 
 struct Camera

--- a/src/osp/Active/drawing.h
+++ b/src/osp/Active/drawing.h
@@ -81,6 +81,41 @@ using TexIdOwner_t      = TexRefCount_t::Owner_t;
 struct ACtxDrawing
 {
 
+    // Scene-space Meshes
+    lgrn::IdRegistryStl<MeshId>             m_meshIds;
+    MeshRefCount_t                          m_meshRefCounts;
+
+    // Scene-space Textures
+    lgrn::IdRegistryStl<TexId>              m_texIds;
+    TexRefCount_t                           m_texRefCounts;
+};
+
+/**
+ * @brief Associates mesh/texture resources Ids from ACtxDrawing with Resources
+ */
+struct ACtxDrawingRes
+{
+    // Required for std::is_copy_assignable to work properly inside of entt::any
+    ACtxDrawingRes() = default;
+    ACtxDrawingRes(ACtxDrawingRes const& copy) = delete;
+    ACtxDrawingRes(ACtxDrawingRes&& move) = default;
+
+    // Associate Texture Ids with resources
+    IdMap_t<ResId, TexId>                   m_resToTex;
+    IdMap_t<TexId, ResIdOwner_t>            m_texToRes;
+
+    // Associate Mesh Ids with resources
+    IdMap_t<ResId, MeshId>                  m_resToMesh;
+    IdMap_t<MeshId, ResIdOwner_t>           m_meshToRes;
+};
+
+struct ACtxSceneRender
+{
+    // Required for std::is_copy_assignable to work properly inside of entt::any
+    ACtxSceneRender() = default;
+    ACtxSceneRender(ACtxSceneRender const& copy) = delete;
+    ACtxSceneRender(ACtxSceneRender&& move) = default;
+
     void resize_draw()
     {
         std::size_t const size = m_drawIds.capacity();
@@ -107,14 +142,6 @@ struct ACtxDrawing
     DrawEntSet_t                            m_needDrawTf;
     KeyedVec<ActiveEnt, DrawEnt>            m_activeToDraw;
 
-    // Scene-space Meshes
-    lgrn::IdRegistryStl<MeshId>             m_meshIds;
-    MeshRefCount_t                          m_meshRefCounts;
-
-    // Scene-space Textures
-    lgrn::IdRegistryStl<TexId>              m_texIds;
-    TexRefCount_t                           m_texRefCounts;
-
     // Meshes and textures assigned to DrawEnts
     KeyedVec<DrawEnt, TexIdOwner_t>         m_diffuseTex;
     std::vector<DrawEnt>                    m_diffuseDirty;
@@ -124,25 +151,8 @@ struct ACtxDrawing
 
     lgrn::IdRegistryStl<MaterialId>         m_materialIds;
     KeyedVec<MaterialId, Material>          m_materials;
-};
 
-/**
- * @brief Associates mesh/texture resources Ids from ACtxDrawing with Resources
- */
-struct ACtxDrawingRes
-{
-    // Required for std::is_copy_assignable to work properly inside of entt::any
-    ACtxDrawingRes() = default;
-    ACtxDrawingRes(ACtxDrawingRes const& copy) = delete;
-    ACtxDrawingRes(ACtxDrawingRes&& move) = default;
-
-    // Associate Texture Ids with resources
-    IdMap_t<ResId, TexId>                   m_resToTex;
-    IdMap_t<TexId, ResIdOwner_t>            m_texToRes;
-
-    // Associate Mesh Ids with resources
-    IdMap_t<ResId, MeshId>                  m_resToMesh;
-    IdMap_t<MeshId, ResIdOwner_t>           m_meshToRes;
+    //DrawTransforms_t        m_drawTransform;
 };
 
 struct Camera

--- a/src/osp/Active/opengl/SysRenderGL.h
+++ b/src/osp/Active/opengl/SysRenderGL.h
@@ -104,7 +104,6 @@ struct ACtxSceneRenderGL
 {
     MeshGlEntStorage_t      m_meshId;
     TexGlEntStorage_t       m_diffuseTexId;
-    DrawTransforms_t        m_drawTransform;
 };
 
 /**

--- a/src/osp/Active/physics.h
+++ b/src/osp/Active/physics.h
@@ -27,6 +27,7 @@
 #include "activetypes.h"
 
 #include "../CommonPhysics.h"
+#include "../keyed_vector.h"
 #include "../types.h"
 
 namespace osp::active
@@ -47,7 +48,7 @@ struct ACompMass
  */
 struct ACtxPhysics
 {
-    std::vector<phys::EShape>       m_shape;
+    KeyedVec<ActiveEnt, phys::EShape> m_shape;
     ActiveEntSet_t                        m_hasColliders;
 
     acomp_storage_t<ACompMass>      m_mass;

--- a/src/osp/Shaders/Flat.cpp
+++ b/src/osp/Shaders/Flat.cpp
@@ -24,47 +24,40 @@
  */
 #include "Flat.h"
 
-// for the 0xrrggbb_rgbf and angle literals
-using namespace Magnum::Math::Literals;
-
 using namespace osp;
 using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_flat(
-        DrawEnt ent, ViewProjMatrix const& viewProj,
-        EntityToDraw::UserData_t userData) noexcept
+        DrawEnt                     ent,
+        ViewProjMatrix const&       viewProj,
+        EntityToDraw::UserData_t    userData) noexcept
 {
-    using Flag = Flat::Flag;
-
     void* const pData   = std::get<0>(userData);
     void* const pShader = std::get<1>(userData);
     assert(pData   != nullptr);
     assert(pShader != nullptr);
 
     auto &rData   = *reinterpret_cast<ACtxDrawFlat*>(pData);
-    auto &rShader = *reinterpret_cast<Flat*>(pShader);
+    auto &rShader = *reinterpret_cast<FlatGL3D*>(pShader);
 
     // Collect uniform information
-    Matrix4 const &drawTf = (*rData.m_pDrawTf)[ent];
+    Matrix4 const &drawTf = (*rData.pDrawTf)[ent];
 
-    if (rShader.flags() & Flag::Textured)
+    if (rShader.flags() & FlatGL3D::Flag::Textured)
     {
-        TexGlId const texGlId = (*rData.m_pDiffuseTexId)[ent].m_glId;
-        rShader.bindTexture(rData.m_pTexGl->get(texGlId));
+        TexGlId const texGlId = (*rData.pDiffuseTexId)[ent].m_glId;
+        rShader.bindTexture(rData.pTexGl->get(texGlId));
     }
 
-    if (rData.m_pColor != nullptr)
+    if (rData.pColor != nullptr)
     {
-        rShader.setColor((*rData.m_pColor)[ent]);
+        rShader.setColor((*rData.pColor)[ent]);
     }
 
-    MeshGlId const meshId = (*rData.m_pMeshId)[ent].m_glId;
-    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
+    MeshGlId const      meshId = (*rData.pMeshId)[ent].m_glId;
+    Magnum::GL::Mesh    &rMesh = rData.pMeshGl->get(meshId);
 
-    rShader
-        .setTransformationProjectionMatrix(viewProj.m_viewProj * drawTf)
-        .draw(rMesh);
+    rShader.setTransformationProjectionMatrix(viewProj.m_viewProj * drawTf)
+           .draw(rMesh);
 }
-
-

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -32,35 +32,34 @@
 namespace osp::shader
 {
 
-using Flat = Magnum::Shaders::FlatGL3D;
+using FlatGL3D = Magnum::Shaders::FlatGL3D;
 
 
 struct ACtxDrawFlat
 {
-    template <typename T>
-    using acomp_storage_t = osp::active::acomp_storage_t<T>;
+    FlatGL3D                    shaderUntextured    {Corrade::NoCreate};
+    FlatGL3D                    shaderDiffuse       {Corrade::NoCreate};
 
-    Flat m_shaderUntextured     {Corrade::NoCreate};
-    Flat m_shaderDiffuse        {Corrade::NoCreate};
+    active::DrawTransforms_t    *pDrawTf            {nullptr};
+    active::DrawEntColors_t     *pColor             {nullptr};
+    active::TexGlEntStorage_t   *pDiffuseTexId      {nullptr};
+    active::MeshGlEntStorage_t  *pMeshId            {nullptr};
 
-    osp::active::DrawTransforms_t               *m_pDrawTf{nullptr};
-    osp::KeyedVec<osp::active::DrawEnt, Magnum::Color4> *m_pColor{nullptr};
-    osp::active::TexGlEntStorage_t              *m_pDiffuseTexId{nullptr};
-    osp::active::MeshGlEntStorage_t             *m_pMeshId{nullptr};
+    active::TexGlStorage_t      *pTexGl             {nullptr};
+    active::MeshGlStorage_t     *pMeshGl            {nullptr};
 
-    osp::active::TexGlStorage_t                 *m_pTexGl{nullptr};
-    osp::active::MeshGlStorage_t                *m_pMeshGl{nullptr};
+    active::MaterialId materialId { lgrn::id_null<active::MaterialId>() };
 
-    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
-                                   active::RenderGL& rRenderGl) noexcept
+    constexpr void assign_pointers(active::ACtxSceneRender&     rScnRender,
+                                   active::ACtxSceneRenderGL&   rScnRenderGl,
+                                   active::RenderGL&            rRenderGl) noexcept
     {
-        m_pDrawTf       = &rCtxScnGl.m_drawTransform;
-        // TODO: ACompColor
-        m_pDiffuseTexId = &rCtxScnGl.m_diffuseTexId;
-        m_pMeshId       = &rCtxScnGl.m_meshId;
-
-        m_pTexGl        = &rRenderGl.m_texGl;
-        m_pMeshGl       = &rRenderGl.m_meshGl;
+        pDrawTf         = &rScnRenderGl .m_drawTransform;
+        pColor          = &rScnRender   .m_color;
+        pDiffuseTexId   = &rScnRenderGl .m_diffuseTexId;
+        pMeshId         = &rScnRenderGl .m_meshId;
+        pTexGl          = &rRenderGl    .m_texGl;
+        pMeshGl         = &rRenderGl    .m_meshGl;
     }
 };
 
@@ -69,74 +68,59 @@ void draw_ent_flat(
         active::ViewProjMatrix const& viewProj,
         active::EntityToDraw::UserData_t userData) noexcept;
 
-/**
- * @brief Assign a Flat shader to a set of entities, and write results to
- *        a RenderGroup
- *
- * @param dirtyFirst            [in] Iterator to first entity to sync
- * @param dirtyLast             [in] Iterator to last entity to sync
- * @param hasMaterial           [in] Which entities a phong material is assigned to
- * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
- * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
- * @param opaque                [in] Storage for opaque component
- * @param diffuse               [in] Storage for diffuse texture component
- * @param rData                 [in] Phong shader data, stable memory required
- */
-template<typename ITA_T, typename ITB_T>
-void sync_flat(
-        ITA_T                                                   dirtyIt,
-        ITB_T const&                                            dirtyLast,
-        active::DrawEntSet_t const&                             hasMaterial,
-        active::RenderGroup::Storage_t *const                   pStorageOpaque,
-        active::RenderGroup::Storage_t *const                   pStorageTransparent,
-        KeyedVec<active::DrawEnt, active::BasicDrawProps> const& drawBasic,
-        active::TexGlEntStorage_t const&                        diffuse,
-        ACtxDrawFlat &rData)
+struct ArgsForSyncDrawEntFlat
 {
-    using namespace active;
+    active::DrawEntSet_t const&             hasMaterial;
+    active::RenderGroup::Storage_t *const   pStorageOpaque;
+    active::RenderGroup::Storage_t *const   pStorageTransparent;
+    active::DrawEntSet_t const&             opaque;
+    active::DrawEntSet_t const&             transparent;
+    active::TexGlEntStorage_t const&        diffuse;
+    ACtxDrawFlat&                           rData;
+};
 
-    for (; dirtyIt != dirtyLast; std::advance(dirtyIt, 1))
+inline void sync_drawent_flat(active::DrawEnt ent, ArgsForSyncDrawEntFlat const args)
+{
+    using namespace osp::active;
+
+    auto const entInt = std::size_t(ent);
+
+    bool const hasMaterial = args.hasMaterial.test(entInt);
+    bool const hasTexture = (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
+
+    FlatGL3D *pShader = hasTexture
+                      ? &args.rData.shaderDiffuse
+                      : &args.rData.shaderUntextured;
+
+    if (args.pStorageTransparent != nullptr)
     {
-        DrawEnt const ent = *dirtyIt;
+        auto value = (hasMaterial && args.transparent.test(entInt))
+                   ? std::make_optional(EntityToDraw{&draw_ent_flat, {&args.rData, pShader}})
+                   : std::nullopt;
 
-        // Erase from group if they exist
-        if (pStorageOpaque != nullptr)
-        {
-            pStorageOpaque->remove(ent);
-        }
-        if (pStorageTransparent != nullptr)
-        {
-            pStorageTransparent->remove(ent);
-        }
-
-        if ( ! hasMaterial.test(std::size_t(ent)))
-        {
-            continue; // Phong material is not assigned to this entity
-        }
-
-        Flat *pShader = (diffuse[ent].m_glId != lgrn::id_null<TexGlId>())
-                      ? &rData.m_shaderDiffuse
-                      : &rData.m_shaderUntextured;
-
-        if (drawBasic[ent].m_opaque)
-        {
-            if (pStorageOpaque == nullptr)
-            {
-                continue;
-            }
-
-            pStorageOpaque->emplace(ent, EntityToDraw{&draw_ent_flat, {&rData, pShader} });
-        }
-        else
-        {
-            if (pStorageTransparent == nullptr)
-            {
-                continue;
-            }
-
-            pStorageTransparent->emplace(ent, EntityToDraw{&draw_ent_flat, {&rData, pShader} });
-        }
+        storage_assign(*args.pStorageTransparent, ent, std::move(value));
     }
+
+    if (args.pStorageOpaque != nullptr)
+    {
+        auto value = (hasMaterial && args.opaque.test(entInt))
+                   ? std::make_optional(EntityToDraw{&draw_ent_flat, {&args.rData, pShader}})
+                   : std::nullopt;
+
+        storage_assign(*args.pStorageOpaque, ent, std::move(value));
+    }
+}
+
+template<typename ITA_T, typename ITB_T>
+void sync_drawent_flat(
+        ITA_T const&                    first,
+        ITB_T const&                    last,
+        ArgsForSyncDrawEntFlat const    args)
+{
+    std::for_each(first, last, [&args] (active::DrawEnt const ent)
+    {
+        sync_drawent_flat(ent, args);
+    });
 }
 
 

--- a/src/osp/Shaders/Flat.h
+++ b/src/osp/Shaders/Flat.h
@@ -54,7 +54,7 @@ struct ACtxDrawFlat
                                    active::ACtxSceneRenderGL&   rScnRenderGl,
                                    active::RenderGL&            rRenderGl) noexcept
     {
-        pDrawTf         = &rScnRenderGl .m_drawTransform;
+        pDrawTf         = &rScnRender   .m_drawTransform;
         pColor          = &rScnRender   .m_color;
         pDiffuseTexId   = &rScnRenderGl .m_diffuseTexId;
         pMeshId         = &rScnRenderGl .m_meshId;
@@ -86,7 +86,7 @@ inline void sync_drawent_flat(active::DrawEnt ent, ArgsForSyncDrawEntFlat const 
     auto const entInt = std::size_t(ent);
 
     bool const hasMaterial = args.hasMaterial.test(entInt);
-    bool const hasTexture = (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
+    bool const hasTexture = (args.diffuse.size() > std::size_t(ent)) && (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
 
     FlatGL3D *pShader = hasTexture
                       ? &args.rData.shaderDiffuse

--- a/src/osp/Shaders/MeshVisualizer.cpp
+++ b/src/osp/Shaders/MeshVisualizer.cpp
@@ -36,8 +36,9 @@ using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_visualizer(
-        DrawEnt ent, const ViewProjMatrix &viewProj,
-        EntityToDraw::UserData_t userData) noexcept
+        DrawEnt                     ent,
+        ViewProjMatrix const&       viewProj,
+        EntityToDraw::UserData_t    userData) noexcept
 {
     using Magnum::Shaders::MeshVisualizerGL3D;
 
@@ -45,9 +46,8 @@ void shader::draw_ent_visualizer(
     assert(pData != nullptr);
     auto &rData = *reinterpret_cast<ACtxDrawMeshVisualizer*>(pData);
 
-    Matrix4 const& drawTf = (*rData.m_pDrawTf)[ent];
-
-    Matrix4 const entRelative = viewProj.m_view * drawTf;
+    Matrix4 const&  drawTf      = (*rData.m_pDrawTf)[ent];
+    Matrix4 const   entRelative = viewProj.m_view * drawTf;
 
     MeshVisualizer &rShader = rData.m_shader;
 
@@ -56,15 +56,14 @@ void shader::draw_ent_visualizer(
         rShader.setNormalMatrix(entRelative.normalMatrix());
     }
 
-
     if (rData.m_wireframeOnly)
     {
         rShader.setColor(0x00000000_rgbaf);
         Magnum::GL::Renderer::setDepthMask(false);
     }
 
-    MeshGlId const meshId = (*rData.m_pMeshId)[ent].m_glId;
-    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
+    MeshGlId const      meshId = (*rData.m_pMeshId)[ent].m_glId;
+    Magnum::GL::Mesh    &rMesh = rData.m_pMeshGl->get(meshId);
 
     rShader
         .setViewportSize(Vector2{Magnum::GL::defaultFramebuffer.viewport().size()})
@@ -77,31 +76,3 @@ void shader::draw_ent_visualizer(
         Magnum::GL::Renderer::setDepthMask(true);
     }
 }
-
-void shader::sync_drawent_visualizer(
-        active::DrawEnt const ent,
-        active::DrawEntSet_t const& hasMaterial,
-        active::RenderGroup::Storage_t& rStorage,
-        ACtxDrawMeshVisualizer &rData)
-{
-    using namespace active;
-
-    bool alreadyAdded = rStorage.contains(ent);
-    if (hasMaterial.test(std::size_t(ent)))
-    {
-        if ( ! alreadyAdded)
-        {
-            rStorage.emplace( ent, EntityToDraw{&draw_ent_visualizer, {&rData} } );
-        }
-    }
-    else
-    {
-        if (alreadyAdded)
-        {
-            rStorage.erase(ent);
-        }
-    }
-}
-
-
-

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -59,12 +59,30 @@ void draw_ent_visualizer(
         active::ViewProjMatrix const&       viewProj,
         active::EntityToDraw::UserData_t    userData) noexcept;
 
-void sync_drawent_visualizer(
+inline void sync_drawent_visualizer(
         active::DrawEnt const               ent,
         active::DrawEntSet_t const&         hasMaterial,
         active::RenderGroup::Storage_t&     rStorage,
-        ACtxDrawMeshVisualizer&             rData);
+        ACtxDrawMeshVisualizer&             rData)
+{
+    using namespace active;
 
+    bool alreadyAdded = rStorage.contains(ent);
+    if (hasMaterial.test(std::size_t(ent)))
+    {
+        if ( ! alreadyAdded)
+        {
+            rStorage.emplace( ent, EntityToDraw{&draw_ent_visualizer, {&rData} } );
+        }
+    }
+    else
+    {
+        if (alreadyAdded)
+        {
+            rStorage.erase(ent);
+        }
+    }
+}
 template <typename ITA_T, typename ITB_T>
 static void sync_drawent_visualizer(
         ITA_T const&                        first,

--- a/src/osp/Shaders/MeshVisualizer.h
+++ b/src/osp/Shaders/MeshVisualizer.h
@@ -45,11 +45,12 @@ struct ACtxDrawMeshVisualizer
 
     bool m_wireframeOnly{false};
 
-    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
-                                   active::RenderGL& rRenderGl) noexcept
+constexpr void assign_pointers(active::ACtxSceneRender&         rScnRender,
+                                   active::ACtxSceneRenderGL&   rScnRenderGl,
+                                   active::RenderGL&            rRenderGl) noexcept
     {
-        m_pDrawTf   = &rCtxScnGl.m_drawTransform;
-        m_pMeshId   = &rCtxScnGl.m_meshId;
+        m_pDrawTf   = &rScnRender.m_drawTransform;
+        m_pMeshId   = &rScnRenderGl.m_meshId;
         m_pMeshGl   = &rRenderGl.m_meshGl;
     }
 };

--- a/src/osp/Shaders/Phong.cpp
+++ b/src/osp/Shaders/Phong.cpp
@@ -32,10 +32,11 @@ using namespace osp::active;
 using namespace osp::shader;
 
 void shader::draw_ent_phong(
-        DrawEnt ent, ViewProjMatrix const& viewProj,
-        EntityToDraw::UserData_t userData) noexcept
+        DrawEnt                     ent,
+        ViewProjMatrix const&       viewProj,
+        EntityToDraw::UserData_t    userData) noexcept
 {
-    using Flag = Phong::Flag;
+    using Flag = PhongGL::Flag;
 
     void* const pData   = std::get<0>(userData);
     void* const pShader = std::get<1>(userData);
@@ -43,10 +44,10 @@ void shader::draw_ent_phong(
     assert(pShader != nullptr);
 
     auto &rData   = *reinterpret_cast<ACtxDrawPhong*>(pData);
-    auto &rShader = *reinterpret_cast<Phong*>(pShader);
+    auto &rShader = *reinterpret_cast<PhongGL*>(pShader);
 
     // Collect uniform information
-    Matrix4 const &drawTf = (*rData.m_pDrawTf)[ent];
+    Matrix4 const &drawTf = (*rData.pDrawTf)[ent];
 
     Magnum::Matrix4 entRelative = viewProj.m_view * drawTf;
 
@@ -58,8 +59,8 @@ void shader::draw_ent_phong(
 
     if (rShader.flags() & Flag::DiffuseTexture)
     {
-        TexGlId const texGlId = (*rData.m_pDiffuseTexId)[ent].m_glId;
-        Magnum::GL::Texture2D &rTexture = rData.m_pTexGl->get(texGlId);
+        TexGlId const texGlId = (*rData.pDiffuseTexId)[ent].m_glId;
+        Magnum::GL::Texture2D &rTexture = rData.pTexGl->get(texGlId);
         rShader.bindDiffuseTexture(rTexture);
 
         if (rShader.flags() & (Flag::AmbientTexture | Flag::AlphaMask))
@@ -68,13 +69,13 @@ void shader::draw_ent_phong(
         }
     }
 
-    if (rData.m_pColor != nullptr)
+    if (rData.pColor != nullptr)
     {
-        rShader.setDiffuseColor((*rData.m_pColor)[ent]);
+        rShader.setDiffuseColor((*rData.pColor)[ent]);
     }
 
-    MeshGlId const meshId = (*rData.m_pMeshId)[ent].m_glId;
-    Magnum::GL::Mesh &rMesh = rData.m_pMeshGl->get(meshId);
+    MeshGlId const      meshId = (*rData.pMeshId)[ent].m_glId;
+    Magnum::GL::Mesh    &rMesh = rData.pMeshGl->get(meshId);
 
     Matrix3 a{viewProj.m_view};
 
@@ -111,5 +112,4 @@ void shader::draw_ent_phong(
         .setNormalMatrix(entRelative.normalMatrix())
         .draw(rMesh);
 }
-
 

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -57,7 +57,7 @@ struct ACtxDrawPhong
                                    active::ACtxSceneRenderGL&   rScnRenderGl,
                                    active::RenderGL&            rRenderGl) noexcept
     {
-        pDrawTf         = &rScnRenderGl .m_drawTransform;
+        pDrawTf         = &rScnRender   .m_drawTransform;
         pColor          = &rScnRender   .m_color;
         pDiffuseTexId   = &rScnRenderGl .m_diffuseTexId;
         pMeshId         = &rScnRenderGl .m_meshId;
@@ -89,7 +89,7 @@ inline void sync_drawent_phong(active::DrawEnt ent, ArgsForSyncDrawEntPhong cons
     auto const entInt = std::size_t(ent);
 
     bool const hasMaterial = args.hasMaterial.test(entInt);
-    bool const hasTexture = (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
+    bool const hasTexture = (args.diffuse.size() > std::size_t(ent)) && (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
 
     PhongGL *pShader = hasTexture
                      ? &args.rData.shaderDiffuse

--- a/src/osp/Shaders/Phong.h
+++ b/src/osp/Shaders/Phong.h
@@ -28,40 +28,41 @@
 
 #include <Magnum/Shaders/PhongGL.h>
 
+#include <optional>
+
 namespace osp::shader
 {
 
-using Phong = Magnum::Shaders::PhongGL;
+using PhongGL = Magnum::Shaders::PhongGL;
 
 /**
  * @brief Stores per-scene data needed for Phong shaders to draw
  */
 struct ACtxDrawPhong
 {
-    template <typename T>
-    using acomp_storage_t = osp::active::acomp_storage_t<T>;
+    PhongGL                     shaderUntextured    {Corrade::NoCreate};
+    PhongGL                     shaderDiffuse       {Corrade::NoCreate};
 
-    Phong m_shaderUntextured    {Corrade::NoCreate};
-    Phong m_shaderDiffuse       {Corrade::NoCreate};
+    active::DrawTransforms_t    *pDrawTf            {nullptr};
+    active::DrawEntColors_t     *pColor             {nullptr};
+    active::TexGlEntStorage_t   *pDiffuseTexId      {nullptr};
+    active::MeshGlEntStorage_t  *pMeshId            {nullptr};
 
-    osp::active::DrawTransforms_t               *m_pDrawTf{nullptr};
-    osp::KeyedVec<osp::active::DrawEnt, Magnum::Color4> *m_pColor{nullptr};
-    osp::active::TexGlEntStorage_t              *m_pDiffuseTexId{nullptr};
-    osp::active::MeshGlEntStorage_t             *m_pMeshId{nullptr};
+    active::TexGlStorage_t      *pTexGl             {nullptr};
+    active::MeshGlStorage_t     *pMeshGl            {nullptr};
 
-    osp::active::TexGlStorage_t                 *m_pTexGl{nullptr};
-    osp::active::MeshGlStorage_t                *m_pMeshGl{nullptr};
+    active::MaterialId materialId { lgrn::id_null<active::MaterialId>() };
 
-    constexpr void assign_pointers(active::ACtxSceneRenderGL& rCtxScnGl,
-                                   active::RenderGL& rRenderGl) noexcept
+    constexpr void assign_pointers(active::ACtxSceneRender&     rScnRender,
+                                   active::ACtxSceneRenderGL&   rScnRenderGl,
+                                   active::RenderGL&            rRenderGl) noexcept
     {
-        m_pDrawTf       = &rCtxScnGl.m_drawTransform;
-        // TODO: ACompColor
-        m_pDiffuseTexId = &rCtxScnGl.m_diffuseTexId;
-        m_pMeshId       = &rCtxScnGl.m_meshId;
-
-        m_pTexGl        = &rRenderGl.m_texGl;
-        m_pMeshGl       = &rRenderGl.m_meshGl;
+        pDrawTf         = &rScnRenderGl .m_drawTransform;
+        pColor          = &rScnRender   .m_color;
+        pDiffuseTexId   = &rScnRenderGl .m_diffuseTexId;
+        pMeshId         = &rScnRenderGl .m_meshId;
+        pTexGl          = &rRenderGl    .m_texGl;
+        pMeshGl         = &rRenderGl    .m_meshGl;
     }
 };
 
@@ -70,75 +71,59 @@ void draw_ent_phong(
         active::ViewProjMatrix const& viewProj,
         active::EntityToDraw::UserData_t userData) noexcept;
 
-/**
- * @brief Assign a Phong shader to a set of entities, and write results to
- *        a RenderGroup
- *
- * @param dirtyFirst            [in] Iterator to first entity to sync
- * @param dirtyLast             [in] Iterator to last entity to sync
- * @param hasMaterial           [in] Which entities a phong material is assigned to
- * @param pStorageOpaque        [out] Optional RenderGroup storage for opaque
- * @param pStorageTransparent   [out] Optional RenderGroup storage for transparent
- * @param opaque                [in] Storage for opaque component
- * @param diffuse               [in] Storage for diffuse texture component
- * @param rData                 [in] Phong shader data, stable memory required
- */
-template<typename ITA_T, typename ITB_T>
-void sync_phong(
-        ITA_T dirtyIt,
-        ITB_T const& dirtyLast,
-        active::DrawEntSet_t const& hasMaterial,
-        active::RenderGroup::Storage_t *const pStorageOpaque,
-        active::RenderGroup::Storage_t *const pStorageTransparent,
-        KeyedVec<active::DrawEnt, active:: BasicDrawProps> const& drawBasic,
-        active::TexGlEntStorage_t const& diffuse,
-        ACtxDrawPhong &rData)
+struct ArgsForSyncDrawEntPhong
+{
+    active::DrawEntSet_t const&             hasMaterial;
+    active::RenderGroup::Storage_t *const   pStorageOpaque      {nullptr};
+    active::RenderGroup::Storage_t *const   pStorageTransparent {nullptr};
+    active::DrawEntSet_t const&             opaque;
+    active::DrawEntSet_t const&             transparent;
+    active::TexGlEntStorage_t const&        diffuse;
+    ACtxDrawPhong&                          rData;
+};
+
+inline void sync_drawent_phong(active::DrawEnt ent, ArgsForSyncDrawEntPhong const args)
 {
     using namespace active;
 
-    for (; dirtyIt != dirtyLast; std::advance(dirtyIt, 1))
+    auto const entInt = std::size_t(ent);
+
+    bool const hasMaterial = args.hasMaterial.test(entInt);
+    bool const hasTexture = (args.diffuse[ent].m_glId != lgrn::id_null<TexGlId>());
+
+    PhongGL *pShader = hasTexture
+                     ? &args.rData.shaderDiffuse
+                     : &args.rData.shaderUntextured;
+
+    if (args.pStorageTransparent != nullptr)
     {
-        DrawEnt const ent = *dirtyIt;
+        auto value = (hasMaterial && args.transparent.test(entInt))
+                   ? std::make_optional(EntityToDraw{&draw_ent_phong, {&args.rData, pShader}})
+                   : std::nullopt;
 
-        // Erase from group if they exist
-        if (pStorageOpaque != nullptr)
-        {
-            pStorageOpaque->remove(ent);
-        }
-        if (pStorageTransparent != nullptr)
-        {
-            pStorageTransparent->remove(ent);
-        }
+        storage_assign(*args.pStorageTransparent, ent, std::move(value));
+    }
 
-        if ( ! hasMaterial.test(std::size_t(ent)))
-        {
-            continue; // Phong material is not assigned to this entity
-        }
+    if (args.pStorageOpaque != nullptr)
+    {
+        auto value = (hasMaterial && args.opaque.test(entInt))
+                   ? std::make_optional(EntityToDraw{&draw_ent_phong, {&args.rData, pShader}})
+                   : std::nullopt;
 
-        Phong *pShader = (diffuse[ent].m_glId != lgrn::id_null<TexGlId>())
-                       ? &rData.m_shaderDiffuse
-                       : &rData.m_shaderUntextured;
-
-        if (drawBasic[ent].m_opaque)
-        {
-            if (pStorageOpaque == nullptr)
-            {
-                continue;
-            }
-
-            pStorageOpaque->emplace(ent, EntityToDraw{&draw_ent_phong, {&rData, pShader} });
-        }
-        else
-        {
-            if (pStorageTransparent == nullptr)
-            {
-                continue;
-            }
-
-            pStorageTransparent->emplace(ent, EntityToDraw{&draw_ent_phong, {&rData, pShader} });
-        }
+        storage_assign(*args.pStorageOpaque, ent, std::move(value));
     }
 }
 
+template<typename ITA_T, typename ITB_T>
+void sync_drawent_phong(
+        ITA_T const&                    first,
+        ITB_T const&                    last,
+        ArgsForSyncDrawEntPhong const   args)
+{
+    std::for_each(first, last, [&args] (active::DrawEnt const ent)
+    {
+        sync_drawent_phong(ent, args);
+    });
+}
 
 } // namespace osp::shader

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -289,9 +289,6 @@ struct PlNewton
 
 #define TESTAPP_DATA_UNI_CORE 2, \
     idUniverse,         tgUniDeltaTimeIn
-#define OSP_TAGS_TESTAPP_UNI_CORE 4, \
-    tgUniUpdEvt,        tgUniTimeEvt,                           \
-    tgUniTransferMod,   tgUniTransferReq
 struct PlUniCore
 {
     PipelineDef<EStgOptn> update            {"update - Universe update"};
@@ -300,8 +297,6 @@ struct PlUniCore
 
 #define TESTAPP_DATA_UNI_SCENEFRAME 1, \
     idScnFrame
-#define OSP_TAGS_TESTAPP_UNI_SCENEFRAME 2, \
-    tgScnFramePosMod,   tgScnFramePosReq
 struct PlUniSceneFrame
 {
     PipelineDef<EStgCont> sceneFrame        {"sceneFrame"};

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -344,6 +344,8 @@ struct PlSceneRenderer
     PipelineDef<EStgCont> material          {"material"};
     PipelineDef<EStgIntr> materialDirty     {"materialDirty"};
 
+    PipelineDef<EStgIntr> drawTransforms    {"drawTransforms"};
+
     PipelineDef<EStgCont> group             {"group"};
     PipelineDef<EStgCont> groupEnts         {"groupEnts"};
     PipelineDef<EStgCont> entMesh           {"entMesh"};
@@ -377,7 +379,6 @@ struct PlMagnumScene
 {
     PipelineDef<EStgFBO>  fbo               {"fboRender"};
 
-    PipelineDef<EStgIntr> drawTransforms    {"drawTransforms"};
     PipelineDef<EStgCont> camera            {"camera"};
 
 };

--- a/src/test_application/activescenes/identifiers.h
+++ b/src/test_application/activescenes/identifiers.h
@@ -158,25 +158,6 @@ struct PlCommonScene
 
     PipelineDef<EStgCont> transform         {"transform"};
     PipelineDef<EStgCont> hierarchy         {"hierarchy"};
-
-    PipelineDef<EStgCont> drawEnt           {"drawEnt"};
-    PipelineDef<EStgOptn> drawEntResized    {"drawEntResized"};
-    PipelineDef<EStgIntr> drawEntDelete     {"drawEntDelete - Vector of DrawEnts that need to be deleted"};
-
-    PipelineDef<EStgCont> mesh              {"mesh"};
-    PipelineDef<EStgCont> texture           {"texture"};
-
-    PipelineDef<EStgCont> entMesh           {"entMesh - Scene-side DrawEnt-MeshId association"};
-    PipelineDef<EStgCont> entTexture        {"entTexture - Scene-side DrawEnt-TexId association"};
-
-    PipelineDef<EStgIntr> entTextureDirty   {"entTextureDirty"};
-    PipelineDef<EStgIntr> entMeshDirty      {"entMeshDirty"};
-
-    PipelineDef<EStgIntr> meshResDirty      {"meshResDirty"};
-    PipelineDef<EStgIntr> textureResDirty   {"textureResDirty"};
-
-    PipelineDef<EStgCont> material          {"material"};
-    PipelineDef<EStgIntr> materialDirty     {"materialDirty"};
 };
 
 
@@ -196,6 +177,7 @@ struct PlShapeSpawn
 {
     PipelineDef<EStgIntr> spawnRequest      {"spawnRequest"};
     PipelineDef<EStgIntr> spawnedEnts       {"spawnedEnts"};
+    PipelineDef<EStgRevd> ownedEnts         {"ownedEnts"};
 };
 
 
@@ -310,11 +292,20 @@ struct PlNewton
 #define OSP_TAGS_TESTAPP_UNI_CORE 4, \
     tgUniUpdEvt,        tgUniTimeEvt,                           \
     tgUniTransferMod,   tgUniTransferReq
+struct PlUniCore
+{
+    PipelineDef<EStgOptn> update            {"update - Universe update"};
+    PipelineDef<EStgIntr> transfer          {"transfer"};
+};
 
 #define TESTAPP_DATA_UNI_SCENEFRAME 1, \
     idScnFrame
 #define OSP_TAGS_TESTAPP_UNI_SCENEFRAME 2, \
     tgScnFramePosMod,   tgScnFramePosReq
+struct PlUniSceneFrame
+{
+    PipelineDef<EStgCont> sceneFrame        {"sceneFrame"};
+};
 
 #define TESTAPP_DATA_UNI_PLANETS 2, \
     idPlanetMainSpace, idSatSurfaceSpaces
@@ -328,6 +319,41 @@ struct PlNewton
 struct PlWindowApp
 {
     PipelineDef<EStgOptn> inputs            {"inputs"};
+    PipelineDef<EStgOptn> sync              {"sync"};
+    PipelineDef<EStgOptn> resync            {"resync"};
+
+    PipelineDef<EStgEvnt> cleanup           {"cleanup - Cleanup renderer resources before destruction"};
+
+};
+
+
+
+#define TESTAPP_DATA_SCENE_RENDERER 1, \
+    idScnRender
+struct PlSceneRenderer
+{
+    PipelineDef<EStgOptn> render            {"render"};
+
+    PipelineDef<EStgCont> drawEnt           {"drawEnt"};
+    PipelineDef<EStgOptn> drawEntResized    {"drawEntResized"};
+    PipelineDef<EStgIntr> drawEntDelete     {"drawEntDelete - Vector of DrawEnts that need to be deleted"};
+
+    PipelineDef<EStgIntr> entTextureDirty   {"entTextureDirty"};
+    PipelineDef<EStgIntr> entMeshDirty      {"entMeshDirty"};
+
+    PipelineDef<EStgCont> material          {"material"};
+    PipelineDef<EStgIntr> materialDirty     {"materialDirty"};
+
+    PipelineDef<EStgCont> group             {"group"};
+    PipelineDef<EStgCont> groupEnts         {"groupEnts"};
+    PipelineDef<EStgCont> entMesh           {"entMesh"};
+    PipelineDef<EStgCont> entTexture        {"entTexture"};
+
+    PipelineDef<EStgCont> mesh              {"mesh"};
+    PipelineDef<EStgCont> texture           {"texture"};
+
+    PipelineDef<EStgIntr> meshResDirty      {"meshResDirty"};
+    PipelineDef<EStgIntr> textureResDirty   {"textureResDirty"};
 };
 
 
@@ -336,11 +362,6 @@ struct PlWindowApp
     idActiveApp, idRenderGl
 struct PlMagnum
 {
-    PipelineDef<EStgEvnt> cleanup           {"cleanup - Cleanup magnum renderer resources before destruction"};
-
-    PipelineDef<EStgOptn> sync              {"sync"};
-    PipelineDef<EStgOptn> resync            {"resync"};
-
     PipelineDef<EStgCont> meshGL            {"meshGL"};
     PipelineDef<EStgCont> textureGL         {"textureGL"};
 
@@ -350,20 +371,15 @@ struct PlMagnum
 
 
 
-#define TESTAPP_DATA_COMMON_RENDERER 3, \
-    idScnRender, idGroupFwd, idCamera
-struct PlSceneRenderer
+#define TESTAPP_DATA_MAGNUM_SCENE 3, \
+    idScnRenderGl, idGroupFwd, idCamera
+struct PlMagnumScene
 {
-    PipelineDef<EStgOptn> render            {"render"};
-
     PipelineDef<EStgFBO>  fbo               {"fboRender"};
-    PipelineDef<EStgCont> scnRender         {"scnRender"};
-    PipelineDef<EStgCont> group             {"group"};
-    PipelineDef<EStgCont> groupEnts         {"groupEnts"};
+
     PipelineDef<EStgIntr> drawTransforms    {"drawTransforms"};
     PipelineDef<EStgCont> camera            {"camera"};
-    PipelineDef<EStgCont> entMesh           {"entMesh"};
-    PipelineDef<EStgCont> entTexture        {"entTexture"};
+
 };
 
 

--- a/src/test_application/activescenes/scenarios.cpp
+++ b/src/test_application/activescenes/scenarios.cpp
@@ -228,7 +228,7 @@ static ScenarioMap_t make_scenarios()
                  [] (TestApp& rTestApp) -> RendererSetupFunc_t
     {
         #define SCENE_SESSIONS      scene, commonScene, physics, shapeSpawn, droppers, bounds, newton, nwtGravSet, nwtGrav, shapeSpawnNwt
-        #define RENDERER_SESSIONS   sceneRenderer, magnumScene, cameraCtrl, cameraFree, shVisual, camThrow, shapeDraw
+        #define RENDERER_SESSIONS   sceneRenderer, magnumScene, cameraCtrl, cameraFree, shVisual, shFlat, shPhong, camThrow, shapeDraw, cursor
 
         using namespace testapp::scenes;
 
@@ -244,7 +244,7 @@ static ScenarioMap_t make_scenarios()
         scene           = setup_scene               (builder, rTopData, application);
         commonScene     = setup_common_scene        (builder, rTopData, scene, application, defaultPkg);
         physics         = setup_physics             (builder, rTopData, scene, commonScene);
-        shapeSpawn      = setup_shape_spawn         (builder, rTopData, scene, commonScene, physics, sc_matVisualizer);
+        shapeSpawn      = setup_shape_spawn         (builder, rTopData, scene, commonScene, physics, sc_matPhong);
         droppers        = setup_droppers            (builder, rTopData, scene, commonScene, shapeSpawn);
         bounds          = setup_bounds              (builder, rTopData, scene, commonScene, shapeSpawn);
 
@@ -266,17 +266,20 @@ static ScenarioMap_t make_scenarios()
             TopTaskBuilder builder{rTestApp.m_tasks, rTestApp.m_renderer.m_edges, rTestApp.m_taskData};
 
             auto & [SCENE_SESSIONS] = unpack<10>(rTestApp.m_scene.m_sessions);
-            auto & [RENDERER_SESSIONS] = resize_then_unpack<7>(rTestApp.m_renderer.m_sessions);
+            auto & [RENDERER_SESSIONS] = resize_then_unpack<10>(rTestApp.m_renderer.m_sessions);
 
             sceneRenderer   = setup_scene_renderer      (builder, rTopData, application, windowApp, commonScene);
+            create_materials(rTopData, sceneRenderer, sc_materialCount);
+
             magnumScene     = setup_magnum_scene        (builder, rTopData, application, windowApp, sceneRenderer, magnum, scene, commonScene);
             cameraCtrl      = setup_camera_ctrl         (builder, rTopData, windowApp, sceneRenderer, magnumScene);
             cameraFree      = setup_camera_free         (builder, rTopData, windowApp, scene, cameraCtrl);
-            shVisual        = setup_shader_phong        (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, sc_matVisualizer);
+            shVisual        = setup_shader_visualizer   (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, sc_matVisualizer);
+            shFlat          = setup_shader_flat         (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, sc_matFlat);
+            shPhong         = setup_shader_phong        (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, sc_matPhong);
             camThrow        = setup_thrower             (builder, rTopData, windowApp, cameraCtrl, shapeSpawn);
             shapeDraw       = setup_shape_spawn_draw    (builder, rTopData, windowApp, sceneRenderer, commonScene, physics, shapeSpawn);
-
-            create_materials(rTopData, sceneRenderer, sc_materialCount);
+            cursor          = setup_cursor              (builder, rTopData, application, sceneRenderer, cameraCtrl, commonScene, sc_matFlat, rTestApp.m_defaultPkg);
 
             setup_magnum_draw(rTestApp, scene, sceneRenderer, magnumScene);
         };

--- a/src/test_application/activescenes/scenarios.cpp
+++ b/src/test_application/activescenes/scenarios.cpp
@@ -266,14 +266,13 @@ static ScenarioMap_t make_scenarios()
             TopTaskBuilder builder{rTestApp.m_tasks, rTestApp.m_renderer.m_edges, rTestApp.m_taskData};
 
             auto & [SCENE_SESSIONS] = unpack<10>(rTestApp.m_scene.m_sessions);
-
             auto & [RENDERER_SESSIONS] = resize_then_unpack<7>(rTestApp.m_renderer.m_sessions);
 
             sceneRenderer   = setup_scene_renderer      (builder, rTopData, application, windowApp, commonScene);
             magnumScene     = setup_magnum_scene        (builder, rTopData, application, windowApp, sceneRenderer, magnum, scene, commonScene);
             cameraCtrl      = setup_camera_ctrl         (builder, rTopData, windowApp, sceneRenderer, magnumScene);
             cameraFree      = setup_camera_free         (builder, rTopData, windowApp, scene, cameraCtrl);
-            shVisual        = setup_shader_visualizer   (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, scene, commonScene, sc_matVisualizer);
+            shVisual        = setup_shader_phong        (builder, rTopData, windowApp, sceneRenderer, magnum, magnumScene, sc_matVisualizer);
             camThrow        = setup_thrower             (builder, rTopData, windowApp, cameraCtrl, shapeSpawn);
             shapeDraw       = setup_shape_spawn_draw    (builder, rTopData, windowApp, sceneRenderer, commonScene, physics, shapeSpawn);
 
@@ -281,7 +280,11 @@ static ScenarioMap_t make_scenarios()
 
             setup_magnum_draw(rTestApp, scene, sceneRenderer, magnumScene);
         };
+
+        #undef SCENE_SESSIONS
+        #undef RENDERER_SESSIONS
     });
+
 
 #if 0
 

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -229,15 +229,15 @@ struct EngineTestRenderer
  * @param rRenderer [ref] Renderer data for test scene
  */
 void sync_test_scene(
-        RenderGL& rRenderGl, EngineTestScene const& rScene,
+        RenderGL& rRenderGl, EngineTestScene& rScene,
         EngineTestRenderer& rRenderer)
 {
     using namespace osp::active;
     using namespace osp::shader;
 
-    rRenderer.m_sceneRenderGL.m_drawTransform.resize(rScene.m_scnRdr.m_drawIds.capacity());
+    rScene.m_scnRdr.m_drawTransform         .resize(rScene.m_scnRdr.m_drawIds.capacity());
     rRenderer.m_sceneRenderGL.m_diffuseTexId.resize(rScene.m_scnRdr.m_drawIds.capacity());
-    rRenderer.m_sceneRenderGL.m_meshId.resize(rScene.m_scnRdr.m_drawIds.capacity());
+    rRenderer.m_sceneRenderGL.m_meshId      .resize(rScene.m_scnRdr.m_drawIds.capacity());
 
     // Assign or remove phong shaders from entities marked dirty
     sync_drawent_phong(rScene.m_matPhongDirty.cbegin(), rScene.m_matPhongDirty.cend(),
@@ -280,7 +280,7 @@ void sync_test_scene(
             rScene.m_basic.m_scnGraph,
             rScene.m_scnRdr.m_activeToDraw,
             rScene.m_basic.m_transform,
-            rRenderer.m_sceneRenderGL.m_drawTransform,
+            rScene.m_scnRdr.m_drawTransform,
             rScene.m_scnRdr.m_needDrawTf,
             drawTfDirty.begin(),
             drawTfDirty.end());

--- a/src/test_application/activescenes/scenarios_enginetest.cpp
+++ b/src/test_application/activescenes/scenarios_enginetest.cpp
@@ -99,6 +99,8 @@ struct EngineTestScene
     osp::active::ActiveEntSet_t         m_matPhong;
     std::vector<osp::active::DrawEnt>   m_matPhongDirty;
 
+    // This should be part of the renderer but who cares lol!
+    osp::active::ACtxSceneRender m_scnRdr;
 };
 
 EngineTestScene::~EngineTestScene()
@@ -111,7 +113,7 @@ EngineTestScene::~EngineTestScene()
     // single integer internally.
     // Cleanup must be manual, but this has the advantage of having no side
     // effects, and practically zero runtime overhead.
-    osp::active::SysRender::clear_owners(m_drawing);
+    osp::active::SysRender::clear_owners(m_scnRdr, m_drawing);
     osp::active::SysRender::clear_resource_owners(m_drawingRes, *m_pResources);
 }
 
@@ -126,13 +128,14 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
 
     // Make a cube
     ActiveEnt const cubeEnt = rScene.m_activeIds.create();
-    DrawEnt const   cubeDraw = rScene.m_drawing.m_drawIds.create();
+    DrawEnt const   cubeDraw = rScene.m_scnRdr.m_drawIds.create();
 
     // Resize some containers to fit all existing entities
-    rScene.m_matPhong.ints()    .resize(rScene.m_activeIds.vec().capacity());
-    rScene.m_basic.m_scnGraph   .resize(rScene.m_activeIds.capacity());
-    rScene.m_drawing.resize_active(rScene.m_activeIds.capacity());
-    rScene.m_drawing.resize_draw();
+    std::size_t const maxEnts = rScene.m_activeIds.vec().capacity();
+    rScene.m_matPhong.ints()    .resize(maxEnts);
+    rScene.m_basic.m_scnGraph   .resize(maxEnts);
+    rScene.m_scnRdr.resize_active(maxEnts);
+    rScene.m_scnRdr.resize_draw();
 
     // Take ownership of the cube mesh Resource. This will create a scene-space
     // MeshId that we can assign to ActiveEnts
@@ -142,10 +145,10 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
 
     // Add cube mesh to cube
 
-    rScene.m_drawing.m_needDrawTf.set(std::size_t(cubeEnt));
-    rScene.m_drawing.m_activeToDraw[cubeEnt] = cubeDraw;
-    rScene.m_drawing.m_mesh[cubeDraw] = rScene.m_drawing.m_meshRefCounts.ref_add(meshCube);
-    rScene.m_drawing.m_meshDirty.push_back(cubeDraw);
+    rScene.m_scnRdr.m_needDrawTf.set(std::size_t(cubeEnt));
+    rScene.m_scnRdr.m_activeToDraw[cubeEnt] = cubeDraw;
+    rScene.m_scnRdr.m_mesh[cubeDraw] = rScene.m_drawing.m_meshRefCounts.ref_add(meshCube);
+    rScene.m_scnRdr.m_meshDirty.push_back(cubeDraw);
 
     // Add transform
     rScene.m_basic.m_transform.emplace(cubeEnt);
@@ -155,8 +158,8 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
     rScene.m_matPhongDirty.push_back(cubeDraw);
 
     // Add drawble, opaque, and visible component
-    rScene.m_drawing.m_visible.set(std::size_t(cubeDraw));
-    rScene.m_drawing.m_drawBasic[cubeDraw].m_opaque = true;
+    rScene.m_scnRdr.m_visible.set(std::size_t(cubeDraw));
+    rScene.m_scnRdr.m_drawBasic[cubeDraw].m_opaque = true;
 
     // Add cube to hierarchy, parented to root
     SubtreeBuilder builder = SysSceneGraph::add_descendants(rScene.m_basic.m_scnGraph, 1);
@@ -175,8 +178,8 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
 void update_test_scene(EngineTestScene& rScene, float const delta)
 {
     // Clear drawing-related dirty flags/vectors
-    rScene.m_drawing.m_meshDirty.clear();
-    rScene.m_drawing.m_diffuseDirty.clear();
+    rScene.m_scnRdr.m_meshDirty.clear();
+    rScene.m_scnRdr.m_diffuseDirty.clear();
     rScene.m_matPhongDirty.clear();
 
     // Rotate the cube
@@ -232,16 +235,16 @@ void sync_test_scene(
     using namespace osp::active;
     using namespace osp::shader;
 
-    rRenderer.m_sceneRenderGL.m_drawTransform.resize(rScene.m_drawing.m_drawIds.capacity());
-    rRenderer.m_sceneRenderGL.m_diffuseTexId.resize(rScene.m_drawing.m_drawIds.capacity());
-    rRenderer.m_sceneRenderGL.m_meshId.resize(rScene.m_drawing.m_drawIds.capacity());
+    rRenderer.m_sceneRenderGL.m_drawTransform.resize(rScene.m_scnRdr.m_drawIds.capacity());
+    rRenderer.m_sceneRenderGL.m_diffuseTexId.resize(rScene.m_scnRdr.m_drawIds.capacity());
+    rRenderer.m_sceneRenderGL.m_meshId.resize(rScene.m_scnRdr.m_drawIds.capacity());
 
     // Assign or remove phong shaders from entities marked dirty
     sync_phong(
             std::cbegin(rScene.m_matPhongDirty),
             std::cend(rScene.m_matPhongDirty),
             rScene.m_matPhong, &rRenderer.m_groupFwdOpaque.m_entities, nullptr,
-            rScene.m_drawing.m_drawBasic, rRenderer.m_sceneRenderGL.m_diffuseTexId,
+            rScene.m_scnRdr.m_drawBasic, rRenderer.m_sceneRenderGL.m_diffuseTexId,
             rRenderer.m_phong);
 
     // Load required meshes and textures into OpenGL
@@ -250,18 +253,18 @@ void sync_test_scene(
 
     // Assign GL meshes to entities with a mesh component
     SysRenderGL::sync_drawent_mesh(
-            rScene.m_drawing.m_meshDirty.begin(),
-            rScene.m_drawing.m_meshDirty.end(),
-            rScene.m_drawing.m_mesh,
+            rScene.m_scnRdr.m_meshDirty.begin(),
+            rScene.m_scnRdr.m_meshDirty.end(),
+            rScene.m_scnRdr.m_mesh,
             rScene.m_drawingRes.m_meshToRes,
             rRenderer.m_sceneRenderGL.m_meshId,
             rRenderGl);
 
     // Assign GL textures to entities with a texture component
     SysRenderGL::sync_drawent_texture(
-            rScene.m_drawing.m_meshDirty.begin(),
-            rScene.m_drawing.m_meshDirty.end(),
-            rScene.m_drawing.m_diffuseTex,
+            rScene.m_scnRdr.m_meshDirty.begin(),
+            rScene.m_scnRdr.m_meshDirty.end(),
+            rScene.m_scnRdr.m_diffuseTex,
             rScene.m_drawingRes.m_texToRes,
             rRenderer.m_sceneRenderGL.m_diffuseTexId,
             rRenderGl);
@@ -272,10 +275,10 @@ void sync_test_scene(
 
     SysRender::update_draw_transforms(
             rScene.m_basic.m_scnGraph,
-            rScene.m_drawing.m_activeToDraw,
+            rScene.m_scnRdr.m_activeToDraw,
             rScene.m_basic.m_transform,
             rRenderer.m_sceneRenderGL.m_drawTransform,
-            rScene.m_drawing.m_needDrawTf,
+            rScene.m_scnRdr.m_needDrawTf,
             drawTfDirty.begin(),
             drawTfDirty.end());
 }
@@ -312,7 +315,7 @@ void render_test_scene(
     // Forward Render fwd_opaque group to FBO
     SysRenderGL::render_opaque(
             rRenderer.m_groupFwdOpaque,
-            rScene.m_drawing.m_visible, viewProj);
+            rScene.m_scnRdr.m_visible, viewProj);
 
     // Display FBO
     Texture2D &rFboColor = rRenderGl.m_texGl.get(rRenderGl.m_fboColor);
@@ -327,9 +330,6 @@ public:
      , m_rScene     {rScene}
      , m_rRenderGl  {rRenderGl}
     { }
-
-    ~EngineTestApp() override
-    { };
 
     void run(MagnumApplication& rApp) override
     { }
@@ -348,7 +348,10 @@ public:
     }
 
     void exit(MagnumApplication& rApp) override
-    { }
+    {
+        osp::active::SysRenderGL::clear_resource_owners(m_rRenderGl, *m_rScene.m_pResources);
+        m_rRenderGl = {}; // clear all GPU resources
+    }
 
     EngineTestRenderer  m_renderer;
 
@@ -378,7 +381,32 @@ MagnumApplication::AppPtr_t generate_draw_func(EngineTestScene& rScene, MagnumAp
 
     // Set all drawing stuff dirty then sync with renderer.
     // This allows clean re-openning of the scene
-    SysRender::set_dirty_all(rScene.m_drawing);
+    for (std::size_t const drawEntInt : rScene.m_scnRdr.m_drawIds.bitview().zeros())
+    {
+        auto const drawEnt = DrawEnt(drawEntInt);
+
+        // Set all meshs dirty
+        if (rScene.m_scnRdr.m_mesh[drawEnt] != lgrn::id_null<MeshId>())
+        {
+            rScene.m_scnRdr.m_meshDirty.push_back(drawEnt);
+        }
+
+        // Set all textures dirty
+        if (rScene.m_scnRdr.m_diffuseTex[drawEnt] != lgrn::id_null<TexId>())
+        {
+            rScene.m_scnRdr.m_diffuseDirty.push_back(drawEnt);
+        }
+    }
+
+    for (std::size_t const materialInt : rScene.m_scnRdr.m_materialIds.bitview().zeros())
+    {
+        Material &mat = rScene.m_scnRdr.m_materials[MaterialId(materialInt)];
+        for (std::size_t const entInt : mat.m_ents.ones())
+        {
+            mat.m_dirty.push_back(DrawEnt(entInt));
+        }
+    }
+
     for (std::size_t const entInt : rScene.m_matPhong.ones())
     {
         rScene.m_matPhongDirty.push_back(DrawEnt(entInt));

--- a/src/test_application/activescenes/scene_misc.cpp
+++ b/src/test_application/activescenes/scene_misc.cpp
@@ -39,6 +39,8 @@
 
 #include <osp/unpack.h>
 
+#include <random>
+
 using namespace osp;
 using namespace osp::active;
 
@@ -53,107 +55,67 @@ namespace testapp::scenes
 
 void create_materials(
         ArrayView<entt::any> const  topData,
-        Session const&              commonScene,
+        Session const&              sceneRenderer,
         int const                   count)
 {
-    OSP_DECLARE_GET_DATA_IDS(commonScene, TESTAPP_DATA_COMMON_SCENE);
-    auto &rDrawing = top_get< ACtxDrawing >(topData, idDrawing);
+    OSP_DECLARE_GET_DATA_IDS(sceneRenderer, TESTAPP_DATA_SCENE_RENDERER);
+    auto &rScnRender = top_get< ACtxSceneRender >(topData, idScnRender);
 
     for (int i = 0; i < count; ++i)
     {
-        [[maybe_unused]] MaterialId const mat = rDrawing.m_materialIds.create();
+        [[maybe_unused]] MaterialId const mat = rScnRender.m_materialIds.create();
         LGRN_ASSERT(int(mat) == i);
     }
 
-    rDrawing.m_materials.resize(count);
+    rScnRender.m_materials.resize(count);
 }
 
 void add_floor(
         ArrayView<entt::any> const  topData,
-        Session const&              application,
-        Session const&              commonScene,
         Session const&              shapeSpawn,
         MaterialId const            materialId,
         PkgId const                 pkg)
 {
-    OSP_DECLARE_GET_DATA_IDS(application,   TESTAPP_DATA_APPLICATION);
-    OSP_DECLARE_GET_DATA_IDS(commonScene,   TESTAPP_DATA_COMMON_SCENE);
-    OSP_DECLARE_GET_DATA_IDS(shapeSpawn,    TESTAPP_DATA_SHAPE_SPAWN);
+    OSP_DECLARE_GET_DATA_IDS(shapeSpawn, TESTAPP_DATA_SHAPE_SPAWN);
 
-    auto &rResources    = top_get< Resources >          (topData, idResources);
-    auto &rBasic        = top_get< ACtxBasic >          (topData, idBasic);
-    auto &rDrawing      = top_get< ACtxDrawing >        (topData, idDrawing);
-    auto &rDrawingRes   = top_get< ACtxDrawingRes >     (topData, idDrawingRes);
-    auto &rSpawner      = top_get< ACtxShapeSpawner >   (topData, idSpawner);
+    auto &rSpawner = top_get<ACtxShapeSpawner>(topData, idSpawner);
 
-    Material &rMaterial = rDrawing.m_materials.at(materialId);
+    std::mt19937 randGen(69);
+    auto distSizeX  = std::uniform_real_distribution<float>{20.0, 80.0};
+    auto distSizeY  = std::uniform_real_distribution<float>{20.0, 80.0};
+    auto distHeight = std::uniform_real_distribution<float>{1.0, 10.0};
 
-    // Convenient functor to get a reference-counted mesh owner
-    auto const quick_add_mesh = SysRender::gen_drawable_mesh_adder(rDrawing, rDrawingRes, rResources, pkg);
+    constexpr int   extendCount = 6;
+    constexpr float spread      = 128.0f;
 
-    // start making floor
-
-    static constexpr Vector3 const sc_floorSize{64.0f, 64.0f, 1.0f};
-    static constexpr Vector3 const sc_floorPos{0.0f, 0.0f, -1.005f};
-
-    // Create floor root and mesh entity
-    ActiveEnt const floorRootEnt = rBasic.m_activeIds.create();
-    ActiveEnt const floorMeshEnt = rBasic.m_activeIds.create();
-    DrawEnt const floorMeshDrawEnt = rDrawing.m_drawIds.create();
-
-    // Resize some containers to fit all existing entities
-    rBasic.m_scnGraph.resize(rBasic.m_activeIds.capacity());
-    rDrawing.resize_active(rBasic.m_activeIds.capacity());
-    rDrawing.resize_draw();
-    bitvector_resize(rMaterial.m_ents, rDrawing.m_drawIds.capacity());
-
-    rBasic.m_transform.emplace(floorRootEnt);
-
-    // Add mesh to floor mesh entity
-    rDrawing.m_activeToDraw[floorMeshEnt] = floorMeshDrawEnt;
-    rDrawing.m_mesh[floorMeshDrawEnt] = quick_add_mesh("grid64solid");
-    rDrawing.m_meshDirty.push_back(floorMeshDrawEnt);
-
-    // Add mesh visualizer material to floor mesh entity
-    rMaterial.m_ents.set(std::size_t(floorMeshDrawEnt));
-    rMaterial.m_dirty.push_back(floorMeshDrawEnt);
-
-    // Add transform, draw transform, opaque, and visible entity
-    rBasic.m_transform.emplace(floorMeshEnt, ACompTransform{Matrix4::scaling(sc_floorSize)});
-    rDrawing.m_drawBasic[floorMeshDrawEnt].m_opaque = true;
-    rDrawing.m_visible.set(std::size_t(floorMeshDrawEnt));
-    rDrawing.m_needDrawTf.set(std::size_t(floorRootEnt));
-    rDrawing.m_needDrawTf.set(std::size_t(floorMeshEnt));
-
-    SubtreeBuilder builder = SysSceneGraph::add_descendants(rBasic.m_scnGraph, 2);
-
-    // Add floor root to hierarchy root
-    SubtreeBuilder bldFloorRoot = builder.add_child(floorRootEnt, 1);
-
-    // Parent floor mesh entity to floor root entity
-    bldFloorRoot.add_child(floorMeshEnt);
-
-    // Add collider to floor root entity
-    rSpawner.m_spawnRequest.emplace_back(SpawnShape{
-        .m_position = sc_floorPos,
-        .m_velocity = sc_floorSize,
-        .m_size     = sc_floorSize,
-        .m_mass     = 0.0f,
-        .m_shape    = EShape::Box
-    });
+    for (int x = -extendCount; x < extendCount+1; ++x)
+    {
+        for (int y = -extendCount; y < extendCount+1; ++y)
+        {
+            float const heightZ = distHeight(randGen);
+            rSpawner.m_spawnRequest.emplace_back(SpawnShape{
+                .m_position = Vector3{x*spread, y*spread, heightZ},
+                .m_velocity = {0.0f, 0.0f, 0.0f},
+                .m_size     = Vector3{distSizeX(randGen), distSizeY(randGen), heightZ},
+                .m_mass     = 0.0f,
+                .m_shape    = EShape::Box
+            });
+        }
+    }
 }
 
 Session setup_camera_ctrl(
         TopTaskBuilder&             rBuilder,
         ArrayView<entt::any> const  topData,
         Session const&              windowApp,
-        Session const&              scnRender)
+        Session const&              sceneRenderer,
+        Session const&              magnumScene)
 {
     OSP_DECLARE_GET_DATA_IDS(windowApp,     TESTAPP_DATA_WINDOW_APP);
-    OSP_DECLARE_GET_DATA_IDS(scnRender,     TESTAPP_DATA_COMMON_RENDERER);
-
-    auto const tgSR  = scnRender.get_pipelines<PlSceneRenderer>();
-    //auto const tgWin = windowApp.get_pipelines<PlWindowApp>();
+    OSP_DECLARE_GET_DATA_IDS(magnumScene,   TESTAPP_DATA_MAGNUM_SCENE);
+    auto const tgWin    = windowApp     .get_pipelines<PlWindowApp>();
+    auto const tgScnRdr = sceneRenderer .get_pipelines<PlSceneRenderer>();
+    auto const tgSR     = magnumScene   .get_pipelines<PlMagnumScene>();
 
     auto &rUserInput = top_get< osp::input::UserInputHandler >(topData, idUserInput);
 
@@ -163,11 +125,11 @@ Session setup_camera_ctrl(
 
     top_emplace< ACtxCameraController > (topData, idCamCtrl, rUserInput);
 
-    rBuilder.pipeline(tgCmCt.camCtrl).parent(tgSR.render);
+    rBuilder.pipeline(tgCmCt.camCtrl).parent(tgScnRdr.render);
 
     rBuilder.task()
         .name       ("Position Rendering Camera according to Camera Controller")
-        .run_on     ({tgSR.render(Run)})
+        .run_on     ({tgScnRdr.render(Run)})
         .sync_with  ({tgCmCt.camCtrl(Ready), tgSR.camera(Modify)})
         .push_to    (out.m_tasks)
         .args       ({                           idCamCtrl,        idCamera })
@@ -334,8 +296,6 @@ Session setup_bounds(
         Session const&              commonScene,
         Session const&              shapeSpawn)
 {
-    using ActiveEntVec_t = std::vector<ActiveEnt>;
-
     OSP_DECLARE_GET_DATA_IDS(commonScene,   TESTAPP_DATA_COMMON_SCENE);
     OSP_DECLARE_GET_DATA_IDS(shapeSpawn,    TESTAPP_DATA_SHAPE_SPAWN);
     auto const tgScn    = scene         .get_pipelines<PlScene>();

--- a/src/test_application/activescenes/scene_misc.cpp
+++ b/src/test_application/activescenes/scene_misc.cpp
@@ -74,7 +74,8 @@ void add_floor(
         ArrayView<entt::any> const  topData,
         Session const&              shapeSpawn,
         MaterialId const            materialId,
-        PkgId const                 pkg)
+        PkgId const                 pkg,
+        int const                   size)
 {
     OSP_DECLARE_GET_DATA_IDS(shapeSpawn, TESTAPP_DATA_SHAPE_SPAWN);
 
@@ -85,12 +86,11 @@ void add_floor(
     auto distSizeY  = std::uniform_real_distribution<float>{20.0, 80.0};
     auto distHeight = std::uniform_real_distribution<float>{1.0, 10.0};
 
-    constexpr int   extendCount = 6;
     constexpr float spread      = 128.0f;
 
-    for (int x = -extendCount; x < extendCount+1; ++x)
+    for (int x = -size; x < size+1; ++x)
     {
-        for (int y = -extendCount; y < extendCount+1; ++y)
+        for (int y = -size; y < size+1; ++y)
         {
             float const heightZ = distHeight(randGen);
             rSpawner.m_spawnRequest.emplace_back(SpawnShape{
@@ -113,7 +113,6 @@ Session setup_camera_ctrl(
 {
     OSP_DECLARE_GET_DATA_IDS(windowApp,     TESTAPP_DATA_WINDOW_APP);
     OSP_DECLARE_GET_DATA_IDS(magnumScene,   TESTAPP_DATA_MAGNUM_SCENE);
-    auto const tgWin    = windowApp     .get_pipelines<PlWindowApp>();
     auto const tgScnRdr = sceneRenderer .get_pipelines<PlSceneRenderer>();
     auto const tgSR     = magnumScene   .get_pipelines<PlMagnumScene>();
 
@@ -206,13 +205,20 @@ Session setup_thrower(
             Matrix4 const &camTf = rCamCtrl.m_transform;
             float const speed = 120;
             float const dist = 8.0f;
-            rSpawner.m_spawnRequest.push_back({
-                .m_position = camTf.translation() - camTf.backward() * dist,
-                .m_velocity = -camTf.backward() * speed,
-                .m_size     = Vector3{1.0f},
-                .m_mass     = 1.0f,
-                .m_shape    = EShape::Sphere
-            });
+
+            for (int x = -2; x < 3; ++x)
+            {
+                for (int y = -2; y < 3; ++y)
+                {
+                    rSpawner.m_spawnRequest.push_back({
+                        .m_position = camTf.translation() - camTf.backward()*dist + camTf.up()*y*5.5f + camTf.right()*x*5.5f,
+                        .m_velocity = -camTf.backward()*speed,
+                        .m_size     = Vector3{1.0f},
+                        .m_mass     = 1.0f,
+                        .m_shape    = EShape::Sphere
+                    });
+                }
+            }
         }
     });
 

--- a/src/test_application/activescenes/scene_misc.h
+++ b/src/test_application/activescenes/scene_misc.h
@@ -40,7 +40,8 @@ void add_floor(
         osp::ArrayView<entt::any>   topData,
         osp::Session const&         shapeSpawn,
         osp::active::MaterialId     material,
-        osp::PkgId                  pkg);
+        osp::PkgId                  pkg,
+        int                         size);
 
 /**
  * @brief Create CameraController connected to an app's UserInputHandler

--- a/src/test_application/activescenes/scene_misc.h
+++ b/src/test_application/activescenes/scene_misc.h
@@ -33,13 +33,11 @@ namespace testapp::scenes
 
 void create_materials(
         osp::ArrayView<entt::any>   topData,
-        osp::Session const&         commonScene,
+        osp::Session const&         sceneRenderer,
         int                         count);
 
 void add_floor(
         osp::ArrayView<entt::any>   topData,
-        osp::Session const&         application,
-        osp::Session const&         commonScene,
         osp::Session const&         shapeSpawn,
         osp::active::MaterialId     material,
         osp::PkgId                  pkg);
@@ -51,7 +49,8 @@ osp::Session setup_camera_ctrl(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
         osp::Session const&         windowApp,
-        osp::Session const&         scnRender);
+        osp::Session const&         sceneRenderer,
+        osp::Session const&         magnumScene);
 
 /**
  * @brief Adds free cam controls to a CameraController

--- a/src/test_application/activescenes/scene_physics.cpp
+++ b/src/test_application/activescenes/scene_physics.cpp
@@ -232,7 +232,6 @@ Session setup_shape_spawn_draw(
     auto const tgWin    = windowApp     .get_pipelines< PlWindowApp >();
     auto const tgScnRdr = sceneRenderer .get_pipelines< PlSceneRenderer >();
     auto const tgCS     = commonScene   .get_pipelines< PlCommonScene >();
-    auto const tgPhy    = physics       .get_pipelines< PlPhysics >();
     auto const tgShSp   = shapeSpawn    .get_pipelines< PlShapeSpawn >();
 
     Session out;

--- a/src/test_application/activescenes/scene_physics.cpp
+++ b/src/test_application/activescenes/scene_physics.cpp
@@ -281,7 +281,7 @@ Session setup_shape_spawn_draw(
             rMat.m_dirty.push_back(drawEnt);
 
             rScnRender.m_visible.set(std::size_t(drawEnt));
-            rScnRender.m_drawBasic[drawEnt].m_opaque = true;
+            rScnRender.m_opaque.set(std::size_t(drawEnt));
         }
     });
 
@@ -334,7 +334,7 @@ Session setup_shape_spawn_draw(
             rMat.m_dirty.push_back(drawEnt);
 
             rScnRender.m_visible.set(std::size_t(drawEnt));
-            rScnRender.m_drawBasic[drawEnt].m_opaque = true;
+            rScnRender.m_opaque.set(std::size_t(drawEnt));
         }
     });
 

--- a/src/test_application/activescenes/scene_physics.h
+++ b/src/test_application/activescenes/scene_physics.h
@@ -47,6 +47,8 @@ struct SpawnShape
 
 struct ACtxShapeSpawner
 {
+    osp::active::ActiveEntSet_t     m_ownedEnts;
+
     std::vector<SpawnShape>         m_spawnRequest;
     osp::active::ActiveEntVec_t     m_ents;
     osp::active::MaterialId         m_materialId;
@@ -82,6 +84,15 @@ osp::Session setup_shape_spawn(
         osp::Session const&         commonScene,
         osp::Session const&         physics,
         osp::active::MaterialId     materialId);
+
+osp::Session setup_shape_spawn_draw(
+        osp::TopTaskBuilder&        rBuilder,
+        osp::ArrayView<entt::any>   topData,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
+        osp::Session const&         commonScene,
+        osp::Session const&         physics,
+        osp::Session const&         shapeSpawn);
 
 /**
  * @brief Queues and logic for spawning Prefab resources

--- a/src/test_application/activescenes/scene_renderer.h
+++ b/src/test_application/activescenes/scene_renderer.h
@@ -76,8 +76,6 @@ osp::Session setup_shader_visualizer(
         osp::Session const&         sceneRenderer,
         osp::Session const&         magnum,
         osp::Session const&         magnumScene,
-        osp::Session const&         scene,
-        osp::Session const&         commonScene,
         osp::active::MaterialId     materialId = lgrn::id_null<osp::active::MaterialId>());
 
 
@@ -88,10 +86,11 @@ osp::Session setup_shader_visualizer(
 osp::Session setup_shader_flat(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         magnum,
-        osp::Session const&         scene,
-        osp::Session const&         scnRender,
-        osp::Session const&         material);
+        osp::Session const&         magnumScene,
+        osp::active::MaterialId     materialId = lgrn::id_null<osp::active::MaterialId>());
 
 /**
  * @brief Magnum Phong shader and optional material for drawing ActiveEnts with it
@@ -99,10 +98,11 @@ osp::Session setup_shader_flat(
 osp::Session setup_shader_phong(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         magnum,
-        osp::Session const&         scene,
-        osp::Session const&         scnRender,
-        osp::Session const&         material);
+        osp::Session const&         magnumScene,
+        osp::active::MaterialId     materialId = lgrn::id_null<osp::active::MaterialId>());
 
 /**
  * @brief Red indicators over Magic Rockets

--- a/src/test_application/activescenes/scene_renderer.h
+++ b/src/test_application/activescenes/scene_renderer.h
@@ -78,8 +78,6 @@ osp::Session setup_shader_visualizer(
         osp::Session const&         magnumScene,
         osp::active::MaterialId     materialId = lgrn::id_null<osp::active::MaterialId>());
 
-
-
 /**
  * @brief Magnum Flat shader and optional material for drawing ActiveEnts with it
  */
@@ -133,21 +131,20 @@ osp::Session setup_cursor(
         osp::active::MaterialId const material,
         osp::PkgId const            pkg);
 
-
-
 /**
  * @brief Draw universe, specifically designed for setup_uni_test_planets
  */
-osp::Session setup_uni_test_planets_renderer(
+osp::Session setup_testplanets_draw(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
-        osp::Session const&         magnum,
-        osp::Session const&         scnRender,
-        osp::Session const&         commonScene,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         cameraCtrl,
-        osp::Session const&         visualizer,
+        osp::Session const&         commonScene,
         osp::Session const&         uniCore,
         osp::Session const&         uniScnFrame,
-        osp::Session const&         uniTestPlanets);
+        osp::Session const&         uniTestPlanets,
+        osp::active::MaterialId const matPlanets,
+        osp::active::MaterialId const matAxis);
 
 }

--- a/src/test_application/activescenes/scene_renderer.h
+++ b/src/test_application/activescenes/scene_renderer.h
@@ -126,13 +126,14 @@ osp::Session setup_thrust_indicators(
 osp::Session setup_cursor(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
-        osp::Session const&         magnum,
-        osp::Session const&         commonScene,
-        osp::Session const&         scnRender,
+        osp::Session const&         application,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         cameraCtrl,
-        osp::Session const&         shFlat,
-        osp::TopDataId const        idResources,
+        osp::Session const&         commonScene,
+        osp::active::MaterialId const material,
         osp::PkgId const            pkg);
+
+
 
 /**
  * @brief Draw universe, specifically designed for setup_uni_test_planets

--- a/src/test_application/activescenes/scene_renderer.h
+++ b/src/test_application/activescenes/scene_renderer.h
@@ -35,25 +35,33 @@ namespace testapp::scenes
 {
 
 osp::Session setup_window_app(
-        osp::TopTaskBuilder&            rBuilder,
-        osp::ArrayView<entt::any>       topData,
-        osp::Session const&             application);
+        osp::TopTaskBuilder&        rBuilder,
+        osp::ArrayView<entt::any>   topData,
+        osp::Session const&         application);
 
-osp::Session setup_magnum(
-        osp::TopTaskBuilder&            rBuilder,
-        osp::ArrayView<entt::any>       topData,
-        osp::Session const&             windowApp,
-        osp::Session const&             application,
-        MagnumApplication::Arguments    args);
-
-/**
- * @brief Magnum-powered OpenGL Renderer
- */
 osp::Session setup_scene_renderer(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
         osp::Session const&         application,
         osp::Session const&         windowApp,
+        osp::Session const&         commonScene);
+
+osp::Session setup_magnum(
+        osp::TopTaskBuilder&            rBuilder,
+        osp::ArrayView<entt::any>       topData,
+        osp::Session const&             application,
+        osp::Session const&             windowApp,
+        MagnumApplication::Arguments    args);
+
+/**
+ * @brief stuff needed to render a scene using Magnum
+ */
+osp::Session setup_magnum_scene(
+        osp::TopTaskBuilder&        rBuilder,
+        osp::ArrayView<entt::any>   topData,
+        osp::Session const&         application,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         magnum,
         osp::Session const&         scene,
         osp::Session const&         commonScene);
@@ -64,11 +72,15 @@ osp::Session setup_scene_renderer(
 osp::Session setup_shader_visualizer(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
+        osp::Session const&         windowApp,
+        osp::Session const&         sceneRenderer,
         osp::Session const&         magnum,
+        osp::Session const&         magnumScene,
         osp::Session const&         scene,
         osp::Session const&         commonScene,
-        osp::Session const&         scnRender,
         osp::active::MaterialId     materialId = lgrn::id_null<osp::active::MaterialId>());
+
+
 
 /**
  * @brief Magnum Flat shader and optional material for drawing ActiveEnts with it

--- a/src/test_application/activescenes/scene_universe.cpp
+++ b/src/test_application/activescenes/scene_universe.cpp
@@ -41,35 +41,43 @@ using namespace osp::universe;
 namespace testapp::scenes
 {
 
-#if 0
-
 Session setup_uni_core(
         TopTaskBuilder&             rBuilder,
-        ArrayView<entt::any>        topData)
+        ArrayView<entt::any>        topData,
+        PipelineId const            updateOn)
 {
-    Session uniCore;
-    OSP_SESSION_ACQUIRE_DATA(uniCore, topData, TESTAPP_UNI_CORE);
-    OSP_SESSION_ACQUIRE_TAGS(uniCore, rTags,   TESTAPP_UNI_CORE);
+    Session out;
+    OSP_DECLARE_CREATE_DATA_IDS(out, topData, TESTAPP_DATA_UNI_CORE);
 
     top_emplace< Universe > (topData, idUniverse);
 
-    return uniCore;
+    auto const tgUCore = out.create_pipelines<PlUniCore>(rBuilder);
+
+    rBuilder.pipeline(tgUCore.update).parent(updateOn).wait_for_signal(EStgOptn::ModifyOrSignal);
+
+    rBuilder.pipeline(tgUCore.transfer).parent(tgUCore.update);
+
+    return out;
 }
 
 
 Session setup_uni_sceneframe(
         TopTaskBuilder&             rBuilder,
+        Session const&              uniCore,
         ArrayView<entt::any>        topData)
 {
-    Session scnFrame;
-    OSP_SESSION_ACQUIRE_DATA(scnFrame, topData, TESTAPP_UNI_SCENEFRAME);
-    OSP_SESSION_ACQUIRE_TAGS(scnFrame, rTags,   TESTAPP_UNI_SCENEFRAME);
+    auto const tgUCore =  uniCore.get_pipelines<PlUniCore>();
 
-    rBuilder.tag(tgScnFramePosReq).depend_on({tgScnFramePosMod});
+    Session out;
+    OSP_DECLARE_CREATE_DATA_IDS(out, topData, TESTAPP_DATA_UNI_SCENEFRAME);
 
     top_emplace< SceneFrame > (topData, idScnFrame);
 
-    return scnFrame;
+    auto const tgUSFrm = out.create_pipelines<PlUniSceneFrame>(rBuilder);
+
+    rBuilder.pipeline(tgUSFrm.sceneFrame).parent(tgUCore.update);
+
+    return out;
 }
 
 
@@ -82,10 +90,11 @@ Session setup_uni_test_planets(
     using CoSpaceIdVec_t = std::vector<CoSpaceId>;
     using Corrade::Containers::Array;
 
-    OSP_SESSION_UNPACK_TAGS(uniCore,        TESTAPP_UNI_CORE);
-    OSP_SESSION_UNPACK_DATA(uniCore,        TESTAPP_UNI_CORE);
-    OSP_SESSION_UNPACK_TAGS(scnFrame,    TESTAPP_UNI_SCENEFRAME);
-    OSP_SESSION_UNPACK_DATA(scnFrame,    TESTAPP_UNI_SCENEFRAME);
+    OSP_DECLARE_GET_DATA_IDS(uniCore, TESTAPP_DATA_UNI_CORE);
+    OSP_DECLARE_GET_DATA_IDS(scnFrame, TESTAPP_DATA_UNI_SCENEFRAME);
+
+    auto const tgUCore = uniCore.get_pipelines<PlUniCore>();
+    auto const tgUSFrm = scnFrame.get_pipelines<PlUniSceneFrame>();
 
     auto &rUniverse = top_get< Universe >(topData, idUniverse);
 
@@ -170,18 +179,20 @@ Session setup_uni_test_planets(
     rScnFrame.m_parent   = mainSpace;
     rScnFrame.m_position = math::mul_2pow<Vector3g, int>({400, 400, 400}, precision);
 
-    Session uniTestPlanets;
-    OSP_SESSION_ACQUIRE_DATA(uniTestPlanets, topData, TESTAPP_UNI_PLANETS);
+    Session out;
+    OSP_DECLARE_CREATE_DATA_IDS(out, topData, TESTAPP_DATA_UNI_PLANETS);
 
     top_emplace< CoSpaceId >        (topData, idPlanetMainSpace, mainSpace);
     top_emplace< float >            (topData, tgUniDeltaTimeIn, 1.0f / 60.0f);
     top_emplace< CoSpaceIdVec_t >   (topData, idSatSurfaceSpaces, std::move(satSurfaceSpaces));
 
-
-    uniTestPlanets.task() = rBuilder.task().assign({tgUniTimeEvt, tgScnFramePosReq}).data(
-            "Update planets",
-            TopDataIds_t{          idUniverse,               idPlanetMainSpace,            idScnFrame,                      idSatSurfaceSpaces,           tgUniDeltaTimeIn},
-            wrap_args([] (Universe& rUniverse, CoSpaceId const planetMainSpace, SceneFrame &rScnFrame, CoSpaceIdVec_t const& rSatSurfaceSpaces, float const uniDeltaTimeIn) noexcept
+    rBuilder.task()
+        .name       ("Update planets")
+        .run_on     (tgUCore.update(Run))
+        .sync_with  ({tgUSFrm.sceneFrame(Modify)})
+        .push_to    (out.m_tasks)
+        .args       ({     idUniverse,               idPlanetMainSpace,            idScnFrame,                      idSatSurfaceSpaces,           tgUniDeltaTimeIn })
+        .func([] (Universe& rUniverse, CoSpaceId const planetMainSpace, SceneFrame &rScnFrame, CoSpaceIdVec_t const& rSatSurfaceSpaces, float const uniDeltaTimeIn) noexcept
     {
         CoSpaceCommon &rMainSpaceCommon = rUniverse.m_coordCommon[planetMainSpace];
 
@@ -283,11 +294,9 @@ Session setup_uni_test_planets(
                 rScnFrame.m_rotation = surfaceToMain.rotation() * rScnFrame.m_rotation;
             }
         }
-    }));
+    });
 
-    return uniTestPlanets;
+    return out;
 }
-
-#endif
 
 } // namespace testapp::scenes

--- a/src/test_application/activescenes/scene_universe.cpp
+++ b/src/test_application/activescenes/scene_universe.cpp
@@ -53,7 +53,7 @@ Session setup_uni_core(
 
     auto const tgUCore = out.create_pipelines<PlUniCore>(rBuilder);
 
-    rBuilder.pipeline(tgUCore.update).parent(updateOn).wait_for_signal(EStgOptn::ModifyOrSignal);
+    rBuilder.pipeline(tgUCore.update).parent(updateOn);//.wait_for_signal(EStgOptn::ModifyOrSignal);
 
     rBuilder.pipeline(tgUCore.transfer).parent(tgUCore.update);
 
@@ -63,8 +63,8 @@ Session setup_uni_core(
 
 Session setup_uni_sceneframe(
         TopTaskBuilder&             rBuilder,
-        Session const&              uniCore,
-        ArrayView<entt::any>        topData)
+        ArrayView<entt::any>        topData,
+        Session const&              uniCore)
 {
     auto const tgUCore =  uniCore.get_pipelines<PlUniCore>();
 
@@ -81,20 +81,20 @@ Session setup_uni_sceneframe(
 }
 
 
-Session setup_uni_test_planets(
+Session setup_uni_testplanets(
         TopTaskBuilder&             rBuilder,
         ArrayView<entt::any>        topData,
         Session const&              uniCore,
-        Session const&              scnFrame)
+        Session const&              uniScnFrame)
 {
     using CoSpaceIdVec_t = std::vector<CoSpaceId>;
     using Corrade::Containers::Array;
 
     OSP_DECLARE_GET_DATA_IDS(uniCore, TESTAPP_DATA_UNI_CORE);
-    OSP_DECLARE_GET_DATA_IDS(scnFrame, TESTAPP_DATA_UNI_SCENEFRAME);
+    OSP_DECLARE_GET_DATA_IDS(uniScnFrame, TESTAPP_DATA_UNI_SCENEFRAME);
 
-    auto const tgUCore = uniCore.get_pipelines<PlUniCore>();
-    auto const tgUSFrm = scnFrame.get_pipelines<PlUniSceneFrame>();
+    auto const tgUCore = uniCore    .get_pipelines<PlUniCore>();
+    auto const tgUSFrm = uniScnFrame.get_pipelines<PlUniSceneFrame>();
 
     auto &rUniverse = top_get< Universe >(topData, idUniverse);
 

--- a/src/test_application/activescenes/scene_universe.h
+++ b/src/test_application/activescenes/scene_universe.h
@@ -42,13 +42,13 @@ osp::Session setup_uni_core(
  */
 osp::Session setup_uni_sceneframe(
         osp::TopTaskBuilder&        rBuilder,
-        osp::Session const&         uniCore,
-        osp::ArrayView<entt::any>   topData);
+        osp::ArrayView<entt::any>   topData,
+        osp::Session const&         uniCore);
 
 /**
  * @brief Unrealistic planets test, allows SceneFrame to move around and get captured into planets
  */
-osp::Session setup_uni_test_planets(
+osp::Session setup_uni_testplanets(
         osp::TopTaskBuilder&        rBuilder,
         osp::ArrayView<entt::any>   topData,
         osp::Session const&         uniCore,

--- a/src/test_application/activescenes/scene_universe.h
+++ b/src/test_application/activescenes/scene_universe.h
@@ -34,13 +34,15 @@ namespace testapp::scenes
  */
 osp::Session setup_uni_core(
         osp::TopTaskBuilder&        rBuilder,
-        osp::ArrayView<entt::any>   topData);
+        osp::ArrayView<entt::any>   topData,
+        osp::PipelineId             updateOn);
 
 /**
  * @brief Represents the physics scene's presence in a Universe
  */
 osp::Session setup_uni_sceneframe(
         osp::TopTaskBuilder&        rBuilder,
+        osp::Session const&         uniCore,
         osp::ArrayView<entt::any>   topData);
 
 /**

--- a/src/test_application/main.cpp
+++ b/src/test_application/main.cpp
@@ -279,7 +279,7 @@ void start_magnum_async()
         osp::TopTaskBuilder builder{g_testApp.m_tasks, g_testApp.m_renderer.m_edges, g_testApp.m_taskData};
 
         g_testApp.m_windowApp   = scenes::setup_window_app  (builder, g_testApp.m_topData, g_testApp.m_application);
-        g_testApp.m_magnum      = scenes::setup_magnum      (builder, g_testApp.m_topData, g_testApp.m_windowApp, g_testApp.m_application, {g_argc, g_argv});
+        g_testApp.m_magnum      = scenes::setup_magnum      (builder, g_testApp.m_topData, g_testApp.m_application, g_testApp.m_windowApp, {g_argc, g_argv});
 
         OSP_DECLARE_GET_DATA_IDS(g_testApp.m_magnum, TESTAPP_DATA_MAGNUM); // declares idActiveApp
         auto &rActiveApp = osp::top_get<MagnumApplication>(g_testApp.m_topData, idActiveApp);
@@ -300,6 +300,7 @@ void start_magnum_async()
         rActiveApp.set_osp_app({});
         
         // Closing sessions will delete their associated TopData and Tags
+        g_testApp.m_pExecutor->run(g_testApp, g_testApp.m_windowApp.m_cleanup);
         g_testApp.close_sessions(g_testApp.m_renderer.m_sessions);
         g_testApp.m_renderer.m_sessions.clear();
         g_testApp.m_renderer.m_edges.m_syncWith.clear();


### PR DESCRIPTION
adds stuff

## Move DrawEnts to renderer

The universe test scene, cursor, and other stuff actually call OpenGL-specific functions and do a bit of heavy lifting when all they really need to do is 'put a sphere at xyz', motivating the 'phase-2' of separating out DrawEnts from ActiveEnt.

The idea of "Draw Entities" came around when separating the concerns the common game engine pattern of "representing the world using a tree of entities, nodes, or game objects". This causes spaghetti as the tree handles too much of everything. Things intended only for visual effect can overlap and interfere with other game logic. Unfortunately, I was following this pattern because I didn't know any better at the time, leading to a tree of ActiveEnts representing everything.

DrawEnts were separated out from ActiveEnt back in #234, but the DrawEnts still resided as scene state. Nothing was changed structurally. Now, it's moved to its own 'scene renderer' session. This means all DrawEnts are deleted when the window closes, and must be regenerated from existing scene state when re-opened.

DrawEnts evolved to basically describes an API-agnostic drawable 3d scene; a retained-mode graphics library or additional layer of indirection. It uses the same 'ECS-inspired' pattern of each DrawEnt being a unique integer starting from zero, used as an index to many separate containers.

This completely cuts most or all scene-renderer coupling (I feel like I write this before but that was a joke), which means in theory, multiple windows/renderers can now be added simultaneously.

In order to draw things from the scene, the scene state needs to be synchronized with DrawEnts (this was already the case before). The shape spawning system, for example, has the renderer session `setup_shape_spawn_draw()` which basically goes:

```
for (each shape spawned) { make a DrawEnt for it }
```

Additionally, DrawEnts entirely optional. It's still possible to write tasks that call API-specific functions:

```
for (each shape spawned) { call OpenGL draw functions }
```

## Universe Test scene

It looks cool. Same one from #204 but updated for the current architecture.

![Screenshot_20230917_143155](https://github.com/TheOpenSpaceProgram/osp-magnum/assets/14708882/90a0f92f-59f1-4453-afe4-eb3d82e0c156)


## Other changes

* Increased power of the shape thrower to throw 25 spheres at the same time. this is more fun.
* Added bigger and more interesting floor for the test scenes
* Updated Flat and Phong shaders for the new architecture
* Re-add cursor session. This creates a green wireframe cube to indicate the center of where the camera is orbiting around in test scenes. It uses DrawEnts.