### PR TITLE
Update Longeron++ submodule

### DIFF
--- a/src/osp/core/Resources.cpp
+++ b/src/osp/core/Resources.cpp
@@ -41,7 +41,7 @@ ResId Resources::create(ResTypeId const typeId, PkgId const pkgId, SharedString 
     assert(rPkg.m_resTypeOwn.size() > std::size_t(typeId));
     PerPkgResType &rPkgType = rPkg.m_resTypeOwn[std::size_t(typeId)];
     rPkgType.m_owned.resize(rPerResType.m_resIds.capacity());
-    rPkgType.m_owned.set(std::size_t(newResId));
+    rPkgType.m_owned.insert(newResId);
 
     // Track name
     auto const& [newIt, success] = rPkgType.m_nameToResId.emplace(std::move(name), newResId);
@@ -80,7 +80,7 @@ SharedString const& Resources::name(ResTypeId const typeId, ResId const resId) c
     return rPerResType.m_resNames[std::size_t(resId)];
 }
 
-lgrn::IdRegistry<ResId> const& Resources::ids(ResTypeId const typeId) const noexcept
+lgrn::IdRegistryStl<ResId> const& Resources::ids(ResTypeId const typeId) const noexcept
 {
     return get_type(typeId).m_resIds;
 }

--- a/src/osp/core/Resources.h
+++ b/src/osp/core/Resources.h
@@ -24,11 +24,13 @@
  */
 #pragma once
 
+#include "copymove_macros.h"
 #include "shared_string.h"
 #include "resourcetypes.h"
 
-#include <longeron/id_management/registry.hpp>
+#include <longeron/id_management/id_set_stl.hpp>
 #include <longeron/id_management/refcount.hpp>
+#include <longeron/id_management/registry_stl.hpp>
 
 #include <entt/core/family.hpp>
 #include <entt/core/any.hpp>
@@ -48,7 +50,7 @@ class Resources
 
     struct PerResType
     {
-        lgrn::IdRegistry<ResId>         m_resIds;
+        lgrn::IdRegistryStl<ResId>      m_resIds;
         lgrn::RefCount<int>             m_resRefs;
         std::vector<res_data_type_t>    m_resDataTypes;
         std::vector<entt::any>          m_resData;
@@ -59,7 +61,7 @@ class Resources
 
     struct PerPkgResType
     {
-        lgrn::HierarchicalBitset<uint64_t> m_owned;
+        lgrn::IdSetStl<ResId> m_owned;
         std::unordered_map< SharedString, ResId, std::hash<SharedString>, std::equal_to<> > m_nameToResId;
     };
 
@@ -69,6 +71,9 @@ class Resources
     };
 
 public:
+
+    Resources() = default;
+    OSP_MOVE_ONLY_CTOR_ASSIGN(Resources);
 
     /**
      * @brief Resize to fit a certain number of resource types
@@ -103,7 +108,7 @@ public:
      */
     [[nodiscard]] SharedString const& name(ResTypeId typeId, ResId resId) const noexcept;
 
-    [[nodiscard]] lgrn::IdRegistry<ResId> const& ids(ResTypeId typeId) const noexcept;
+    [[nodiscard]] lgrn::IdRegistryStl<ResId> const& ids(ResTypeId typeId) const noexcept;
 
     [[nodiscard]] ResIdOwner_t owner_create(ResTypeId typeId, ResId resId) noexcept;
 
@@ -201,9 +206,9 @@ private:
     template <typename T>
     res_container_t<T> const& get_container(PerResType const &rPerResType, ResTypeId typeId) const;
 
-    std::vector<PerResType> m_perResType;
-    lgrn::IdRegistry<PkgId> m_pkgIds;
-    std::vector<PerPkg> m_pkgData;
+    std::vector<PerResType>     m_perResType;
+    lgrn::IdRegistryStl<PkgId>  m_pkgIds;
+    std::vector<PerPkg>         m_pkgData;
 };
 
 template<typename T>

--- a/src/osp/drawing_gl/rendergl.h
+++ b/src/osp/drawing_gl/rendergl.h
@@ -36,7 +36,7 @@
 #include <Magnum/Trade/MeshData.h>
 #include <Magnum/Trade/ImageData.h>
 
