### PR TITLE
Replace osp::BitVector_t with lgrn::IdSetStl

### DIFF
--- a/src/adera/drawing_gl/flat_shader.h
+++ b/src/adera/drawing_gl/flat_shader.h
@@ -80,9 +80,7 @@ struct ArgsForSyncDrawEntFlat
 
 inline void sync_drawent_flat(osp::draw::DrawEnt ent, ArgsForSyncDrawEntFlat const args)
 {
-    auto const entInt = std::size_t(ent);
-
-    bool const hasMaterial = args.hasMaterial.test(entInt);
+    bool const hasMaterial = args.hasMaterial.contains(ent);
     bool const hasTexture =    (args.diffuse.size() > std::size_t(ent))
                             && (args.diffuse[ent].m_glId != lgrn::id_null<osp::draw::TexGlId>());
 
@@ -92,7 +90,7 @@ inline void sync_drawent_flat(osp::draw::DrawEnt ent, ArgsForSyncDrawEntFlat con
 
     if (args.pStorageTransparent != nullptr)
     {
-        auto value = (hasMaterial && args.transparent.test(entInt))
+        auto value = (hasMaterial && args.transparent.contains(ent))
                    ? std::make_optional(osp::draw::EntityToDraw{&draw_ent_flat, {&args.rData, pShader}})
                    : std::nullopt;
 
@@ -101,7 +99,7 @@ inline void sync_drawent_flat(osp::draw::DrawEnt ent, ArgsForSyncDrawEntFlat con
 
     if (args.pStorageOpaque != nullptr)
     {
-        auto value = (hasMaterial && args.opaque.test(entInt))
+        auto value = (hasMaterial && args.opaque.contains(ent))
                    ? std::make_optional(osp::draw::EntityToDraw{&draw_ent_flat, {&args.rData, pShader}})
                    : std::nullopt;
 

--- a/src/adera/drawing_gl/phong_shader.h
+++ b/src/adera/drawing_gl/phong_shader.h
@@ -82,9 +82,8 @@ struct ArgsForSyncDrawEntPhong
 
 inline void sync_drawent_phong(osp::draw::DrawEnt ent, ArgsForSyncDrawEntPhong const args)
 {
-    auto const entInt = std::size_t(ent);
 
-    bool const hasMaterial = args.hasMaterial.test(entInt);
+    bool const hasMaterial = args.hasMaterial.contains(ent);
     bool const hasTexture = (args.diffuse.size() > std::size_t(ent)) && (args.diffuse[ent].m_glId != lgrn::id_null<osp::draw::TexGlId>());
 
     PhongGL *pShader = hasTexture
@@ -93,7 +92,7 @@ inline void sync_drawent_phong(osp::draw::DrawEnt ent, ArgsForSyncDrawEntPhong c
 
     if (args.pStorageTransparent != nullptr)
     {
-        auto value = (hasMaterial && args.transparent.test(entInt))
+        auto value = (hasMaterial && args.transparent.contains(ent))
                    ? std::make_optional(osp::draw::EntityToDraw{&draw_ent_phong, {&args.rData, pShader}})
                    : std::nullopt;
 
@@ -102,7 +101,7 @@ inline void sync_drawent_phong(osp::draw::DrawEnt ent, ArgsForSyncDrawEntPhong c
 
     if (args.pStorageOpaque != nullptr)
     {
-        auto value = (hasMaterial && args.opaque.test(entInt))
+        auto value = (hasMaterial && args.opaque.contains(ent))
                    ? std::make_optional(osp::draw::EntityToDraw{&draw_ent_phong, {&args.rData, pShader}})
                    : std::nullopt;
 

--- a/src/adera/drawing_gl/visualizer_shader.h
+++ b/src/adera/drawing_gl/visualizer_shader.h
@@ -67,7 +67,7 @@ inline void sync_drawent_visualizer(
         ACtxDrawMeshVisualizer&             rData)
 {
     bool alreadyAdded = rStorage.contains(ent);
-    if (hasMaterial.test(std::size_t(ent)))
+    if (hasMaterial.contains(ent))
     {
         if ( ! alreadyAdded)
         {

--- a/src/osp/activescene/basic.h
+++ b/src/osp/activescene/basic.h
@@ -26,13 +26,13 @@
 
 #include "active_ent.h"
 
-#include "../core/bitvector.h"
 #include "../core/keyed_vector.h"
 #include "../core/math_types.h"
 #include "../core/storage.h"
 
 #include <longeron/id_management/null.hpp>
-#include <longeron/id_management/registry_stl.hpp> // for lgrn::IdRegistryStl
+#include <longeron/id_management/registry_stl.hpp>
+#include <longeron/id_management/id_set_stl.hpp> 
 
 #include <string>
 
@@ -40,7 +40,7 @@ namespace osp::active
 {
 
 using ActiveEntVec_t = std::vector<ActiveEnt>;
-using ActiveEntSet_t = BitVector_t;
+using ActiveEntSet_t = lgrn::IdSetStl<ActiveEnt>;
 
 /**
  * @brief Component for transformation (in meters)

--- a/src/osp/activescene/physics_fn.cpp
+++ b/src/osp/activescene/physics_fn.cpp
@@ -54,7 +54,7 @@ void SysPhysics::calculate_subtree_mass_center(
             rMassPos    += childTf.translation() * childMass.m_mass;
         }
 
-        if (rCtxPhys.m_hasColliders.test(std::size_t(child)))
+        if (rCtxPhys.m_hasColliders.contains(child))
         {
             calculate_subtree_mass_center(rTf, rCtxPhys, rScnGraph, child, rMassPos, rTotalMass, childTf);
         }
@@ -88,7 +88,7 @@ void SysPhysics::calculate_subtree_mass_inertia(
             rInertiaTensor += transform_inertia_tensor(inertiaTensor, childMass.m_mass, offset, childTf.rotation());
         }
 
-        if (rCtxPhys.m_hasColliders.test(std::size_t(child)))
+        if (rCtxPhys.m_hasColliders.contains(child))
         {
             calculate_subtree_mass_inertia(rTf, rCtxPhys, rScnGraph, child, rInertiaTensor, childTf);
         }

--- a/src/osp/activescene/prefab_fn.cpp
+++ b/src/osp/activescene/prefab_fn.cpp
@@ -171,7 +171,7 @@ void SysPrefabInit::init_info(
 
             if (parents[i] == -1)
             {
-                rPrefabs.roots.set(std::size_t(ent));
+                rPrefabs.roots.insert(ent);
             }
         }
 
@@ -222,11 +222,11 @@ void SysPrefabInit::init_physics(
                 = [&rHasColliders = rCtxPhys.m_hasColliders, ents, objects, parents]
                   (auto const& self, int objectId, ActiveEnt ent) -> void
         {
-            if (rHasColliders.test(std::size_t(ent)))
+            if (rHasColliders.contains(ent))
             {
                 return; // HasColliders bit already set, this means all ancestors have it set too
             }
-            rHasColliders.set(std::size_t(ent));
+            rHasColliders.insert(ent);
 
             int const parentId = parents[objectId];
 

--- a/src/osp/drawing/drawing.h
+++ b/src/osp/drawing/drawing.h
@@ -26,7 +26,6 @@
 
 #include "draw_ent.h"
 
-#include "../core/bitvector.h"
 #include "../core/copymove_macros.h"
 #include "../core/id_map.h"
 #include "../core/keyed_vector.h"
@@ -35,18 +34,20 @@
 #include "../core/storage.h"
 
 #include "../activescene/active_ent.h"
+#include "../activescene/basic.h"
 
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Color.h>
 
 #include <longeron/id_management/refcount.hpp>
-#include <longeron/id_management/registry_stl.hpp> // for lgrn::IdRegistryStl
+#include <longeron/id_management/registry_stl.hpp>
+#include <longeron/id_management/id_set_stl.hpp>
 
 namespace osp::draw
 {
 
 using DrawEntVec_t  = std::vector<DrawEnt>;
-using DrawEntSet_t  = BitVector_t;
+using DrawEntSet_t  = lgrn::IdSetStl<DrawEnt>;
 
 struct Material
 {
@@ -122,9 +123,9 @@ struct ACtxSceneRender
     {
         std::size_t const size = m_drawIds.capacity();
 
-        bitvector_resize(m_opaque,      size);
-        bitvector_resize(m_transparent, size);
-        bitvector_resize(m_visible,     size);
+        m_opaque.resize(size);
+        m_transparent.resize(size);
+        m_visible.resize(size);
 
         m_drawTransform .resize(size);
         m_color         .resize(size, {1.0f, 1.0f, 1.0f, 1.0f}); // Default white
@@ -133,13 +134,13 @@ struct ACtxSceneRender
 
         for (uint32_t matInt : m_materialIds.bitview().zeros())
         {
-            bitvector_resize(m_materials[MaterialId(matInt)].m_ents, size);
+            m_materials[MaterialId(matInt)].m_ents.resize(size);
         }
     }
 
     void resize_active(std::size_t const size)
     {
-        bitvector_resize(m_needDrawTf, size);
+        m_needDrawTf.resize(size);
         m_activeToDraw      .resize(size, lgrn::id_null<DrawEnt>());
         drawTfObserverEnable.resize(size, 0);
     }
@@ -151,7 +152,7 @@ struct ACtxSceneRender
     DrawEntSet_t                            m_visible;
     DrawEntColors_t                         m_color;
 
-    DrawEntSet_t                            m_needDrawTf;
+    active::ActiveEntSet_t                  m_needDrawTf;
     KeyedVec<active::ActiveEnt, DrawEnt>    m_activeToDraw;
 
     KeyedVec<active::ActiveEnt, uint16_t>   drawTfObserverEnable;

--- a/src/osp/drawing/drawing_fn.h
+++ b/src/osp/drawing/drawing_fn.h
@@ -210,12 +210,12 @@ void SysRender::needs_draw_transforms(
         active::ActiveEntSet_t&         rNeedDrawTf,
         active::ActiveEnt               ent)
 {
-    rNeedDrawTf.set(ent.value);
+    rNeedDrawTf.insert(ent);
 
     active::ActiveEnt const parentEnt = scnGraph.m_entParent[ent];
 
     if (   parentEnt != lgrn::id_null<active::ActiveEnt>()
-        && ! rNeedDrawTf.test(std::size_t(parentEnt)) )
+        && ! rNeedDrawTf.contains(parentEnt) )
     {
         SysRender::needs_draw_transforms(scnGraph, rNeedDrawTf, parentEnt);
     }
@@ -234,7 +234,7 @@ void SysRender::update_draw_transforms(
     {
         active::ActiveEnt const ent = *first;
 
-        if (args.needDrawTf.test(ent.value))
+        if (args.needDrawTf.contains(ent))
         {
             update_draw_transforms_recurse(args, ent, identity, true, func);
         }
@@ -266,7 +266,7 @@ void SysRender::update_draw_transforms_recurse(
 
     for (ActiveEnt entChild : SysSceneGraph::children(args.scnGraph, ent))
     {
-        if (args.needDrawTf.test(std::size_t(entChild)))
+        if (args.needDrawTf.contains(entChild))
         {
             update_draw_transforms_recurse(args, entChild, entDrawTf, depth + 1, func);
         }

--- a/src/osp/drawing/prefab_draw.cpp
+++ b/src/osp/drawing/prefab_draw.cpp
@@ -77,10 +77,8 @@ void SysPrefabDraw::resync_drawents(
         ACtxDrawing&                rDrawing,
         ACtxSceneRender&            rScnRender)
 {
-    for (std::size_t const rootInt : rPrefabs.roots.ones())
+    for (ActiveEnt const root : rPrefabs.roots)
     {
-        auto const root = ActiveEnt::from_index(rootInt);
-
         PrefabInstanceInfo const &rRootInfo = rPrefabs.instanceInfo[root];
 
         LGRN_ASSERT(rRootInfo.prefab   != lgrn::id_null<PrefabId>());
@@ -130,7 +128,7 @@ void SysPrefabDraw::init_mesh_texture_material(
             = [&parents, &ents, &rDrawing, &needDrawTf = rScnRender.m_needDrawTf]
               (auto&& self, int const object, ActiveEnt const ent) noexcept -> void
         {
-            needDrawTf.set(ent.value);
+            needDrawTf.insert(ent);
 
             int const parentObj = parents[object];
 
@@ -176,13 +174,13 @@ void SysPrefabDraw::init_mesh_texture_material(
                 }
             }
 
-            rScnRender.m_opaque.set(drawEnt.value);
-            rScnRender.m_visible.set(drawEnt.value);
+            rScnRender.m_opaque.insert(drawEnt);
+            rScnRender.m_visible.insert(drawEnt);
 
             if (material != lgrn::id_null<MaterialId>())
             {
                 rScnRender.m_materials[material].m_dirty.push_back(drawEnt);
-                rScnRender.m_materials[material].m_ents.set(drawEnt.value);
+                rScnRender.m_materials[material].m_ents.insert(drawEnt);
             }
         }
 
@@ -200,10 +198,8 @@ void SysPrefabDraw::resync_mesh_texture_material(
         ACtxSceneRender&            rScnRender,
         MaterialId                  material)
 {
-    for (std::size_t const rootInt : rPrefabs.roots.ones())
+    for (ActiveEnt const root : rPrefabs.roots)
     {
-        auto const root = ActiveEnt::from_index(rootInt);
-
         PrefabInstanceInfo const &rRootInfo = rPrefabs.instanceInfo[root];
 
         LGRN_ASSERT(rRootInfo.prefab   != lgrn::id_null<PrefabId>());
@@ -248,13 +244,13 @@ void SysPrefabDraw::resync_mesh_texture_material(
                 }
             }
 
-            rScnRender.m_opaque.set(drawEnt.value);
-            rScnRender.m_visible.set(drawEnt.value);
+            rScnRender.m_opaque.insert(drawEnt);
+            rScnRender.m_visible.insert(drawEnt);
 
             if (material != lgrn::id_null<MaterialId>())
             {
                 rScnRender.m_materials[material].m_dirty.push_back(drawEnt);
-                rScnRender.m_materials[material].m_ents.set(drawEnt.value);
+                rScnRender.m_materials[material].m_ents.insert(drawEnt);
             }
         }
     }

--- a/src/osp/drawing_gl/rendergl.cpp
+++ b/src/osp/drawing_gl/rendergl.cpp
@@ -385,7 +385,7 @@ void SysRenderGL::draw_group(
 {
     for (auto const& [ent, toDraw] : entt::basic_view{group.entities}.each())
     {
-        if (visible.test(std::size_t(ent)))
+        if (visible.contains(ent))
         {
             toDraw.draw(ent, viewProj, toDraw.data);
         }

--- a/src/osp/link/machines.h
+++ b/src/osp/link/machines.h
@@ -25,13 +25,13 @@
 #pragma once
 
 #include "../core/array_view.h"
-#include "../core/bitvector.h"
 #include "../core/global_id.h"
 #include "../core/keyed_vector.h"
 
 #include <longeron/containers/intarray_multimap.hpp>
 #include <longeron/containers/bit_view.hpp>
 #include <longeron/id_management/registry_stl.hpp>
+#include <longeron/id_management/id_set_stl.hpp>
 
 #include <atomic>
 #include <vector>
@@ -81,10 +81,10 @@ struct MachineUpdater
 {
     alignas(64) std::atomic<bool> requestMachineUpdateLoop {false};
 
-    BitVector_t machTypesDirty;
+    lgrn::IdSetStl<MachTypeId> machTypesDirty;
 
     // [MachTypeId][MachLocalId]
-    osp::KeyedVec<MachTypeId, BitVector_t> localDirty;
+    osp::KeyedVec<MachTypeId, lgrn::IdSetStl<MachLocalId>> localDirty;
 };
 
 struct MachinePair

--- a/src/osp/link/signal.h
+++ b/src/osp/link/signal.h
@@ -38,7 +38,7 @@ using SignalValues_t = std::vector<VALUE_T>;
 template <typename VALUE_T>
 struct UpdateNodes
 {
-    BitVector_t                 nodeDirty;
+    lgrn::IdSetStl<NodeId>      nodeDirty;
     SignalValues_t<VALUE_T>     nodeNewValues;
 
     bool                        dirty{false};
@@ -46,7 +46,7 @@ struct UpdateNodes
     void assign(NodeId node, VALUE_T value)
     {
         dirty = true;
-        nodeDirty.set(node);
+        nodeDirty.insert(node);
         nodeNewValues[node] = std::forward<VALUE_T>(value);
     }
 };
@@ -75,10 +75,10 @@ bool update_signal_nodes(
                 somethingNotified = true;
 
                 // A machine of type "junc.m_type" has new values to read
-                rUpdMach.machTypesDirty.set(junc.type);
+                rUpdMach.machTypesDirty.insert(junc.type);
 
                 // Specify using local Id on which machine needs to update
-                rUpdMach.localDirty[junc.type].set(junc.local);
+                rUpdMach.localDirty[junc.type].insert(junc.local);
             }
         }
     }

--- a/src/osp/tasks/execute.cpp
+++ b/src/osp/tasks/execute.cpp
@@ -82,9 +82,9 @@ void exec_update(Tasks const& tasks, TaskGraph const& graph, ExecContext &rExec)
                                              "Make sure all pipelines are finished running.");
         }
 
-        for (PipelineId const plInt : rExec.plRequestRun)
+        for (PipelineId const plId : rExec.plRequestRun)
         {
-            pipeline_run_root(tasks, graph, rExec, plInt);
+            pipeline_run_root(tasks, graph, rExec, plId);
         }
         rExec.plRequestRun.clear();
         rExec.hasRequestRun = false;
@@ -105,25 +105,23 @@ void exec_update(Tasks const& tasks, TaskGraph const& graph, ExecContext &rExec)
 
         rExec.requestLoop.clear();
 
-        for (PipelineId const plInt : rExec.plAdvance)
+        for (PipelineId const plId : rExec.plAdvance)
         {
-            pipeline_advance_stage(tasks, graph, rExec, plInt);
+            pipeline_advance_stage(tasks, graph, rExec, plId);
         }
 
-        for (PipelineId const plInt : rExec.plAdvance)
+        for (PipelineId const plId : rExec.plAdvance)
         {
-            pipeline_advance_reqs(tasks, graph, rExec, plInt);
+            pipeline_advance_reqs(tasks, graph, rExec, plId);
         }
 
-        for (PipelineId const plInt : rExec.plAdvance)
+        for (PipelineId const plId : rExec.plAdvance)
         {
-            pipeline_advance_run(tasks, graph, rExec, plInt);
+            pipeline_advance_run(tasks, graph, rExec, plId);
         }
         rExec.plAdvance.clear();
-        for (PipelineId const pipeline : rExec.plAdvanceNext)
-        {
-            rExec.plAdvance.insert(pipeline);
-        }
+        
+        rExec.plAdvance.insert(rExec.plAdvanceNext.begin(), rExec.plAdvanceNext.end());
         rExec.plAdvanceNext.clear();
     }
 

--- a/src/osp/tasks/execute.cpp
+++ b/src/osp/tasks/execute.cpp
@@ -26,6 +26,7 @@
 #include "execute.h"
 
 #include <Corrade/Containers/ArrayViewStl.h>
+#include <iterator>
 
 namespace osp
 {
@@ -81,11 +82,11 @@ void exec_update(Tasks const& tasks, TaskGraph const& graph, ExecContext &rExec)
                                              "Make sure all pipelines are finished running.");
         }
 
-        for (PipelineInt const plInt : rExec.plRequestRun.ones())
+        for (PipelineId const plInt : rExec.plRequestRun)
         {
-            pipeline_run_root(tasks, graph, rExec, PipelineId(plInt));
+            pipeline_run_root(tasks, graph, rExec, plInt);
         }
-        rExec.plRequestRun.reset();
+        rExec.plRequestRun.clear();
         rExec.hasRequestRun = false;
     }
 
@@ -104,25 +105,26 @@ void exec_update(Tasks const& tasks, TaskGraph const& graph, ExecContext &rExec)
 
         rExec.requestLoop.clear();
 
-        for (PipelineInt const plInt : rExec.plAdvance.ones())
+        for (PipelineId const plInt : rExec.plAdvance)
         {
-            pipeline_advance_stage(tasks, graph, rExec, PipelineId(plInt));
+            pipeline_advance_stage(tasks, graph, rExec, plInt);
         }
 
-        for (PipelineInt const plInt : rExec.plAdvance.ones())
+        for (PipelineId const plInt : rExec.plAdvance)
         {
-            pipeline_advance_reqs(tasks, graph, rExec, PipelineId(plInt));
+            pipeline_advance_reqs(tasks, graph, rExec, plInt);
         }
 
-        for (PipelineInt const plInt : rExec.plAdvance.ones())
+        for (PipelineId const plInt : rExec.plAdvance)
         {
-            pipeline_advance_run(tasks, graph, rExec, PipelineId(plInt));
+            pipeline_advance_run(tasks, graph, rExec, plInt);
         }
-
-        std::copy(rExec.plAdvanceNext.ints().begin(),
-                  rExec.plAdvanceNext.ints().end(),
-                  rExec.plAdvance    .ints().begin());
-        rExec.plAdvanceNext.reset();
+        rExec.plAdvance.clear();
+        for (PipelineId const pipeline : rExec.plAdvanceNext)
+        {
+            rExec.plAdvance.insert(pipeline);
+        }
+        rExec.plAdvanceNext.clear();
     }
 
     exec_log(rExec, ExecContext::UpdateEnd{});
@@ -249,7 +251,7 @@ static int pipeline_run(Tasks const& tasks, TaskGraph const& graph, ExecContext 
 
             ++ rExec.pipelinesRunning;
 
-            rExec.plAdvance.set(std::size_t(pipeline));
+            rExec.plAdvance.insert(pipeline);
             exec_log(rExec, ExecContext::PipelineRun{pipeline});
         }
 
@@ -257,7 +259,7 @@ static int pipeline_run(Tasks const& tasks, TaskGraph const& graph, ExecContext 
         {
             rExecPl.canceled = false;
 
-            rExec.plAdvanceNext.set(std::size_t(pipeline));
+            rExec.plAdvanceNext.insert(pipeline);
             exec_log(rExec, ExecContext::PipelineLoop{pipeline});
         }
 
@@ -608,7 +610,7 @@ static void pipeline_advance_run(Tasks const& tasks, TaskGraph const& graph, Exe
         // No tasks to run. RunTasks are responsible for setting this pipeline dirty once they're
         // all done. If there is none, then this pipeline may get stuck if nothing sets it dirty,
         // so set dirty right away.
-        rExec.plAdvanceNext.set(std::size_t(pipeline));
+        rExec.plAdvanceNext.insert(pipeline);
         rExec.hasPlAdvanceOrLoop = true;
     }
 }
@@ -768,7 +770,7 @@ static void pipeline_try_advance(ExecContext &rExec, ExecPipeline &rExecPl, Pipe
 {
     if (pipeline_can_advance(rExecPl))
     {
-        rExec.plAdvance.set(std::size_t(pipeline));
+        rExec.plAdvance.insert(pipeline);
         rExec.hasPlAdvanceOrLoop = true;
     }
 };
@@ -896,9 +898,9 @@ void exec_conform(Tasks const& tasks, ExecContext &rOut)
     rOut.tasksQueuedRun    .reserve(maxTasks);
     rOut.tasksQueuedBlocked.reserve(maxTasks);
     rOut.plData.resize(maxPipeline);
-    bitvector_resize(rOut.plAdvance,     maxPipeline);
-    bitvector_resize(rOut.plAdvanceNext, maxPipeline);
-    bitvector_resize(rOut.plRequestRun,  maxPipeline);
+    rOut.plAdvance.resize(maxPipeline);
+    rOut.plAdvanceNext.resize(maxPipeline);
+    rOut.plRequestRun.resize(maxPipeline);
 
     for (PipelineInt const pipelineInt : tasks.m_pipelineIds.bitview().zeros())
     {

--- a/src/osp/tasks/execute.h
+++ b/src/osp/tasks/execute.h
@@ -27,7 +27,8 @@
 #include "tasks.h"
 #include "worker.h"
 
-#include "../core/bitvector.h"
+#include <longeron/id_management/id_set_stl.hpp>
+
 
 #include <entt/entity/storage.hpp>
 
@@ -202,11 +203,11 @@ struct ExecContext : public ExecLog
     entt::basic_sparse_set<TaskId>              tasksQueuedRun;
     entt::basic_storage<BlockedTask, TaskId>    tasksQueuedBlocked;
 
-    BitVector_t                         plAdvance;
-    BitVector_t                         plAdvanceNext;
+    lgrn::IdSetStl<PipelineId>          plAdvance;
+    lgrn::IdSetStl<PipelineId>          plAdvanceNext;
     bool                                hasPlAdvanceOrLoop  {false};
 
-    BitVector_t                         plRequestRun;
+    lgrn::IdSetStl<PipelineId>          plRequestRun;
     std::vector<LoopRequestRun>         requestLoop;
     bool                                hasRequestRun {false};
 
@@ -227,7 +228,7 @@ void exec_conform(Tasks const& tasks, ExecContext &rOut);
 
 inline void exec_request_run(ExecContext &rExec, PipelineId pipeline) noexcept
 {
-    rExec.plRequestRun.set(std::size_t(pipeline));
+    rExec.plRequestRun.insert(pipeline);
     rExec.hasRequestRun = true;
 }
 

--- a/src/ospnewton/activescene/newtoninteg.h
+++ b/src/ospnewton/activescene/newtoninteg.h
@@ -28,11 +28,11 @@
 
 #include <osp/activescene/basic.h>
 #include <osp/core/id_map.h>
-#include <osp/core/bitvector.h>
 
 #include <Newton.h>
 
 #include <longeron/id_management/registry_stl.hpp>
+#include <longeron/id_management/id_set_stl.hpp>
 
 #include <entt/core/any.hpp>
 
@@ -93,7 +93,7 @@ struct ACtxNwtWorld
     lgrn::IdRegistryStl<BodyId>                     m_bodyIds;
     std::vector<NwtBodyPtr_t>                       m_bodyPtrs;
     std::vector<ForceFactors_t>                     m_bodyFactors;
-    osp::BitVector_t                                m_bodyDirty;
+    lgrn::IdSetStl<BodyId>                          m_bodyDirty;
 
     std::vector<osp::active::ActiveEnt>             m_bodyToEnt;
     osp::IdMap_t<osp::active::ActiveEnt, BodyId>    m_entToBody;

--- a/src/ospnewton/activescene/newtoninteg_fn.cpp
+++ b/src/ospnewton/activescene/newtoninteg_fn.cpp
@@ -242,7 +242,7 @@ void SysNewton::find_colliders_recurse(
         NewtonCompoundCollisionAddSubCollision(pCompound, pCollision);
     }
 
-    if ( ! rCtxPhys.m_hasColliders.test(std::size_t(ent)) )
+    if ( ! rCtxPhys.m_hasColliders.contains(ent) )
     {
         return;
     }

--- a/src/testapp/enginetest.cpp
+++ b/src/testapp/enginetest.cpp
@@ -133,8 +133,8 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
 
     // Resize some containers to fit all existing entities
     std::size_t const maxEnts = rScene.m_activeIds.vec().capacity();
-    rScene.m_matPhong.ints()    .resize(maxEnts);
-    rScene.m_basic.m_scnGraph   .resize(maxEnts);
+    rScene.m_matPhong.resize(maxEnts);
+    rScene.m_basic.m_scnGraph.resize(maxEnts);
     rScene.m_scnRdr.resize_active(maxEnts);
     rScene.m_scnRdr.resize_draw();
 
@@ -146,7 +146,7 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
 
     // Add cube mesh to cube
 
-    rScene.m_scnRdr.m_needDrawTf.set(std::size_t(cubeEnt));
+    rScene.m_scnRdr.m_needDrawTf.insert(cubeEnt);
     rScene.m_scnRdr.m_activeToDraw[cubeEnt] = cubeDraw;
     rScene.m_scnRdr.m_mesh[cubeDraw] = rScene.m_drawing.m_meshRefCounts.ref_add(meshCube);
     rScene.m_scnRdr.m_meshDirty.push_back(cubeDraw);
@@ -155,12 +155,12 @@ entt::any setup_scene(osp::Resources& rResources, osp::PkgId const pkg)
     rScene.m_basic.m_transform.emplace(cubeEnt);
 
     // Add phong material to cube
-    rScene.m_matPhong.set(std::size_t(cubeDraw));
+    rScene.m_matPhong.insert(cubeDraw);
     rScene.m_matPhongDirty.push_back(cubeDraw);
 
     // Add drawble, opaque, and visible component
-    rScene.m_scnRdr.m_visible.set(std::size_t(cubeDraw));
-    rScene.m_scnRdr.m_opaque.set(std::size_t(cubeDraw));
+    rScene.m_scnRdr.m_visible.insert(cubeDraw);
+    rScene.m_scnRdr.m_opaque.insert(cubeDraw);
 
     // Add cube to hierarchy, parented to root
     SubtreeBuilder builder = SysSceneGraph::add_descendants(rScene.m_basic.m_scnGraph, 1);
@@ -407,15 +407,15 @@ MagnumApplication::AppPtr_t generate_osp_magnum_app(EngineTestScene& rScene, Mag
     for (std::size_t const materialInt : rScene.m_scnRdr.m_materialIds.bitview().zeros())
     {
         Material &mat = rScene.m_scnRdr.m_materials[MaterialId(materialInt)];
-        for (std::size_t const entInt : mat.m_ents.ones())
+        for (DrawEnt const drawEnt : mat.m_ents)
         {
-            mat.m_dirty.push_back(DrawEnt(entInt));
+            mat.m_dirty.push_back(drawEnt);
         }
     }
 
-    for (std::size_t const entInt : rScene.m_matPhong.ones())
+    for (DrawEnt const drawEnt : rScene.m_matPhong)
     {
-        rScene.m_matPhongDirty.emplace_back(entInt);
+        rScene.m_matPhongDirty.emplace_back(drawEnt);
     }
 
     sync_test_scene(rRenderGl, rScene, rRenderer);

--- a/src/testapp/sessions/common.cpp
+++ b/src/testapp/sessions/common.cpp
@@ -440,7 +440,7 @@ Session setup_scene_renderer(
             {
                 if (std::size_t(ent) < rMat.m_ents.size())
                 {
-                    rMat.m_ents.reset(std::size_t(ent));
+                    rMat.m_ents.erase(ent);
                 }
             }
         }

--- a/src/testapp/sessions/magnum.cpp
+++ b/src/testapp/sessions/magnum.cpp
@@ -366,9 +366,9 @@ Session setup_shader_visualizer(
         .func([] (ACtxSceneRender& rScnRender, RenderGroup& rGroupFwd, ACtxDrawMeshVisualizer& rDrawShVisual) noexcept
     {
         Material const &rMat = rScnRender.m_materials[rDrawShVisual.m_materialId];
-        for (auto const drawEntInt : rMat.m_ents.ones())
+        for (DrawEnt const drawEnt : rMat.m_ents)
         {
-            sync_drawent_visualizer(DrawEnt(drawEntInt), rMat.m_ents, rGroupFwd.entities, rDrawShVisual);
+            sync_drawent_visualizer(drawEnt, rMat.m_ents, rGroupFwd.entities, rDrawShVisual);
         }
     });
 
@@ -442,9 +442,9 @@ Session setup_shader_flat(
         .func([] (ACtxSceneRender& rScnRender, RenderGroup& rGroupFwd, ACtxSceneRenderGL const& rScnRenderGl, ACtxDrawFlat& rDrawShFlat) noexcept
     {
         Material const &rMat = rScnRender.m_materials[rDrawShFlat.materialId];
-        for (auto const drawEntInt : rMat.m_ents.ones())
+        for (DrawEnt const drawEnt : rMat.m_ents)
         {
-            sync_drawent_flat(DrawEnt(drawEntInt),
+            sync_drawent_flat(drawEnt,
             {
                 .hasMaterial    = rMat.m_ents,
                 .pStorageOpaque = &rGroupFwd.entities,
@@ -528,9 +528,9 @@ Session setup_shader_phong(
         .func([] (ACtxSceneRender& rScnRender, RenderGroup& rGroupFwd, ACtxSceneRenderGL const& rScnRenderGl, ACtxDrawPhong& rDrawShPhong) noexcept
     {
         Material const &rMat = rScnRender.m_materials[rDrawShPhong.materialId];
-        for (auto const drawEntInt : rMat.m_ents.ones())
+        for (DrawEnt const drawEnt : rMat.m_ents)
         {
-            sync_drawent_phong(DrawEnt(drawEntInt),
+            sync_drawent_phong(drawEnt,
             {
                 .hasMaterial    = rMat.m_ents,
                 .pStorageOpaque = &rGroupFwd.entities,

--- a/src/testapp/sessions/misc.cpp
+++ b/src/testapp/sessions/misc.cpp
@@ -167,11 +167,11 @@ Session setup_cursor(
 
     rScnRender.m_mesh[cursorEnt] = SysRender::add_drawable_mesh(rDrawing, rDrawingRes, rResources, pkg, "cubewire");
     rScnRender.m_color[cursorEnt] = { 0.0f, 1.0f, 0.0f, 1.0f };
-    rScnRender.m_visible.set(std::size_t(cursorEnt));
-    rScnRender.m_opaque.set(std::size_t(cursorEnt));
+    rScnRender.m_visible.insert(cursorEnt);
+    rScnRender.m_opaque.insert(cursorEnt);
 
     Material &rMat = rScnRender.m_materials[material];
-    rMat.m_ents.set(std::size_t(cursorEnt));
+    rMat.m_ents.insert(cursorEnt);
 
     rBuilder.task()
         .name       ("Move cursor")

--- a/src/testapp/sessions/newton.cpp
+++ b/src/testapp/sessions/newton.cpp
@@ -260,7 +260,7 @@ void compound_collect_recurse(
         NewtonCompoundCollisionAddSubCollision(pCompound, rPtr.get());
     }
 
-    if ( ! rCtxPhys.m_hasColliders.test(std::size_t(ent)) )
+    if ( ! rCtxPhys.m_hasColliders.contains(ent) )
     {
         return;
     }
@@ -402,7 +402,7 @@ Session setup_vehicle_spawn_newton(
     {
         LGRN_ASSERT(rVehicleSpawn.new_vehicle_count() != 0);
 
-        rPhys.m_hasColliders.ints().resize(rBasic.m_activeIds.vec().capacity());
+        rPhys.m_hasColliders.resize(rBasic.m_activeIds.vec().capacity());
 
         auto const& itWeldsFirst        = std::begin(rVehicleSpawn.spawnedWelds);
         auto const& itWeldOffsetsLast   = std::end(rVehicleSpawn.spawnedWeldOffsets);
@@ -424,7 +424,7 @@ Session setup_vehicle_spawn_newton(
                 auto const transform = Matrix4::from(toInit.rotation.toMatrix(), toInit.position);
                 NwtColliderPtr_t pCompound{ NewtonCreateCompoundCollision(rNwt.m_world.get(), 0) };
 
-                rPhys.m_hasColliders.set(std::size_t(weldEnt));
+                rPhys.m_hasColliders.insert(weldEnt);
 
                 // Collect all colliders from hierarchy.
                 NewtonCompoundCollisionBeginAddRemove(pCompound.get());

--- a/src/testapp/sessions/newton.cpp
+++ b/src/testapp/sessions/newton.cpp
@@ -402,7 +402,7 @@ Session setup_vehicle_spawn_newton(
     {
         LGRN_ASSERT(rVehicleSpawn.new_vehicle_count() != 0);
 
-        rPhys.m_hasColliders.resize(rBasic.m_activeIds.vec().capacity());
+        rPhys.m_hasColliders.resize(rBasic.m_activeIds.capacity());
 
         auto const& itWeldsFirst        = std::begin(rVehicleSpawn.spawnedWelds);
         auto const& itWeldOffsetsLast   = std::end(rVehicleSpawn.spawnedWeldOffsets);

--- a/src/testapp/sessions/physics.cpp
+++ b/src/testapp/sessions/physics.cpp
@@ -154,7 +154,7 @@ Session setup_prefabs(
         .func([] (ACtxBasic& rBasic, Resources& rResources, ACtxPrefabs& rPrefabs) noexcept
     {
         rPrefabs.instanceInfo.resize(rBasic.m_activeIds.capacity(), PrefabInstanceInfo{.prefab = lgrn::id_null<PrefabId>()});
-        osp::bitvector_resize(rPrefabs.roots, rBasic.m_activeIds.capacity());
+        rPrefabs.roots.resize(rBasic.m_activeIds.capacity());
         SysPrefabInit::init_info(rPrefabs, rResources);
     });
 
@@ -166,8 +166,8 @@ Session setup_prefabs(
         .args       ({      idBasic,           idResources,             idPhys,             idPrefabs})
         .func([] (ACtxBasic& rBasic, Resources& rResources, ACtxPhysics& rPhys, ACtxPrefabs& rPrefabs) noexcept
     {
-        rPhys.m_hasColliders.ints().resize(rBasic.m_activeIds.vec().capacity());
-        //rPhys.m_massDirty.ints().resize(rActiveIds.vec().capacity());
+        rPhys.m_hasColliders.resize(rBasic.m_activeIds.vec().capacity());
+        //rPhys.m_massDirty.resize(rActiveIds.vec().capacity());
         rPhys.m_shape.resize(rBasic.m_activeIds.capacity());
         SysPrefabInit::init_physics(rPrefabs, rResources, rPhys);
     });

--- a/src/testapp/sessions/physics.cpp
+++ b/src/testapp/sessions/physics.cpp
@@ -166,8 +166,8 @@ Session setup_prefabs(
         .args       ({      idBasic,           idResources,             idPhys,             idPrefabs})
         .func([] (ACtxBasic& rBasic, Resources& rResources, ACtxPhysics& rPhys, ACtxPrefabs& rPrefabs) noexcept
     {
-        rPhys.m_hasColliders.resize(rBasic.m_activeIds.vec().capacity());
-        //rPhys.m_massDirty.resize(rActiveIds.vec().capacity());
+        rPhys.m_hasColliders.resize(rBasic.m_activeIds.capacity());
+        //rPhys.m_massDirty.resize(rActiveIds.capacity());
         rPhys.m_shape.resize(rBasic.m_activeIds.capacity());
         SysPrefabInit::init_physics(rPrefabs, rResources, rPhys);
     });

--- a/src/testapp/sessions/shapes.cpp
+++ b/src/testapp/sessions/shapes.cpp
@@ -165,7 +165,7 @@ Session setup_phys_shapes(
         .args       ({            idBasic,                idPhysShapes,             idPhys })
         .func([] (ACtxBasic const& rBasic, ACtxPhysShapes& rPhysShapes, ACtxPhysics& rPhys) noexcept
     {
-        rPhys.m_hasColliders.resize(rBasic.m_activeIds.vec().capacity());
+        rPhys.m_hasColliders.resize(rBasic.m_activeIds.capacity());
         rPhys.m_shape.resize(rBasic.m_activeIds.capacity());
 
         for (std::size_t i = 0; i < rPhysShapes.m_spawnRequest.size(); ++i)
@@ -556,7 +556,7 @@ Session setup_bounds(
         .args       ({      idBasic,                idPhysShapes,                idBounds })
         .func([] (ACtxBasic& rBasic, ACtxPhysShapes& rPhysShapes, ActiveEntSet_t& rBounds) noexcept
     {
-        rBounds.resize(rBasic.m_activeIds.vec().capacity());
+        rBounds.resize(rBasic.m_activeIds.capacity());
 
         for (std::size_t i = 0; i < rPhysShapes.m_spawnRequest.size(); ++i)
         {

--- a/src/testapp/sessions/terrain.cpp
+++ b/src/testapp/sessions/terrain.cpp
@@ -593,8 +593,8 @@ Session setup_terrain_debug_draw(
                         rDrawing.m_meshRefCounts.ref_release(std::exchange(rScnRender.m_mesh[rDrawEnt], {}));
                     }
                     rScnRender.m_meshDirty  .push_back  (rDrawEnt);
-                    rScnRender.m_visible    .reset      (rDrawEnt.value);
-                    rMatPlanet.m_ents       .reset      (rDrawEnt.value);
+                    rScnRender.m_visible    .erase      (rDrawEnt);
+                    rMatPlanet.m_ents       .erase      (rDrawEnt);
                     rMatPlanet.m_dirty      .push_back  (rDrawEnt);
 
                     rScnRender.m_drawIds.remove(std::exchange(rDrawEnt, {}));
@@ -630,9 +630,9 @@ Session setup_terrain_debug_draw(
             {
                 rScnRender.m_mesh[drawEnt] = rDrawing.m_meshRefCounts.ref_add(cubeMeshId);
                 rScnRender.m_meshDirty.push_back(drawEnt);
-                rScnRender.m_visible.set(drawEnt.value);
-                rScnRender.m_opaque.set(drawEnt.value);
-                rMatPlanet.m_ents.set(drawEnt.value);
+                rScnRender.m_visible.insert(drawEnt);
+                rScnRender.m_opaque.insert(drawEnt);
+                rMatPlanet.m_ents.insert(drawEnt);
                 rMatPlanet.m_dirty.push_back(drawEnt);
             }
 

--- a/src/testapp/sessions/universe.cpp
+++ b/src/testapp/sessions/universe.cpp
@@ -424,26 +424,26 @@ Session setup_testplanets_draw(
 
             rScnRender.m_mesh[drawEnt] = rDrawing.m_meshRefCounts.ref_add(sphereMeshId);
             rScnRender.m_meshDirty.push_back(drawEnt);
-            rScnRender.m_visible.set(std::size_t(drawEnt));
-            rScnRender.m_opaque.set(std::size_t(drawEnt));
-            rMatPlanet.m_ents.set(std::size_t(drawEnt));
+            rScnRender.m_visible.insert(drawEnt);
+            rScnRender.m_opaque.insert(drawEnt);
+            rMatPlanet.m_ents.insert(drawEnt);
             rMatPlanet.m_dirty.push_back(drawEnt);
         }
 
         rScnRender.m_mesh[rPlanetDraw.attractor] = rDrawing.m_meshRefCounts.ref_add(sphereMeshId);
         rScnRender.m_meshDirty.push_back(rPlanetDraw.attractor);
-        rScnRender.m_visible.set(std::size_t(rPlanetDraw.attractor));
-        rScnRender.m_opaque.set(std::size_t(rPlanetDraw.attractor));
-        rMatPlanet.m_ents.set(std::size_t(rPlanetDraw.attractor));
+        rScnRender.m_visible.insert(rPlanetDraw.attractor);
+        rScnRender.m_opaque.insert(rPlanetDraw.attractor);
+        rMatPlanet.m_ents.insert(rPlanetDraw.attractor);
         rMatPlanet.m_dirty.push_back(rPlanetDraw.attractor);
 
         for (DrawEnt const drawEnt : rPlanetDraw.axis)
         {
             rScnRender.m_mesh[drawEnt] = rDrawing.m_meshRefCounts.ref_add(cubeMeshId);
             rScnRender.m_meshDirty.push_back(drawEnt);
-            rScnRender.m_visible.set(std::size_t(drawEnt));
-            rScnRender.m_opaque.set(std::size_t(drawEnt));
-            rMatAxis.m_ents.set(std::size_t(drawEnt));
+            rScnRender.m_visible.insert(drawEnt);
+            rScnRender.m_opaque.insert(drawEnt);
+            rMatAxis.m_ents.insert(drawEnt);
             rMatAxis.m_dirty.push_back(drawEnt);
         }
 

--- a/src/testapp/sessions/vehicles.cpp
+++ b/src/testapp/sessions/vehicles.cpp
@@ -86,7 +86,7 @@ Session setup_parts(
 
     // Resize containers to fit all existing MachTypeIds and NodeTypeIds
     // These Global IDs are dynamically initialized just as the program starts
-    bitvector_resize(rUpdMach.machTypesDirty, MachTypeReg_t::size());
+    rUpdMach.machTypesDirty.resize(MachTypeReg_t::size());
     rUpdMach.localDirty       .resize(MachTypeReg_t::size());
     rScnParts.machines.perType.resize(MachTypeReg_t::size());
     rScnParts.nodePerType     .resize(NodeTypeReg_t::size());
@@ -492,7 +492,7 @@ Session setup_vehicle_spawn_vb(
         Nodes const         &rFloatNodes    = rScnParts.nodePerType[gc_ntSigFloat];
         std::size_t const   maxNodes        = rFloatNodes.nodeIds.capacity();
         rSigUpdFloat.nodeNewValues.resize(maxNodes);
-        bitvector_resize(rSigUpdFloat.nodeDirty, maxNodes);
+        rSigUpdFloat.nodeDirty.resize(maxNodes);
         rSigValFloat.resize(maxNodes);
 
         std::size_t const           newVehicleCount     = rVehicleSpawn.new_vehicle_count();
@@ -547,7 +547,7 @@ Session setup_vehicle_spawn_draw(
     {
         for (ActiveEnt const ent : rVehicleSpawn.rootEnts)
         {
-            rScnRender.m_needDrawTf.set(ent.value);
+            rScnRender.m_needDrawTf.insert(ent);
         }
     });
 
@@ -597,27 +597,27 @@ Session setup_signals_float(
         // NOTE: The various use of reset() clear entire bit arrays, which may or may
         //       not be expensive. They likely optimize to memset
 
-        for (std::size_t const machTypeDirty : rUpdMach.machTypesDirty.ones())
+        for (MachTypeId const machTypeDirty : rUpdMach.machTypesDirty)
         {
-            rUpdMach.localDirty[machTypeDirty].reset();
+            rUpdMach.localDirty[machTypeDirty].clear();
         }
-        rUpdMach.machTypesDirty.reset();
+        rUpdMach.machTypesDirty.clear();
 
         // Sees which nodes changed, and writes into rUpdMach set dirty which MACHINES
         // must be updated next
         update_signal_nodes<float>(
-                rSigUpdFloat.nodeDirty.ones(),
+                rSigUpdFloat.nodeDirty,
                 rFloatNodes.nodeToMach,
                 rScnParts.machines,
                 arrayView(rSigUpdFloat.nodeNewValues),
                 rSigValFloat,
                 rUpdMach);
-        rSigUpdFloat.nodeDirty.reset();
+        rSigUpdFloat.nodeDirty.clear();
         rSigUpdFloat.dirty = false;
 
         // Run tasks needed to update machine types that are dirty
         bool anyMachineNotified = false;
-        for (MachTypeId const type : rUpdMach.machTypesDirty.ones())
+        for (MachTypeId const type : rUpdMach.machTypesDirty)
         {
             anyMachineNotified = true;
         }

--- a/src/testapp/sessions/vehicles_machines.cpp
+++ b/src/testapp/sessions/vehicles_machines.cpp
@@ -68,7 +68,7 @@ Session setup_mach_rocket(
         .args       ({idScnParts, idUpdMach})
         .func       ([] (ACtxParts& rScnParts, MachineUpdater& rUpdMach)
     {
-        rUpdMach.localDirty[gc_mtMagicRocket].ints().resize(rScnParts.machines.perType[gc_mtMagicRocket].localIds.vec().capacity());
+        rUpdMach.localDirty[gc_mtMagicRocket].resize(rScnParts.machines.perType[gc_mtMagicRocket].localIds.vec().capacity());
     });
 
     return out;
@@ -178,13 +178,13 @@ Session setup_thrust_indicators(
 
             if (thrustMag == 0.0f)
             {
-                rScnRender.m_visible.reset(drawEnt.value);
+                rScnRender.m_visible.erase(drawEnt);
                 continue;
             }
 
-            if (!rMat.m_ents.test(drawEnt.value))
+            if (!rMat.m_ents.contains(drawEnt))
             {
-                rMat.m_ents.set(drawEnt.value);
+                rMat.m_ents.insert(drawEnt);
                 rMat.m_dirty.push_back(drawEnt);
             }
 
@@ -195,8 +195,8 @@ Session setup_thrust_indicators(
                 rScnRender.m_meshDirty.push_back(drawEnt);
             }
 
-            rScnRender.m_visible.set(drawEnt.value);
-            rScnRender.m_opaque .set(drawEnt.value);
+            rScnRender.m_visible.insert(drawEnt);
+            rScnRender.m_opaque .insert(drawEnt);
 
             rScnRender.m_color              [drawEnt] = rThrustIndicator.color;
             rScnRender.drawTfObserverEnable [partEnt] = 1;
@@ -282,7 +282,7 @@ Session setup_mach_rcsdriver(
         .args       ({idScnParts, idUpdMach})
         .func       ([] (ACtxParts& rScnParts, MachineUpdater& rUpdMach)
     {
-        rUpdMach.localDirty[gc_mtRcsDriver].ints().resize(rScnParts.machines.perType[gc_mtRcsDriver].localIds.vec().capacity());
+        rUpdMach.localDirty[gc_mtRcsDriver].resize(rScnParts.machines.perType[gc_mtRcsDriver].localIds.vec().capacity());
     });
 
     rBuilder.task()
@@ -296,7 +296,7 @@ Session setup_mach_rcsdriver(
         Nodes const &rFloatNodes = rScnParts.nodePerType[gc_ntSigFloat];
         PerMachType &rRockets    = rScnParts.machines.perType[gc_mtRcsDriver];
 
-        for (MachLocalId const local : rUpdMach.localDirty[gc_mtRcsDriver].ones())
+        for (MachLocalId const local : rUpdMach.localDirty[gc_mtRcsDriver])
         {
             MachAnyId const mach     = rRockets.localToAny[local];
             auto const      portSpan = lgrn::Span<NodeId const>{rFloatNodes.machToNode[mach]};

--- a/src/testapp/sessions/vehicles_machines.cpp
+++ b/src/testapp/sessions/vehicles_machines.cpp
@@ -68,7 +68,7 @@ Session setup_mach_rocket(
         .args       ({idScnParts, idUpdMach})
         .func       ([] (ACtxParts& rScnParts, MachineUpdater& rUpdMach)
     {
-        rUpdMach.localDirty[gc_mtMagicRocket].resize(rScnParts.machines.perType[gc_mtMagicRocket].localIds.vec().capacity());
+        rUpdMach.localDirty[gc_mtMagicRocket].resize(rScnParts.machines.perType[gc_mtMagicRocket].localIds.capacity());
     });
 
     return out;
@@ -282,7 +282,7 @@ Session setup_mach_rcsdriver(
         .args       ({idScnParts, idUpdMach})
         .func       ([] (ACtxParts& rScnParts, MachineUpdater& rUpdMach)
     {
-        rUpdMach.localDirty[gc_mtRcsDriver].resize(rScnParts.machines.perType[gc_mtRcsDriver].localIds.vec().capacity());
+        rUpdMach.localDirty[gc_mtRcsDriver].resize(rScnParts.machines.perType[gc_mtRcsDriver].localIds.capacity());
     });
 
     rBuilder.task()


### PR DESCRIPTION
This pull request replaces osp::BitVector_t with lgrn::IdSetStl as outlined in issue #282. It depends on #281 and #284 at the moment. 

All the functional refactoring should be done, but for some reason both this branch and #281 fail to compile on my (admittedly janky) hardware, and I still need to do a pass to check formatting and variable names.