-#include <longeron/id_management/registry.hpp>
+#include <longeron/id_management/registry_stl.hpp>
 
 namespace osp::draw
 {
@@ -65,11 +65,11 @@ struct RenderGL
     Magnum::GL::Framebuffer             m_fbo{Corrade::NoCreate};
 
     // Renderer-space GL Textures
-    lgrn::IdRegistry<TexGlId>           m_texIds;
+    lgrn::IdRegistryStl<TexGlId>        m_texIds;
     TexGlStorage_t                      m_texGl;
 
     // Renderer-space GL Meshes
-    lgrn::IdRegistry<MeshGlId>          m_meshIds;
+    lgrn::IdRegistryStl<MeshGlId>       m_meshIds;
     MeshGlStorage_t                     m_meshGl;
 
     // Associate GL Texture Ids with resources

--- a/src/osp/tasks/top_session.h
+++ b/src/osp/tasks/top_session.h
@@ -26,6 +26,7 @@
 
 #include "tasks.h"
 #include "top_utils.h"
+#include "top_worker.h"
 
 #include "../core/unpack.h"
 
@@ -38,7 +39,13 @@
 #include <vector>
 
 #define OSP_AUX_DCDI_C(session, topData, count, ...) \
-    session.m_data.resize(count); \
+    session.m_data.resize(count, lgrn::id_null<osp::TopDataId>()); \
+    for (osp::TopDataId const id : session.m_data) \
+    { \
+        LGRN_ASSERTM(id == lgrn::id_null<osp::TopDataId>(),\
+                     "Can't replace existing TopDataId. " \
+                     "You likely meant to use GET_DATA_IDS instead of CREATE_DATA_IDS?");\
+    } \
     osp::top_reserve(topData, 0, session.m_data.begin(), session.m_data.end()); \
     auto const [__VA_ARGS__] = osp::unpack<count>(session.m_data)
 #define OSP_AUX_DCDI_B(x) x

--- a/src/planet-a/chunk_generate.cpp
+++ b/src/planet-a/chunk_generate.cpp
@@ -42,11 +42,11 @@ void ChunkScratchpad::resize(ChunkSkeleton const& rChSk)
 {
     auto const maxSharedVrtx = rChSk.m_sharedIds.capacity();
 
-    edgeVertices.resize((rChSk.m_chunkEdgeVrtxCount - 1) * 3);
-    stitchCmds  .resize(rChSk.m_chunkIds.capacity(), {});
-    osp::bitvector_resize(sharedAdded,        maxSharedVrtx);
-    osp::bitvector_resize(sharedRemoved,      maxSharedVrtx);
-    osp::bitvector_resize(sharedNormalsDirty, maxSharedVrtx);
+    edgeVertices        .resize((rChSk.m_chunkEdgeVrtxCount - 1) * 3);
+    stitchCmds          .resize(rChSk.m_chunkIds.capacity(), {});
+    sharedAdded         .resize(maxSharedVrtx);
+    sharedRemoved       .resize(maxSharedVrtx);
+    sharedNormalsDirty  .resize(maxSharedVrtx);
 }
 
 void restitch_check(
@@ -329,11 +329,11 @@ void subtract_normal_contrib(
             break;
         }
 
-        if (rSkCh.m_sharedIds.exists(rContrib.shared) && ! rChSP.sharedRemoved.test(rContrib.shared.value))
+        if (rSkCh.m_sharedIds.exists(rContrib.shared) && ! rChSP.sharedRemoved.contains(rContrib.shared))
         {
             osp::Vector3 &rNormal = rGeom.sharedNormalSum[rContrib.shared];
             rNormal -= rContrib.sum;
-            rChSP.sharedNormalsDirty.set(rContrib.shared.value);
+            rChSP.sharedNormalsDirty.insert(rContrib.shared);
         }
         rContrib.sum *= 0.0f;
     }
@@ -354,12 +354,12 @@ void subtract_normal_contrib(
                 break;
             }
 
-            if (rSkCh.m_sharedIds.exists(shared) && ! rChSP.sharedRemoved.test(shared.value))
+            if (rSkCh.m_sharedIds.exists(shared) && ! rChSP.sharedRemoved.contains(shared))
             {
                 Vector3 const &contrib = fillNormalContrib[i];
                 Vector3       &rNormal = rGeom.sharedNormalSum[shared];
                 rNormal -= contrib;
-                rChSP.sharedNormalsDirty.set(shared.value);
+                rChSP.sharedNormalsDirty.insert(shared);
             }
             fillNormalContrib[i] *= 0.0f;
         }

--- a/src/planet-a/chunk_generate.h
+++ b/src/planet-a/chunk_generate.h
@@ -51,13 +51,13 @@ struct ChunkScratchpad
     std::vector<ChunkId> chunksAdded;
 
     /// Recently added shared vertices, position needs to be copied from skeleton
-    osp::BitVector_t sharedAdded;
+    lgrn::IdSetStl<SharedVrtxId> sharedAdded;
 
     /// Recently added shared vertices
-    osp::BitVector_t sharedRemoved;
+    lgrn::IdSetStl<SharedVrtxId> sharedRemoved;
 
     /// Shared vertices that need to recalculate normals
-    osp::BitVector_t sharedNormalsDirty;
+    lgrn::IdSetStl<SharedVrtxId> sharedNormalsDirty;
 };
 
 /**

--- a/src/planet-a/geometry.h
+++ b/src/planet-a/geometry.h
@@ -125,7 +125,7 @@ struct TerrainFaceWriter
         fillNormalContrib[local.value]  += selectedFaceNormal;
         sharedNormalSum  [shared.value] += selectedFaceNormal;
 
-        rSharedNormalsDirty.set(shared.value);
+        rSharedNormalsDirty.insert(shared);
     }
 
     void fill_add_normal_filled(VertexIdx const vertex)
@@ -187,7 +187,7 @@ struct TerrainFaceWriter
         {
             rContrib.shared = shared;
             rContrib.sum = osp::Vector3{osp::ZeroInit};
-            rSharedNormalsDirty.set(shared.value);
+            rSharedNormalsDirty.insert(shared);
             std::advance(contribLast, 1);
             LGRN_ASSERT(contribLast != fanNormalContrib.end());
         }
@@ -212,7 +212,7 @@ struct TerrainFaceWriter
     osp::Vector3u                       selectedFaceIndx;
     IndxIt_t                            currentFace;
     ContribIt_t                         contribLast;
-    osp::BitVector_t                    &rSharedNormalsDirty;
+    lgrn::IdSetStl<SharedVrtxId>        &rSharedNormalsDirty;
 };
 static_assert(CFaceWriter<TerrainFaceWriter>, "TerrainFaceWriter must satisfy concept CFaceWriter");
 

--- a/src/planet-a/skeleton.h
+++ b/src/planet-a/skeleton.h
@@ -34,10 +34,11 @@
 #include "planeta_types.h"
 
 #include <osp/core/array_view.h>
-#include <osp/core/bitvector.h>
 #include <osp/core/copymove_macros.h>
 #include <osp/core/keyed_vector.h>
 #include <osp/core/math_2pow.h>
+
+#include <longeron/id_management/id_set_stl.hpp>
 
 #include <array>
 #include <vector>
@@ -394,10 +395,10 @@ public:
     struct Level
     {
         /// Subdivided triangles that neighbor a non-subdivided one
-        osp::BitVector_t hasNonSubdivedNeighbor;
+        lgrn::IdSetStl<SkTriId> hasNonSubdivedNeighbor;
 
         /// Non-subdivided triangles that neighbor a subdivided one
-        osp::BitVector_t hasSubdivedNeighbor;
+        lgrn::IdSetStl<SkTriId> hasSubdivedNeighbor;
     };
 
     std::array<Level, gc_maxSubdivLevels> levels;
@@ -482,12 +483,12 @@ public:
     ChunkId chunk_create(
             SkTriId                                     sktriId,
             SubdivTriangleSkeleton                      &rSkel,
-            osp::BitVector_t                            &rSharedAdded,
+            lgrn::IdSetStl<SharedVrtxId>                &rSharedAdded,
             osp::ArrayView< osp::MaybeNewId<SkVrtxId> > edgeLft,
             osp::ArrayView< osp::MaybeNewId<SkVrtxId> > edgeBtm,
             osp::ArrayView< osp::MaybeNewId<SkVrtxId> > edgeRte);
 
-    void chunk_remove(ChunkId chunkId, SkTriId sktriId, osp::BitVector_t &rSharedRemoved, SubdivTriangleSkeleton& rSkel) noexcept;
+    void chunk_remove(ChunkId chunkId, SkTriId sktriId, lgrn::IdSetStl<SharedVrtxId> &rSharedRemoved, SubdivTriangleSkeleton& rSkel) noexcept;
 
     /**
      * @brief Get shared vertices used by a chunk

--- a/src/planet-a/skeleton_subdiv.h
+++ b/src/planet-a/skeleton_subdiv.h
@@ -62,17 +62,17 @@ struct SkeletonSubdivScratchpad
 
     /// Used to record which Skeleton triangles have already been distance-checked. Used for both
     /// subdividing and unsubdividing
-    osp::BitVector_t distanceTestDone;
+    lgrn::IdSetStl<SkTriId> distanceTestDone;
 
-    osp::BitVector_t tryUnsubdiv;
-    osp::BitVector_t cantUnsubdiv;
+    lgrn::IdSetStl<SkTriId> tryUnsubdiv;
+    lgrn::IdSetStl<SkTriId> cantUnsubdiv;
 
     /// Non-subdivided triangles recently added, excluding intermediate triangles removed
     /// directly after creation.
-    osp::BitVector_t surfaceAdded;
+    lgrn::IdSetStl<SkTriId> surfaceAdded;
     /// Non-subdivided triangles recently removed, excluding intermediate triangles removed
     /// directly after creation.
-    osp::BitVector_t surfaceRemoved;
+    lgrn::IdSetStl<SkTriId> surfaceRemoved;
 
     std::uint8_t levelNeedProcess   {};
 

--- a/src/testapp/main.cpp
+++ b/src/testapp/main.cpp
@@ -241,9 +241,9 @@ void cli_loop(int argc, char** argv)
                 {
                     OSP_DECLARE_GET_DATA_IDS(g_testApp.m_renderer.m_sessions[1], TESTAPP_DATA_MAGNUM); // declares idActiveApp
                     osp::top_get<MagnumApplication>(g_testApp.m_topData, idActiveApp).exit();
-
-                    break;
                 }
+
+                break;
             }
             else 
             {

--- a/src/testapp/testapp.cpp
+++ b/src/testapp/testapp.cpp
@@ -92,43 +92,28 @@ void TestApp::close_session(osp::Session &rSession)
     close_sessions(osp::ArrayView<osp::Session>(&rSession, 1));
 }
 
-
-template<typename FUNC_T>
-static void resource_for_each_type(osp::ResTypeId const type, osp::Resources& rResources, FUNC_T&& do_thing)
-{
-    lgrn::IdRegistry<osp::ResId> const &rReg = rResources.ids(type);
-    for (std::size_t i = 0; i < rReg.capacity(); ++i)
-    {
-        if (rReg.exists(osp::ResId(i)))
-        {
-            do_thing(osp::ResId(i));
-        }
-    }
-}
-
-
 void TestApp::clear_resource_owners()
 {
     using namespace osp::restypes;
 
     // declares idResources
-    OSP_DECLARE_CREATE_DATA_IDS(m_application, m_topData, TESTAPP_DATA_APPLICATION);
+    OSP_DECLARE_GET_DATA_IDS(m_application, TESTAPP_DATA_APPLICATION);
 
     auto &rResources = osp::top_get<osp::Resources>(m_topData, idResources);
 
     // Texture resources contain osp::TextureImgSource, which refererence counts
     // their associated image data
-    resource_for_each_type(gc_texture, rResources, [&rResources] (osp::ResId const id)
+    for (osp::ResId const id : rResources.ids(gc_texture))
     {
         auto * const pData = rResources.data_try_get<osp::TextureImgSource>(gc_texture, id);
         if (pData != nullptr)
         {
             rResources.owner_destroy(gc_image, std::move(*pData));
         }
-    });
+    };
 
     // Importer data own a lot of other resources
-    resource_for_each_type(gc_importer, rResources, [&rResources] (osp::ResId const id)
+    for (osp::ResId const id : rResources.ids(gc_importer))
     {
         auto * const pData = rResources.data_try_get<osp::ImporterData>(gc_importer, id);
         if (pData != nullptr)
@@ -148,7 +133,7 @@ void TestApp::clear_resource_owners()
                 rResources.owner_destroy(gc_mesh, std::move(rOwner));
             }
         }
-    });
+    };
 }
 
 


### PR DESCRIPTION
[Longeron++](https://github.com/Capital-Asterisk/longeronpp) is a library consisting of some OSP 'core' components at the time, that I split off to allow it to be used on different projects and be presented on its own. I made some updates to fix some ugly code.

This PR updates the Longeron++ submodule, and uses some of the new features with the planeta module. Many other parts of the code can be cleaned up in future changes.

### osp::BitVector_t replacement

BitVectors are often used in OSP to represent sets of unique integer IDs (eg: `[1, 2, 24, 83]`). This is done for performance and simplicity: easily outperforming std::set or sorted std::vector of integers in many tasks. Iterating 'ones' bits can be done very quickly as we have 64 bit ints (not to mention SIMD). This is able to work in this project specifically as IDs are array indices and are close to zero; the highest ID correlates to the max number of objects.

`osp::BitVector_t` (aka: `lgrn::BitView< std::vector<uint64_t> >`) has an interface similar to std::bitset. The way it's used is kinda ugly:
```cpp
// get these from somewhere. ActiveEnt is osp::StrongId<std::uint32_t, ...>
ActiveEnt foo = ActiveEnt{12}; 
ActiveEnt bar = ActiveEnt{63};

osp::BitVector_t ids;
osp::bitvector_resize(ids, 100); // yucky

// IDs converted to an integer to add to the set. two different methods:
ids.set(std::size_t(foo));
ids.set(bar.value);

// ids now contains [12, 63]

ids.test(foo.value); // = true

for (std::size_t const idInt : ids.ones())
{
    ActiveEnt id = ActiveEnt::from_index(idInt);
    // do something with id
}

ids.reset(bar.value); // Remove from set
ids.reset() // Remove all
```

This has lots of ugly integer conversions needed here and there, so I added `lgrn::IdSetStl`. This has an interface similar to std::set. Equivalent code to above:
```cpp
// get these from somewhere. ActiveEnt is osp::StrongId<std::uint32_t, ...>
ActiveEnt foo = ActiveEnt{12}; 
ActiveEnt bar = ActiveEnt{63};

lgrn::IdSetStl ids;
ids.resize(100);

// Emplace is also supported (pass function arguments to ActiveEnt's constructor), but insert is recommended to disallow constructing from raw integers.
ids.insert(foo);
ids.insert(bar);

// ids now contains [12, 63]

ids.contains(foo); // = true

for (ActiveEnt const id : ids)
{
    // do something with id, no casting required
}

ids.erase(bar); // Remove from set
ids.clear() // Remove all
```

### Id Registry improvements

Removed stinky lgrn::IdRegistry, completely replaced with lgrn::IdRegistryStl.
IdRegistryStl now has iterators. Iterating all possible IDs previously looks something like this:
```cpp
for (std::size_t const drawEntInt : rScene.m_scnRdr.m_drawIds.bitview().zeros())
{
    auto const drawEnt = DrawEnt(drawEntInt);
    // do something with drawEnt
}
```
This works because IdRegistryStl is internally just a bit view / bitvector; ones bits are used for free IDs, and zeros bits are used for existing ones. There are countless instances of this in the code (search for "bitview().zeros()"), which can now be replaced with:
```cpp
for (DrawEnt const drawEnt : rScene.m_scnRdr.m_drawIds)
{
    // do something with drawEnt
}
```